### PR TITLE
MCMC: export samples to ASCII file

### DIFF
--- a/examples/followup_examples/semi_coherent_directed_follow_up.py
+++ b/examples/followup_examples/semi_coherent_directed_follow_up.py
@@ -89,7 +89,7 @@ for ax in axes:
     ax.grid()
     ax.set_xticks(np.arange(0, 600, 100))
     ax.set_xticklabels([str(s) for s in np.arange(0, 700, 100)])
-axes[-1].set_xlabel(r"$\textrm{Number of steps}$", labelpad=0.1)
+axes[-1].set_xlabel(r"Number of steps", labelpad=0.1)
 fig.tight_layout()
 fig.savefig(os.path.join(mcmc.outdir, mcmc.label + "_walkers.png"), dpi=400)
 

--- a/examples/followup_examples/semi_coherent_directed_follow_up.py
+++ b/examples/followup_examples/semi_coherent_directed_follow_up.py
@@ -76,7 +76,7 @@ mcmc = pyfstat.MCMCFollowUpSearch(
 NstarMax = 1000
 Nsegs0 = 100
 fig, axes = plt.subplots(nrows=2, figsize=(3.4, 3.5))
-fig, axes = mcmc.run(
+mcmc.run(
     NstarMax=NstarMax,
     Nsegs0=Nsegs0,
     labelpad=0.01,
@@ -92,3 +92,6 @@ for ax in axes:
 axes[-1].set_xlabel(r"$\textrm{Number of steps}$", labelpad=0.1)
 fig.tight_layout()
 fig.savefig(os.path.join(mcmc.outdir, mcmc.label + "_walkers.png"), dpi=400)
+
+mcmc.plot_corner(add_prior=True)
+mcmc.print_summary()

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -224,9 +224,12 @@ def predict_fstat(
 class BaseSearchClass(object):
     """ The base search class providing parent methods to other searches """
 
-    def _add_log_file(self):
+    def _add_log_file(self, header=[]):
         """ Log output to a file, requires class to have outdir and label """
         logfilename = os.path.join(self.outdir, self.label + ".log")
+        with open(logfilename, "w") as fp:
+            for hline in header:
+                fp.write("# {:s}\n".format(hline))
         fh = logging.FileHandler(logfilename)
         fh.setLevel(logging.INFO)
         fh.setFormatter(

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -224,8 +224,9 @@ def predict_fstat(
 class BaseSearchClass(object):
     """ The base search class providing parent methods to other searches """
 
-    def _add_log_file(self, header=[]):
+    def _add_log_file(self, header=None):
         """ Log output to a file, requires class to have outdir and label """
+        header = [] if header is None else header
         logfilename = os.path.join(self.outdir, self.label + ".log")
         with open(logfilename, "w") as fp:
             for hline in header:

--- a/pyfstat/grid_based_searches.py
+++ b/pyfstat/grid_based_searches.py
@@ -244,37 +244,13 @@ class GridSearch(BaseSearchClass):
             self.save_array_to_disk(data)
             self.data = data
 
-    def get_doppler_params_output_format(self):
-        # use same format for search parameters as write_FstatCandidate_to_fp()
-        # function of lalapps_CFSv2
-        fmt = []
-        CFSv2_fmt = "%.16g"
-        expected_keys = [
-            "F0",
-            "F1",
-            "F2",
-            "Alpha",
-            "Delta",
-        ]
-        for k in expected_keys:
-            if k in self.keys:
-                fmt += [CFSv2_fmt]
-            else:
-                raise ValueError(
-                    "Expected doppler parameter key"
-                    " '{:s}' not found. "
-                    " If your search class is not using this,"
-                    " consider overriding this method.".format(k)
-                )
-        return fmt
-
     def get_savetxt_fmt(self):
         fmt = []
         if "minStartTime" in self.keys:
             fmt += ["%d"]
         if "maxStartTime" in self.keys:
             fmt += ["%d"]
-        fmt += self.get_doppler_params_output_format()
+        fmt += helper_functions.get_doppler_params_output_format(self.keys)
         fmt += ["%.9g"]  # for detection statistic
         return fmt
 
@@ -743,7 +719,7 @@ class TransientGridSearch(GridSearch):
             fmt += ["%d"]
         if "maxStartTime" in self.keys:
             fmt += ["%d"]
-        fmt += self.get_doppler_params_output_format()
+        fmt += helper_functions.get_doppler_params_output_format(self.keys)
         fmt += ["%.9g"]  # for detection statistic
         fmt += ["%d", "%d"]  # for t0, tau
         return fmt
@@ -1085,7 +1061,7 @@ class GridGlitchSearch(GridSearch):
             fmt += ["%d"]
         if "maxStartTime" in self.keys:
             fmt += ["%d"]
-        fmt += self.get_doppler_params_output_format()
+        fmt += helper_functions.get_doppler_params_output_format(self.keys)
         fmt += ["%.16g", "%.16g", "%d"]  # for delta_F0, delta_F1, tglitch
         fmt += ["%.9g"]  # for detection statistic
         return fmt

--- a/pyfstat/helper_functions.py
+++ b/pyfstat/helper_functions.py
@@ -9,6 +9,7 @@ import argparse
 import logging
 import inspect
 import peakutils
+import shutil
 from functools import wraps
 from scipy.stats.distributions import ncx2
 import numpy as np
@@ -42,7 +43,7 @@ def set_up_optional_tqdm():
 
 def set_up_matplotlib_defaults():
     plt.switch_backend("Agg")
-    plt.rcParams["text.usetex"] = True
+    plt.rcParams["text.usetex"] = shutil.which("latex") is not None
     plt.rcParams["axes.formatter.useoffset"] = False
 
 

--- a/pyfstat/helper_functions.py
+++ b/pyfstat/helper_functions.py
@@ -438,3 +438,21 @@ def get_version_information():
             " or a version file"
             " (which should come with each installed version.)"
         )
+
+
+def get_doppler_params_output_format(keys):
+    # use same format for writing out search parameters
+    # as write_FstatCandidate_to_fp() function of lalapps_CFSv2
+    fmt = []
+    CFSv2_fmt = "%.16g"
+    doppler_keys = [
+        "F0",
+        "F1",
+        "F2",
+        "Alpha",
+        "Delta",
+    ]
+    for k in keys:
+        if k in doppler_keys:
+            fmt += [CFSv2_fmt]
+    return fmt

--- a/pyfstat/helper_functions.py
+++ b/pyfstat/helper_functions.py
@@ -452,7 +452,13 @@ def get_doppler_params_output_format(keys):
         "F2",
         "Alpha",
         "Delta",
+        "asini",
+        "period",
+        "ecc",
+        "tp",
+        "argp",
     ]
+
     for k in keys:
         if k in doppler_keys:
             fmt += [CFSv2_fmt]

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -1564,12 +1564,7 @@ class MCMCSearch(core.BaseSearchClass):
             return False
 
     def get_savetxt_fmt(self):
-        fmt = []
-        if "minStartTime" in self.theta_keys:
-            fmt += ["%d"]
-        if "maxStartTime" in self.theta_keys:
-            fmt += ["%d"]
-        fmt += helper_functions.get_doppler_params_output_format(self.theta_keys)
+        fmt = helper_functions.get_doppler_params_output_format(self.theta_keys)
         return fmt
 
     def export_samples_to_disk(self):
@@ -1577,7 +1572,6 @@ class MCMCSearch(core.BaseSearchClass):
         self.output_file_header = self.get_output_file_header()
         logging.info("Exporting samples to {}".format(self.samples_file))
         header = "\n".join(self.output_file_header)
-        print(self.theta_keys)
         header += "\n" + " ".join(self.theta_keys)
         outfmt = self.get_savetxt_fmt()
         Ncols = np.shape(self.samples)[1]
@@ -1587,7 +1581,7 @@ class MCMCSearch(core.BaseSearchClass):
                 " and output format ({:d})"
                 " do not match."
                 " If your search class uses different"
-                " keys than the base GridSearch class,"
+                " keys than the base MCMCSearch class,"
                 " override the get_savetxt_fmt"
                 " method.".format(Ncols, len(outfmt))
             )
@@ -3097,3 +3091,8 @@ class MCMCTransientSearch(MCMCSearch):
         self.theta_idxs = [self.theta_idxs[i] for i in idxs]
         self.theta_symbols = [self.theta_symbols[i] for i in idxs]
         self.theta_keys = [self.theta_keys[i] for i in idxs]
+
+    def get_savetxt_fmt(self):
+        fmt = ["%d", "%d"]  # for transient_tstart, transient_duration
+        fmt += helper_functions.get_doppler_params_output_format(self.theta_keys)
+        return fmt

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -2806,6 +2806,8 @@ class MCMCFollowUpSearch(MCMCSemiCoherentSearch):
         proposal_scale_factor=2,
         NstarMax=10,
         Nsegs0=None,
+        save_pickle=True,
+        export_samples=True,
         create_plots=True,
         log_table=True,
         gen_tex_table=True,
@@ -2825,8 +2827,12 @@ class MCMCFollowUpSearch(MCMCSemiCoherentSearch):
             (2010). If the acceptance fraction is too low, you can raise it by
             decreasing the a parameter; and if it is too high, you can reduce
             it by increasing the a parameter [Foreman-Mackay (2013)].
+        save_pickle: bool
+            If true, save a pickle file of the full sampler state.
+        export_samples: bool
+            If true, save ASCII samples file to disk.
         create_plots: bool
-            If true, save trace plots of the walkers
+            If true, save trace plots of the walkers.
         window: int
             The minimum number of autocorrelation times needed to trust the
             result when estimating the autocorrelation time (see
@@ -2942,9 +2948,12 @@ class MCMCFollowUpSearch(MCMCSemiCoherentSearch):
         self.lnprobs = lnprobs
         self.lnlikes = lnlikes
         self.all_lnlikelihood = all_lnlikelihood
-        self._pickle_data(
-            sampler, samples, lnprobs, lnlikes, all_lnlikelihood, sampler.chain
-        )
+        if save_pickle:
+            self._pickle_data(
+                sampler, samples, lnprobs, lnlikes, all_lnlikelihood, sampler.chain
+            )
+        if export_samples:
+            self.export_samples_to_disk()
 
         if create_plots:
             try:

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -1255,7 +1255,6 @@ class MCMCSearch(core.BaseSearchClass):
         else:
             extra_subplots = 0
         with plt.style.context((context)):
-            plt.rcParams["text.usetex"] = True
             if fig is None and axes is None:
                 fig = plt.figure(figsize=(4, 3.0 * ndim))
                 ax = fig.add_subplot(ndim + extra_subplots, 1, 1)
@@ -1334,7 +1333,7 @@ class MCMCSearch(core.BaseSearchClass):
                 if symbols:
                     axes[0].set_ylabel(symbols[0], labelpad=labelpad)
 
-            axes[-1].set_xlabel(r"$\textrm{Number of steps}$", labelpad=0.2)
+            axes[-1].set_xlabel(r"Number of steps", labelpad=0.2)
 
             if plot_det_stat:
                 if len(axes) == ndim:

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -547,7 +547,15 @@ class MCMCSearch(core.BaseSearchClass):
             )
         )
 
-    def run(self, proposal_scale_factor=2, create_plots=True, window=50, **kwargs):
+    def run(
+        self,
+        proposal_scale_factor=2,
+        save_pickle=True,
+        export_samples=True,
+        create_plots=True,
+        window=50,
+        **kwargs
+    ):
         """ Run the MCMC simulatation
 
         Parameters
@@ -557,8 +565,12 @@ class MCMCSearch(core.BaseSearchClass):
             (2010). If the acceptance fraction is too low, you can raise it by
             decreasing the a parameter; and if it is too high, you can reduce
             it by increasing the a parameter [Foreman-Mackay (2013)].
+        save_pickle: bool
+            If true, save a pickle file of the full sampler state.
+        export_samples: bool
+            If true, save ASCII samples file to disk.
         create_plots: bool
-            If true, save trace plots of the walkers
+            If true, save trace plots of the walkers.
         window: int
             The minimum number of autocorrelation times needed to trust the
             result when estimating the autocorrelation time (see
@@ -641,10 +653,12 @@ class MCMCSearch(core.BaseSearchClass):
         self.lnprobs = lnprobs
         self.lnlikes = lnlikes
         self.all_lnlikelihood = all_lnlikelihood
-        self._pickle_data(
-            sampler, samples, lnprobs, lnlikes, all_lnlikelihood, sampler.chain
-        )
-        self.export_samples_to_disk()
+        if save_pickle:
+            self._pickle_data(
+                sampler, samples, lnprobs, lnlikes, all_lnlikelihood, sampler.chain
+            )
+        if export_samples:
+            self.export_samples_to_disk()
 
         if create_plots:
             try:

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -2620,7 +2620,7 @@ class MCMCFollowUpSearch(MCMCSemiCoherentSearch):
             return 0.5 * (prior[key]["upper"] + prior[key]["lower"])
 
     def read_setup_input_file(self, run_setup_input_file):
-        with open(run_setup_input_file, "r+") as f:
+        with open(run_setup_input_file, "rb+") as f:
             d = pickle.load(f)
         return d
 

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -632,14 +632,6 @@ class MCMCSearch(core.BaseSearchClass):
         logging.info("Running final burn and prod with {} steps".format(nburn + nprod))
         sampler = self._run_sampler(sampler, p0, nburn=nburn, nprod=nprod)
 
-        if create_plots:
-            try:
-                fig, axes = self._plot_walkers(sampler, nprod=nprod, **kwargs)
-                fig.tight_layout()
-                fig.savefig(os.path.join(self.outdir, self.label + "_walkers.png"))
-            except RuntimeError as e:
-                logging.warning("Failed to save walker plots due to Erro {}".format(e))
-
         samples = sampler.chain[0, :, nburn:, :].reshape((-1, self.ndim))
         lnprobs = sampler.logprobability[0, :, nburn:].reshape((-1))
         lnlikes = sampler.loglikelihood[0, :, nburn:].reshape((-1))
@@ -652,6 +644,15 @@ class MCMCSearch(core.BaseSearchClass):
         self._save_data(
             sampler, samples, lnprobs, lnlikes, all_lnlikelihood, sampler.chain
         )
+
+        if create_plots:
+            try:
+                fig, axes = self._plot_walkers(sampler, nprod=nprod, **kwargs)
+                fig.tight_layout()
+                fig.savefig(os.path.join(self.outdir, self.label + "_walkers.png"))
+            except RuntimeError as e:
+                logging.warning("Failed to save walker plots due to Error {}".format(e))
+
         return sampler
 
     def _get_rescale_multiplier_for_key(self, key):

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -183,7 +183,8 @@ class MCMCSearch(core.BaseSearchClass):
 
         if os.path.isdir(outdir) is False:
             os.mkdir(outdir)
-        self._add_log_file()
+        self.output_file_header = self.get_output_file_header()
+        self._add_log_file(self.output_file_header)
         logging.info("Set-up MCMC search for model {}".format(self.label))
         if sftfilepattern:
             logging.info("Using data {}".format(self.sftfilepattern))
@@ -1569,7 +1570,6 @@ class MCMCSearch(core.BaseSearchClass):
 
     def export_samples_to_disk(self):
         self.samples_file = os.path.join(self.outdir, self.label + "_samples.dat")
-        self.output_file_header = self.get_output_file_header()
         logging.info("Exporting samples to {}".format(self.samples_file))
         header = "\n".join(self.output_file_header)
         header += "\n" + " ".join(self.theta_keys)
@@ -2011,7 +2011,8 @@ class MCMCGlitchSearch(MCMCSearch):
 
         if os.path.isdir(outdir) is False:
             os.mkdir(outdir)
-        self._add_log_file()
+        self.output_file_header = self.get_output_file_header()
+        self._add_log_file(self.output_file_header)
         logging.info(
             (
                 "Set-up MCMC glitch search with {} glitches for model {}" " on data {}"
@@ -2360,7 +2361,8 @@ class MCMCSemiCoherentSearch(MCMCSearch):
 
         if os.path.isdir(outdir) is False:
             os.mkdir(outdir)
-        self._add_log_file()
+        self.output_file_header = self.get_output_file_header()
+        self._add_log_file(self.output_file_header)
         logging.info(
             ("Set-up MCMC semi-coherent search for model {} on data" "{}").format(
                 self.label, self.sftfilepattern
@@ -2564,7 +2566,8 @@ class MCMCFollowUpSearch(MCMCSemiCoherentSearch):
 
         if os.path.isdir(outdir) is False:
             os.mkdir(outdir)
-        self._add_log_file()
+        self.output_file_header = self.get_output_file_header()
+        self._add_log_file(self.output_file_header)
         logging.info(
             ("Set-up MCMC semi-coherent search for model {} on data" "{}").format(
                 self.label, self.sftfilepattern

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -1700,16 +1700,16 @@ class MCMCSearch(core.BaseSearchClass):
 
         logging.info("Writing par file with max twoF = {}".format(max_twoF))
         with open(filename, "w+") as f:
-            f.write(r"MaxtwoF = {}\n".format(max_twoF))
-            f.write(r"tref = {}\n".format(self.tref))
+            f.write("MaxtwoF = {}\n".format(max_twoF))
+            f.write("tref = {}\n".format(self.tref))
             if hasattr(self, "theta0_index"):
-                f.write(r"theta0_index = {}\n".format(self.theta0_idx))
+                f.write("theta0_index = {}\n".format(self.theta0_idx))
             if method == "med":
                 for key, val in median_std_d.items():
-                    f.write(r"{} = {:1.16e}\n".format(key, val))
+                    f.write("{} = {:1.16e}\n".format(key, val))
             if method == "twoFmax":
                 for key, val in max_twoF_d.items():
-                    f.write(r"{} = {:1.16e}\n".format(key, val))
+                    f.write("{} = {:1.16e}\n".format(key, val))
 
     def generate_loudest(self):
         """ Use lalapps_ComputeFstatistic_v2 to produce a .loudest file """
@@ -1766,11 +1766,11 @@ class MCMCSearch(core.BaseSearchClass):
 
                     u = self.unit_dictionary[key]
                     s = self.symbol_dictionary[key]
-                    f.write(r"\n")
+                    f.write("\n")
                     a = helper_functions.texify_float(a)
                     b = helper_functions.texify_float(b)
-                    f.write(r" " + line.format(s, a, b, u) + r" \\")
-            f.write(r"\n\end{tabular}\n")
+                    f.write(" " + line.format(s, a, b, u) + r" \\")
+            f.write("\n\end{tabular}\n")
 
     def print_summary(self):
         """ Prints a summary of the max twoF found to the terminal """
@@ -1926,7 +1926,7 @@ class MCMCSearch(core.BaseSearchClass):
     def write_evidence_file_from_dict(self, EvidenceDict, evidence_file_name):
         with open(evidence_file_name, "w+") as f:
             for key, val in EvidenceDict.items():
-                f.write(r"{} {} {}\n".format(key, val[0], val[1]))
+                f.write("{} {} {}\n".format(key, val[0], val[1]))
 
 
 class MCMCGlitchSearch(MCMCSearch):
@@ -2773,7 +2773,7 @@ class MCMCFollowUpSearch(MCMCSemiCoherentSearch):
                     r"Stage & $N_\mathrm{seg}$ &"
                     r"$T_\mathrm{coh}^{\rm days}$ &"
                     r"$\mathcal{N}^*(\Nseg^{(\ell)}, \Delta\mathbf{\lambda}^{(0)})$ \\ \hline"
-                    r"\n"
+                    "\n"
                 )
                 for i, rs in enumerate(run_setup):
                     Tcoh = float(self.maxStartTime - self.minStartTime) / rs[1] / 86400


### PR DESCRIPTION
As per #7 this adds simple ASCII export of MCMC samples. Passes the tests and looks sane in the first few example cases, but I will check how it works on a real-life follow-up example before merging.

Uses the same file header as GridSearch.