### PR TITLE
use os.path.join instead of manual string joining with "/"

### DIFF
--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -94,7 +94,7 @@ def read_par(
 
     """
     if filename is None:
-        filename = "{}/{}.{}".format(outdir, label, suffix)
+        filename = os.path.join(outdir, "{}.{}".format(label, suffix))
     if os.path.isfile(filename) is False:
         raise ValueError("No file {} found".format(filename))
     d = {}
@@ -220,7 +220,7 @@ class BaseSearchClass(object):
 
     def _add_log_file(self):
         """ Log output to a file, requires class to have outdir and label """
-        logfilename = "{}/{}.log".format(self.outdir, self.label)
+        logfilename = os.path.join(self.outdir, self.label + ".log")
         fh = logging.FileHandler(logfilename)
         fh.setLevel(logging.INFO)
         fh.setFormatter(
@@ -945,7 +945,7 @@ class ComputeFstat(BaseSearchClass):
         """
 
         if pfs_input is None:
-            if os.path.isfile("{}/{}.loudest".format(outdir, label)) is False:
+            if os.path.isfile(os.path.join(outdir, label + ".loudest")) is False:
                 raise ValueError("Need a loudest file to add the predicted Fstat")
             loudest = read_par(label=label, outdir=outdir, suffix="loudest")
             pfs_input = {
@@ -1092,7 +1092,7 @@ class ComputeFstat(BaseSearchClass):
             ax.set_title(title)
         if savefig:
             plt.tight_layout()
-            plt.savefig("{}/{}_twoFcumulative.png".format(outdir, label))
+            plt.savefig(os.path.join(outdir, label + "_twoFcumulative.png"))
             return taus, twoFs
         else:
             return ax
@@ -1182,7 +1182,7 @@ class SemiCoherentSearch(ComputeFstat):
         For all other parameters, see pyfstat.ComputeFStat.
         """
 
-        self.fs_file_name = "{}/{}_FS.dat".format(self.outdir, self.label)
+        self.fs_file_name = os.path.join(self.outdir, self.label + "_FS.dat")
         self.set_ephemeris_files()
         self.transientWindowType = "rect"
         self.t0Band = None
@@ -1359,7 +1359,7 @@ class SemiCoherentGlitchSearch(ComputeFstat):
         For all other parameters, see pyfstat.ComputeFStat.
         """
 
-        self.fs_file_name = "{}/{}_FS.dat".format(self.outdir, self.label)
+        self.fs_file_name = os.path.join(self.outdir, self.label + "_FS.dat")
         self.set_ephemeris_files()
         self.transientWindowType = "rect"
         self.t0Band = None

--- a/pyfstat/grid_based_searches.py
+++ b/pyfstat/grid_based_searches.py
@@ -314,7 +314,7 @@ class GridSearch(BaseSearchClass):
         ax.set_ylabel(ylabel)
         if savefig:
             fig.tight_layout()
-            fig.savefig("{}/{}_1D.png".format(self.outdir, self.label))
+            fig.savefig(os.path.join(self.outdir, self.label + "_1D.png"))
         else:
             return ax
 
@@ -413,7 +413,7 @@ class GridSearch(BaseSearchClass):
 
         if save:
             fig.tight_layout()
-            fig.savefig("{}/{}_2D.png".format(self.outdir, self.label))
+            fig.savefig(os.path.join(self.outdir, self.label + "_2D.png"))
         else:
             return ax
 
@@ -455,12 +455,16 @@ class GridSearch(BaseSearchClass):
         else:
             dets = "NA"
         if extra_label:
-            self.out_file = "{}/{}_{}_{}_{}.txt".format(
-                self.outdir, self.label, dets, type(self).__name__, extra_label
+            self.out_file = os.path.join(
+                self.outdir,
+                "{}_{}_{}_{}.txt".format(
+                    self.label, dets, type(self).__name__, extra_label
+                ),
             )
         else:
-            self.out_file = "{}/{}_{}_{}.txt".format(
-                self.outdir, self.label, dets, type(self).__name__
+            self.out_file = os.path.join(
+                self.outdir,
+                "{}_{}_{}.txt".format(self.label, dets, type(self).__name__),
             )
 
 
@@ -826,7 +830,7 @@ class SliceGridSearch(GridSearch):
             axes[i, i].set_ylabel("$2\mathcal{F}$")
 
         if save:
-            fig.savefig("{}/{}_slice_projection.png".format(self.outdir, self.label))
+            fig.savefig(os.path.join(self.outdir, self.label + "_slice_projection.png"))
         else:
             return fig, axes
 
@@ -1049,7 +1053,9 @@ class SlidingWindow(GridSearch):
     def run(self, key="h0", errkey="dh0"):
         self.key = key
         self.errkey = errkey
-        out_file = "{}/{}_{}-sliding-window.txt".format(self.outdir, self.label, key)
+        out_file = os.path.join(
+            self.outdir, "{}_{}-sliding-window.txt".format(self.label, key)
+        )
 
         if self.check_old_data_is_okay_to_use(out_file) is False:
             self.inititate_search_object()
@@ -1090,7 +1096,9 @@ class SlidingWindow(GridSearch):
 
         if fig:
             fig.savefig(
-                "{}/{}_{}-sliding-window.png".format(self.outdir, self.label, self.key)
+                os.path.join(
+                    self.outdir, "{}_{}-sliding-window.png".format(self.label, self.key)
+                )
             )
         else:
             return ax
@@ -1239,7 +1247,7 @@ class FrequencySlidingWindow(GridSearch):
             ax.set_title(ax.get_title(), y=1.18)
         if savefig:
             plt.tight_layout()
-            plt.savefig("{}/{}_sliding_window.png".format(self.outdir, self.label))
+            plt.savefig(os.path.join(self.outdir, self.label + "_sliding_window.png"))
         else:
             return ax
 
@@ -1454,7 +1462,7 @@ class EarthTest(GridSearch):
             y=0.99,
             size=14,
         )
-        fig.savefig("{}/{}_projection_matrix.png".format(self.outdir, self.label))
+        fig.savefig(os.path.join(self.outdir, self.label + "_projection_matrix.png"))
 
     def plot(self, key, prior_widths=None):
         Bsa, FmaxMismatch = self.marginalised_bayes_factor(prior_widths)
@@ -1479,7 +1487,7 @@ class EarthTest(GridSearch):
             )
         )
         fig.tight_layout()
-        fig.savefig("{}/{}_1D.png".format(self.outdir, self.label))
+        fig.savefig(os.path.join(self.outdir, self.label + "_1D.png"))
 
 
 class DMoff_NO_SPIN(GridSearch):

--- a/pyfstat/helper_functions.py
+++ b/pyfstat/helper_functions.py
@@ -124,7 +124,7 @@ def set_up_command_line_arguments():
 
 def get_ephemeris_files():
     """ Returns the earth_ephem and sun_ephem """
-    config_file = os.path.expanduser("~") + "/.pyfstat.conf"
+    config_file = os.path.join(os.path.expanduser("~"), ".pyfstat.conf")
     env_var = "LALPULSAR_DATADIR"
     please = "Please provide the ephemerides paths when initialising searches."
     if os.path.isfile(config_file):

--- a/tests.py
+++ b/tests.py
@@ -64,7 +64,9 @@ class Writer(Test):
     def test_make_cff(self):
         Writer = pyfstat.Writer(self.label, outdir=self.outdir)
         Writer.make_cff()
-        self.assertTrue(os.path.isfile("./{}/{}.cff".format(self.outdir, self.label)))
+        self.assertTrue(
+            os.path.isfile(os.path.join(".", self.outdir, self.label + ".cff"))
+        )
 
     def test_run_makefakedata(self):
         Writer = pyfstat.Writer(self.label, outdir=self.outdir, duration=3600)
@@ -72,7 +74,9 @@ class Writer(Test):
         Writer.run_makefakedata()
         self.assertTrue(
             os.path.isfile(
-                "./{}/H-2_H1_1800SFT_TestWriter-700000000-3600.sft".format(self.outdir)
+                os.path.join(
+                    ".", self.outdir, "H-2_H1_1800SFT_TestWriter-700000000-3600.sft"
+                )
             )
         )
 
@@ -107,11 +111,10 @@ class par(Test):
     label = "TestPar"
 
     def test(self):
-        os.system('echo "x=100\ny=10" > {}/{}.par'.format(self.outdir, self.label))
+        parfile = os.path.join(self.outdir, self.label + ".par")
+        os.system('echo "x=100\ny=10" > ' + parfile)
 
-        par = pyfstat.core.read_par(
-            "{}/{}.par".format(self.outdir, self.label), return_type="Bunch"
-        )
+        par = pyfstat.core.read_par(parfile, return_type="Bunch")
         self.assertTrue(par.x == 100)
         self.assertTrue(par.y == 10)
 
@@ -186,9 +189,10 @@ class ComputeFstat(Test):
         Writer.make_data()
         predicted_FS = Writer.predict_fstat()
 
+        sftfilepattern = os.path.join(Writer.outdir, "*{}*sft".format(Writer.label))
+
         search_H1L1 = pyfstat.ComputeFstat(
-            tref=Writer.tref,
-            sftfilepattern="{}/*{}*sft".format(Writer.outdir, Writer.label),
+            tref=Writer.tref, sftfilepattern=sftfilepattern,
         )
         FS = search_H1L1.get_fullycoherent_twoF(
             Writer.tstart,
@@ -206,7 +210,7 @@ class ComputeFstat(Test):
         search_H1 = pyfstat.ComputeFstat(
             tref=Writer.tref,
             detectors="H1",
-            sftfilepattern="{}/*{}*sft".format(Writer.outdir, Writer.label),
+            sftfilepattern=sftfilepattern,
             SSBprec=lalpulsar.SSBPREC_RELATIVISTIC,
         )
         FS = search_H1.get_fullycoherent_twoF(
@@ -235,7 +239,7 @@ class ComputeFstat(Test):
         search = pyfstat.ComputeFstat(
             tref=Writer.tref,
             assumeSqrtSX=1,
-            sftfilepattern="{}/*{}*sft".format(Writer.outdir, Writer.label),
+            sftfilepattern=os.path.join(Writer.outdir, "*{}*sft".format(Writer.label)),
         )
         FS = search.get_fullycoherent_twoF(
             Writer.tstart,
@@ -324,7 +328,7 @@ class SemiCoherentSearch(Test):
             label=self.label,
             outdir=self.outdir,
             nsegs=2,
-            sftfilepattern="{}/*{}*sft".format(Writer.outdir, Writer.label),
+            sftfilepattern=os.path.join(Writer.outdir, "*{}*sft".format(Writer.label)),
             tref=Writer.tref,
             minStartTime=Writer.tstart,
             maxStartTime=Writer.tend,
@@ -365,7 +369,7 @@ class SemiCoherentSearch(Test):
             label=self.label,
             outdir=self.outdir,
             nsegs=2,
-            sftfilepattern="{}/*{}*sft".format(Writer.outdir, Writer.label),
+            sftfilepattern=os.path.join(Writer.outdir, "*{}*sft".format(Writer.label)),
             tref=Writer.tref,
             minStartTime=Writer.tstart,
             maxStartTime=Writer.tend,
@@ -407,7 +411,7 @@ class SemiCoherentGlitchSearch(Test):
         search = pyfstat.SemiCoherentGlitchSearch(
             label=self.label,
             outdir=self.outdir,
-            sftfilepattern="{}/*{}*sft".format(Writer.outdir, Writer.label),
+            sftfilepattern=os.path.join(Writer.outdir, "*{}*sft".format(Writer.label)),
             tref=Writer.tref,
             minStartTime=Writer.tstart,
             maxStartTime=Writer.tend,
@@ -490,7 +494,7 @@ class MCMCSearch(Test):
             outdir=self.outdir,
             theta_prior=theta,
             tref=tref,
-            sftfilepattern="{}/*{}*sft".format(Writer.outdir, Writer.label),
+            sftfilepattern=os.path.join(Writer.outdir, "*{}*sft".format(Writer.label)),
             minStartTime=minStartTime,
             maxStartTime=maxStartTime,
             nsteps=[100, 100],


### PR DESCRIPTION
Found this old branch lying around. I think I started this in the suspicion that it would fix some weird failures with ephemerides finding on a non-standard platform, which turned out to have another source in the end. But it's still a good idea for portability. So if black is ok with it, we should merge it in.