### PR TITLE
add manual ephemerides options to search classes

### DIFF
--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -203,10 +203,13 @@ def predict_fstat(
     cl_pfs.append("--maxStartTime={}".format(int(maxStartTime)))
     cl_pfs.append("--outputFstat={}".format(tempory_filename))
 
-    if earth_ephem is not None:
-        cl_pfs.append("--ephemEarth='{}'".format(earth_ephem))
-    if sun_ephem is not None:
-        cl_pfs.append("--ephemSun='{}'".format(sun_ephem))
+    earth_ephem_default, sun_ephem_default = helper_functions.get_ephemeris_files()
+    if earth_ephem is None:
+        earth_ephem = earth_ephem_default
+    if sun_ephem is None:
+        sun_ephem = sun_ephem_default
+    cl_pfs.append("--ephemEarth='{}'".format(earth_ephem))
+    cl_pfs.append("--ephemSun='{}'".format(sun_ephem))
 
     cl_pfs = " ".join(cl_pfs)
     helper_functions.run_commandline(cl_pfs)
@@ -397,6 +400,8 @@ class ComputeFstat(BaseSearchClass):
         tCWFstatMapVersion="lal",
         cudaDeviceName=None,
         computeAtoms=False,
+        earth_ephem=None,
+        sun_ephem=None,
     ):
         """
         Parameters
@@ -455,10 +460,18 @@ class ComputeFstat(BaseSearchClass):
             GPU name to be matched against drv.Device output.
         computeAtoms: bool
             request atoms calculations regardless of transientWindowType
+        earth_ephem: str
+            Earth ephemeris file path
+            if None, will check standard sources as per
+            helper_functions.get_ephemeris_files()
+        sun_ephem: str
+            Sun ephemeris file path
+            if None, will check standard sources as per
+            helper_functions.get_ephemeris_files()
 
         """
 
-        self.set_ephemeris_files()
+        self.set_ephemeris_files(earth_ephem, sun_ephem)
         self.init_computefstatistic_single_point()
 
     def _get_SFTCatalog(self):
@@ -1185,6 +1198,8 @@ class SemiCoherentSearch(ComputeFstat):
         injectSources=None,
         assumeSqrtSX=None,
         SSBprec=None,
+        earth_ephem=None,
+        sun_ephem=None,
     ):
         """
         Parameters
@@ -1203,7 +1218,7 @@ class SemiCoherentSearch(ComputeFstat):
         """
 
         self.fs_file_name = "{}/{}_FS.dat".format(self.outdir, self.label)
-        self.set_ephemeris_files()
+        self.set_ephemeris_files(earth_ephem, sun_ephem)
         self.transientWindowType = "rect"
         self.t0Band = None
         self.tauBand = None
@@ -1357,6 +1372,8 @@ class SemiCoherentGlitchSearch(ComputeFstat):
         detectors=None,
         SSBprec=None,
         injectSources=None,
+        earth_ephem=None,
+        sun_ephem=None,
     ):
         """
         Parameters
@@ -1380,7 +1397,7 @@ class SemiCoherentGlitchSearch(ComputeFstat):
         """
 
         self.fs_file_name = "{}/{}_FS.dat".format(self.outdir, self.label)
-        self.set_ephemeris_files()
+        self.set_ephemeris_files(earth_ephem, sun_ephem)
         self.transientWindowType = "rect"
         self.t0Band = None
         self.tauBand = None

--- a/pyfstat/grid_based_searches.py
+++ b/pyfstat/grid_based_searches.py
@@ -78,6 +78,8 @@ class GridSearch(BaseSearchClass):
         injectSources=None,
         input_arrays=False,
         assumeSqrtSX=None,
+        earth_ephem=None,
+        sun_ephem=None,
     ):
         """
         Parameters
@@ -126,6 +128,8 @@ class GridSearch(BaseSearchClass):
                 SSBprec=self.SSBprec,
                 injectSources=self.injectSources,
                 assumeSqrtSX=self.assumeSqrtSX,
+                earth_ephem=self.earth_ephem,
+                sun_ephem=self.sun_ephem,
             )
             self.search.get_det_stat = self.search.get_fullycoherent_twoF
         else:
@@ -499,6 +503,8 @@ class TransientGridSearch(GridSearch):
         outputAtoms=False,
         tCWFstatMapVersion="lal",
         cudaDeviceName=None,
+        earth_ephem=None,
+        sun_ephem=None,
     ):
         """
         Parameters
@@ -575,6 +581,8 @@ class TransientGridSearch(GridSearch):
             tCWFstatMapVersion=self.tCWFstatMapVersion,
             cudaDeviceName=self.cudaDeviceName,
             computeAtoms=self.outputAtoms,
+            earth_ephem=self.earth_ephem,
+            sun_ephem=self.sun_ephem,
         )
         self.search.get_det_stat = self.search.get_fullycoherent_twoF
 
@@ -692,6 +700,8 @@ class SliceGridSearch(GridSearch):
         input_arrays=False,
         assumeSqrtSX=None,
         Lambda0=None,
+        earth_ephem=None,
+        sun_ephem=None,
     ):
         """
         Parameters
@@ -757,6 +767,8 @@ class SliceGridSearch(GridSearch):
             tref=self.tref,
             minStartTime=self.minStartTime,
             maxStartTime=self.maxStartTime,
+            earth_ephem=self.earth_ephem,
+            sun_ephem=self.sun_ephem,
         )
 
         for i, ikey in enumerate(self.search_keys):
@@ -851,6 +863,8 @@ class GridUniformPriorSearch:
         nsegs=1,
         SSBprec=None,
         injectSources=None,
+        earth_ephem=None,
+        sun_ephem=None,
     ):
         dF0 = (theta_prior["F0"]["upper"] - theta_prior["F0"]["lower"]) / NF0
         dF1 = (theta_prior["F1"]["upper"] - theta_prior["F1"]["lower"]) / NF1
@@ -874,6 +888,8 @@ class GridUniformPriorSearch:
             maxCoverFreq=maxCoverFreq,
             nsegs=nsegs,
             SSBprec=SSBprec,
+            earth_ephem=earth_ephem,
+            sun_ephem=sun_ephem,
         )
 
     def run(self):
@@ -917,6 +933,8 @@ class GridGlitchSearch(GridSearch):
         minCoverFreq=None,
         maxCoverFreq=None,
         detectors=None,
+        earth_ephem=None,
+        sun_ephem=None,
     ):
         """
         Run a single-glitch grid search
@@ -953,6 +971,8 @@ class GridGlitchSearch(GridSearch):
             minCoverFreq=minCoverFreq,
             maxCoverFreq=maxCoverFreq,
             BSGL=self.BSGL,
+            earth_ephem=earth_ephem,
+            sun_ephem=sun_ephem,
         )
         self.search.get_det_stat = self.search.get_semicoherent_nglitch_twoF
 
@@ -994,6 +1014,8 @@ class SlidingWindow(GridSearch):
         detectors=None,
         SSBprec=None,
         injectSources=None,
+        earth_ephem=None,
+        sun_ephem=None,
     ):
         """
         Parameters
@@ -1035,6 +1057,8 @@ class SlidingWindow(GridSearch):
             BSGL=self.BSGL,
             SSBprec=self.SSBprec,
             injectSources=self.injectSources,
+            earth_ephem=self.earth_ephem,
+            sun_ephem=self.sun_ephem,
         )
 
     def check_old_data_is_okay_to_use(self, out_file):
@@ -1121,6 +1145,8 @@ class FrequencySlidingWindow(GridSearch):
         detectors=None,
         SSBprec=None,
         injectSources=None,
+        earth_ephem=None,
+        sun_ephem=None,
     ):
         """
         Parameters
@@ -1170,6 +1196,8 @@ class FrequencySlidingWindow(GridSearch):
             BSGL=self.BSGL,
             SSBprec=self.SSBprec,
             injectSources=self.injectSources,
+            earth_ephem=self.earth_ephem,
+            sun_ephem=self.sun_ephem,
         )
         self.search.get_det_stat = self.search.get_fullycoherent_twoF
 
@@ -1276,6 +1304,8 @@ class EarthTest(GridSearch):
         detectors=None,
         injectSources=None,
         assumeSqrtSX=None,
+        earth_ephem=None,
+        sun_ephem=None,
     ):
         """
         Parameters
@@ -1499,6 +1529,8 @@ class DMoff_NO_SPIN(GridSearch):
         detectors=None,
         injectSources=None,
         assumeSqrtSX=None,
+        earth_ephem=None,
+        sun_ephem=None,
     ):
         """
         Parameters

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -152,6 +152,8 @@ class MCMCSearch(core.BaseSearchClass):
         assumeSqrtSX=None,
         transientWindowType=None,
         tCWFstatMapVersion="lal",
+        earth_ephem=None,
+        sun_ephem=None,
     ):
 
         self.theta_prior = theta_prior
@@ -177,6 +179,7 @@ class MCMCSearch(core.BaseSearchClass):
         self.assumeSqrtSX = assumeSqrtSX
         self.transientWindowType = transientWindowType
         self.tCWFstatMapVersion = tCWFstatMapVersion
+        self.set_ephemeris_files(earth_ephem, sun_ephem)
 
         if os.path.isdir(outdir) is False:
             os.mkdir(outdir)
@@ -229,6 +232,8 @@ class MCMCSearch(core.BaseSearchClass):
             assumeSqrtSX=self.assumeSqrtSX,
             SSBprec=self.SSBprec,
             tCWFstatMapVersion=self.tCWFstatMapVersion,
+            earth_ephem=self.earth_ephem,
+            sun_ephem=self.sun_ephem,
         )
         if self.minStartTime is None:
             self.minStartTime = self.search.minStartTime
@@ -1689,6 +1694,10 @@ class MCMCSearch(core.BaseSearchClass):
             self.minStartTime,
             self.maxStartTime,
         )
+        if self.earth_ephem is not None:
+            cmd += " --ephemEarth='{}'".format(self.earth_ephem)
+        if self.sun_ephem is not None:
+            cmd += " --ephemSun='{}'".format(self.sun_ephem)
         subprocess.call([cmd], shell=True)
 
     def write_prior_table(self):
@@ -1956,6 +1965,8 @@ class MCMCGlitchSearch(MCMCSearch):
         dtglitchmin=1 * 86400,
         theta0_idx=0,
         nglitch=1,
+        earth_ephem=None,
+        sun_ephem=None,
     ):
 
         if os.path.isdir(outdir) is False:
@@ -1979,6 +1990,7 @@ class MCMCGlitchSearch(MCMCSearch):
         self.old_data_is_okay_to_use = self._check_old_data_is_okay_to_use()
         self._log_input()
         self._set_likelihoodcoef()
+        self.set_ephemeris_files(earth_ephem, sun_ephem)
 
     def _set_likelihoodcoef(self):
         self.likelihoodcoef = (self.nglitch + 1) * np.log(70.0 / self.rhohatmax ** 4)
@@ -1999,6 +2011,8 @@ class MCMCGlitchSearch(MCMCSearch):
             nglitch=self.nglitch,
             theta0_idx=self.theta0_idx,
             injectSources=self.injectSources,
+            earth_ephem=self.earth_ephem,
+            sun_ephem=self.sun_ephem,
         )
         if self.minStartTime is None:
             self.minStartTime = self.search.minStartTime
@@ -2276,6 +2290,8 @@ class MCMCSemiCoherentSearch(MCMCSearch):
         injectSources=None,
         assumeSqrtSX=None,
         nsegs=None,
+        earth_ephem=None,
+        sun_ephem=None,
     ):
 
         self.theta_prior = theta_prior
@@ -2300,6 +2316,7 @@ class MCMCSemiCoherentSearch(MCMCSearch):
         self.injectSources = injectSources
         self.assumeSqrtSX = assumeSqrtSX
         self.nsegs = nsegs
+        self.set_ephemeris_files(earth_ephem, sun_ephem)
 
         if os.path.isdir(outdir) is False:
             os.mkdir(outdir)
@@ -2361,6 +2378,8 @@ class MCMCSemiCoherentSearch(MCMCSearch):
             detectors=self.detectors,
             injectSources=self.injectSources,
             assumeSqrtSX=self.assumeSqrtSX,
+            earth_ephem=self.earth_ephem,
+            sun_ephem=self.sun_ephem,
         )
         if self.minStartTime is None:
             self.minStartTime = self.search.minStartTime
@@ -2475,6 +2494,8 @@ class MCMCFollowUpSearch(MCMCSemiCoherentSearch):
         maxCoverFreq=None,
         injectSources=None,
         assumeSqrtSX=None,
+        earth_ephem=None,
+        sun_ephem=None,
     ):
 
         self.theta_prior = theta_prior
@@ -2499,6 +2520,7 @@ class MCMCFollowUpSearch(MCMCSemiCoherentSearch):
         self.injectSources = injectSources
         self.assumeSqrtSX = assumeSqrtSX
         self.nsegs = None
+        self.set_ephemeris_files(earth_ephem, sun_ephem)
 
         if os.path.isdir(outdir) is False:
             os.mkdir(outdir)
@@ -2945,6 +2967,8 @@ class MCMCTransientSearch(MCMCSearch):
             binary=self.binary,
             injectSources=self.injectSources,
             tCWFstatMapVersion=self.tCWFstatMapVersion,
+            earth_ephem=self.earth_ephem,
+            sun_ephem=self.sun_ephem,
         )
         if self.minStartTime is None:
             self.minStartTime = self.search.minStartTime

--- a/tests.py
+++ b/tests.py
@@ -270,6 +270,43 @@ class ComputeFstat(Test):
         )
         self.assertTrue(np.abs(predicted_FS - FS) / FS < 0.3)
 
+    def test_run_computefstatistic_single_point_no_noise_manual_ephem(self):
+        Writer = pyfstat.Writer(
+            self.label,
+            outdir=self.outdir,
+            add_noise=False,
+            duration=86400,
+            h0=1,
+            sqrtSX=1,
+        )
+        Writer.make_data()
+        predicted_FS = Writer.predict_fstat()
+
+        # let's get the default ephemeris files (to be sure their paths exist)
+        # and then pretend we pass them manually, to test those class options
+        (
+            earth_ephem_default,
+            sun_ephem_default,
+        ) = pyfstat.helper_functions.get_ephemeris_files()
+
+        search = pyfstat.ComputeFstat(
+            tref=Writer.tref,
+            assumeSqrtSX=1,
+            sftfilepattern=os.path.join(Writer.outdir, "*" + Writer.label + "*sft"),
+            earth_ephem=earth_ephem_default,
+            sun_ephem=sun_ephem_default,
+        )
+        FS = search.get_fullycoherent_twoF(
+            Writer.tstart,
+            Writer.tend,
+            Writer.F0,
+            Writer.F1,
+            Writer.F2,
+            Writer.Alpha,
+            Writer.Delta,
+        )
+        self.assertTrue(np.abs(predicted_FS - FS) / FS < 0.3)
+
     def test_injectSources(self):
         # This seems to be writing with a signal...
         Writer = pyfstat.Writer(


### PR DESCRIPTION
 -fixes #13

I've added the new input variables to ComputeFstat and all derived classes in core.py, grid_based_searches.py and mcmc_based_searches.py. But I'm somewhat confused about the different ways they do their inits, some explicitly setting self.xxx=xxx and some not, etc. So this might not all be sane, even though tests seem to all pass, but I know we don't have full coverage.

I should also add at least one test that explicitly uses the manual options.
