### PR TITLE
MCMC: improve handling of walker plots

### DIFF
--- a/examples/followup_examples/semi_coherent_directed_follow_up.py
+++ b/examples/followup_examples/semi_coherent_directed_follow_up.py
@@ -79,19 +79,24 @@ fig, axes = plt.subplots(nrows=2, figsize=(3.4, 3.5))
 mcmc.run(
     NstarMax=NstarMax,
     Nsegs0=Nsegs0,
-    labelpad=0.01,
-    plot_det_stat=False,
-    return_fig=True,
-    fig=fig,
-    axes=axes,
+    walker_plot_args={
+        "labelpad": 0.01,
+        "plot_det_stat": False,
+        "fig": fig,
+        "axes": axes,
+    },
 )
-for ax in axes:
-    ax.grid()
-    ax.set_xticks(np.arange(0, 600, 100))
-    ax.set_xticklabels([str(s) for s in np.arange(0, 700, 100)])
-axes[-1].set_xlabel(r"Number of steps", labelpad=0.1)
-fig.tight_layout()
-fig.savefig(os.path.join(mcmc.outdir, mcmc.label + "_walkers.png"), dpi=400)
 
-mcmc.plot_corner(add_prior=True)
-mcmc.print_summary()
+if hasattr(mcmc, "walkers_fig") and hasattr(mcmc, "walkers_axes"):
+    # walkers figure is only returned on first run, not when saved data is reused
+    for ax in mcmc.walkers_axes:
+        ax.grid()
+        ax.set_xticks(np.arange(0, 600, 100))
+        ax.set_xticklabels([str(s) for s in np.arange(0, 700, 100)])
+    mcmc.walkers_axes[-1].set_xlabel(r"Number of steps", labelpad=0.1)
+    mcmc.walkers_fig.tight_layout()
+    mcmc.walkers_fig.savefig(
+        os.path.join(mcmc.outdir, mcmc.label + "_walkers.png"), dpi=400
+    )
+    mcmc.plot_corner(add_prior=True)
+    mcmc.print_summary()

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -554,7 +554,7 @@ class MCMCSearch(core.BaseSearchClass):
         save_pickle=True,
         export_samples=True,
         save_loudest=True,
-        create_plots=True,
+        plot_walkers=True,
         window=50,
         **kwargs
     ):
@@ -573,7 +573,7 @@ class MCMCSearch(core.BaseSearchClass):
             If true, save ASCII samples file to disk.
         save_loudest: bool
             If true, save a CFSv2 .loudest file to disk.
-        create_plots: bool
+        plot_walkers: bool
             If true, save trace plots of the walkers.
         window: int
             The minimum number of autocorrelation times needed to trust the
@@ -626,7 +626,7 @@ class MCMCSearch(core.BaseSearchClass):
                 "Running {}/{} initialisation with {} steps".format(j, ninit_steps, n)
             )
             sampler = self._run_sampler(sampler, p0, nburn=n, window=window)
-            if create_plots:
+            if plot_walkers:
                 fig, axes = self._plot_walkers(sampler, **kwargs)
                 fig.tight_layout()
                 fig.savefig(
@@ -666,7 +666,7 @@ class MCMCSearch(core.BaseSearchClass):
         if save_loudest:
             self.generate_loudest()
 
-        if create_plots:
+        if plot_walkers:
             try:
                 fig, axes = self._plot_walkers(sampler, nprod=nprod, **kwargs)
                 fig.tight_layout()
@@ -2814,7 +2814,7 @@ class MCMCFollowUpSearch(MCMCSemiCoherentSearch):
         save_pickle=True,
         export_samples=True,
         save_loudest=True,
-        create_plots=True,
+        plot_walkers=True,
         log_table=True,
         gen_tex_table=True,
         fig=None,
@@ -2839,7 +2839,7 @@ class MCMCFollowUpSearch(MCMCSemiCoherentSearch):
             If true, save ASCII samples file to disk.
         save_loudest: bool
             If true, save a CFSv2 .loudest file to disk.
-        create_plots: bool
+        plot_walkers: bool
             If true, save trace plots of the walkers.
         window: int
             The minimum number of autocorrelation times needed to trust the
@@ -2919,7 +2919,7 @@ class MCMCFollowUpSearch(MCMCSemiCoherentSearch):
                 )
             )
 
-            if create_plots:
+            if plot_walkers:
                 fig, axes = self._plot_walkers(
                     sampler,
                     fig=fig,
@@ -2933,7 +2933,7 @@ class MCMCFollowUpSearch(MCMCSemiCoherentSearch):
 
             nsteps_total += nburn + nprod
 
-        if create_plots:
+        if plot_walkers:
             nstep_list = np.array(
                 [el[0][0] for el in run_setup] + [run_setup[-1][0][1]]
             )
@@ -2965,7 +2965,7 @@ class MCMCFollowUpSearch(MCMCSemiCoherentSearch):
         if save_loudest:
             self.generate_loudest()
 
-        if create_plots:
+        if plot_walkers:
             try:
                 fig.tight_layout()
             except (ValueError, RuntimeError) as e:

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -555,7 +555,7 @@ class MCMCSearch(core.BaseSearchClass):
         export_samples=True,
         save_loudest=True,
         plot_walkers=True,
-        walker_plot_args={},
+        walker_plot_args=None,
         window=50,
     ):
         """ Run the MCMC simulatation
@@ -605,6 +605,8 @@ class MCMCSearch(core.BaseSearchClass):
 
         self._initiate_search_object()
         self._estimate_run_time()
+
+        walker_plot_args = walker_plot_args or {}
 
         sampler = PTSampler(
             ntemps=self.ntemps,
@@ -2844,7 +2846,7 @@ class MCMCFollowUpSearch(MCMCSemiCoherentSearch):
         export_samples=True,
         save_loudest=True,
         plot_walkers=True,
-        walker_plot_args={},
+        walker_plot_args=None,
         log_table=True,
         gen_tex_table=True,
         window=50,
@@ -2893,6 +2895,8 @@ class MCMCFollowUpSearch(MCMCSemiCoherentSearch):
         )
         self.run_setup = run_setup
         self._estimate_run_time()
+
+        walker_plot_args = walker_plot_args or {}
 
         self.old_data_is_okay_to_use = self._check_old_data_is_okay_to_use()
         if self.old_data_is_okay_to_use is True:

--- a/tests.py
+++ b/tests.py
@@ -561,7 +561,7 @@ class MCMCSearch(Test):
             ntemps=2,
             log10beta_min=-1,
         )
-        search.run(create_plots=False)
+        search.run(plot_walkers=False)
         _, FS = search.get_max_twoF()
 
         print(("Predicted twoF is {} while recovered is {}".format(predicted_FS, FS)))


### PR DESCRIPTION
@Rodrigo-Tenorio This should solve the problem in #32 that you had previously spotted when re-running the `examples/followup_examples/semi_coherent_directed_follow_up.py` case.

I decided to do a **backwards-incompatible** change to the arguments of both `MCMCFollowUpSearch.run()` and `MCMCSearch.run()`:

- rename `create_plots` option to `plot_walkers` for clarity
- replace `kwargs` pass-through to `_plot_walkers()` with explicit `walker_plot_args` dictionary
- in `MCMCFollowUpSearch.run()` don't return `fig`, `axes` but store as `self.walker_fig`, `self.walker_axes`
- introduce the same feature to the base `MCMCSearch.run()`
- adapt the followup example script to explicitly check if fig and axes were stored; if not, it's likely because old data was used, and it won't overwrite the figure. This would be the intended usage in general.

Please have a look and test.

cc @GregoryAshton 