### PR TITLE
dump search class init arguments to a text file

### DIFF
--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -283,6 +283,26 @@ class BaseSearchClass(object):
         )
         logging.getLogger().addHandler(fh)
 
+    def _dump_init_params(self, args, outdir="."):
+        """ Dump the class name and __init__() arguments to a text file
+
+        Parameters
+        ----------
+        args : dict
+            Dictionary of key-val pairs.
+        outdir : str
+            Output directory.
+
+        """
+        classname = type(self).__name__
+        dumpfile = os.path.join(outdir,"init_dump.txt")
+        logging.info("Dumping {}.__init__() arguments to file {}".format(classname,dumpfile))
+        with open(dumpfile, "w+") as f:
+            f.write("{}\n".format(classname))
+            for key, val in args.items():
+                if not key=='self':
+                    f.write("{} = {}\n".format(key, val))
+
     def _shift_matrix(self, n, dT):
         """ Generate the shift matrix
 

--- a/pyfstat/grid_based_searches.py
+++ b/pyfstat/grid_based_searches.py
@@ -97,6 +97,7 @@ class GridSearch(BaseSearchClass):
 
         if os.path.isdir(outdir) is False:
             os.mkdir(outdir)
+        self._dump_init_params(locals(), outdir)
         self.set_out_file()
         self.search_keys = ["F0", "F1", "F2", "Alpha", "Delta"]
         self.input_keys = ["minStartTime", "maxStartTime"] + self.search_keys
@@ -798,6 +799,7 @@ class SliceGridSearch(GridSearch):
 
         if os.path.isdir(outdir) is False:
             os.mkdir(outdir)
+        self._dump_init_params(locals(), outdir)
         self.set_out_file()
         self.search_keys = ["F0", "F1", "Alpha", "Delta"]
         self.input_keys = ["minStartTime", "maxStartTime"] + self.search_keys
@@ -1116,6 +1118,7 @@ class SlidingWindow(GridSearch):
 
         if os.path.isdir(outdir) is False:
             os.mkdir(outdir)
+        self._dump_init_params(locals(), outdir)
         self.set_out_file()
         self.nsegs = 1
 
@@ -1259,6 +1262,7 @@ class FrequencySlidingWindow(GridSearch):
 
         if os.path.isdir(outdir) is False:
             os.mkdir(outdir)
+        self._dump_init_params(locals(), outdir)
         self.set_out_file()
         self.F1s = [F1]
         self.F2s = [F2]
@@ -1415,6 +1419,7 @@ class EarthTest(GridSearch):
 
         if os.path.isdir(outdir) is False:
             os.mkdir(outdir)
+        self._dump_init_params(locals(), outdir)
         self.nsegs = 1
         self.F0s = [F0]
         self.F1s = [F1]
@@ -1638,6 +1643,7 @@ class DMoff_NO_SPIN(GridSearch):
 
         if os.path.isdir(outdir) is False:
             os.mkdir(outdir)
+        self._dump_init_params(locals(), outdir)
 
         if type(par) == dict:
             self.par = par

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -183,6 +183,7 @@ class MCMCSearch(core.BaseSearchClass):
 
         if os.path.isdir(outdir) is False:
             os.mkdir(outdir)
+        self._dump_init_params(locals(), outdir)
         self.output_file_header = self.get_output_file_header()
         self._add_log_file(self.output_file_header)
         logging.info("Set-up MCMC search for model {}".format(self.label))
@@ -2058,6 +2059,7 @@ class MCMCGlitchSearch(MCMCSearch):
 
         if os.path.isdir(outdir) is False:
             os.mkdir(outdir)
+        self._dump_init_params(locals(), outdir)
         self.output_file_header = self.get_output_file_header()
         self._add_log_file(self.output_file_header)
         logging.info(
@@ -2417,6 +2419,7 @@ class MCMCSemiCoherentSearch(MCMCSearch):
 
         if os.path.isdir(outdir) is False:
             os.mkdir(outdir)
+        self._dump_init_params(locals(), outdir)
         self.output_file_header = self.get_output_file_header()
         self._add_log_file(self.output_file_header)
         logging.info(
@@ -2622,6 +2625,7 @@ class MCMCFollowUpSearch(MCMCSemiCoherentSearch):
 
         if os.path.isdir(outdir) is False:
             os.mkdir(outdir)
+        self._dump_init_params(locals(), outdir)
         self.output_file_header = self.get_output_file_header()
         self._add_log_file(self.output_file_header)
         logging.info(


### PR DESCRIPTION
 -add `_dump_init_params()` method to `BaseSearchClass`
 -call it from the `__init__()` of all high-level classes
 -closes #35

The idea is to make runs more reproducible.

@GregoryAshton @ReinhardPrix @Rodrigo-Tenorio how does this look?

example output from the fully_coherent_search_using_MCMC.py example:
```
MCMCSearch
theta_prior = {'F0': {'type': 'unif', 'lower': 29.99999995, 'upper': 30.00000005}, 'F1': {'type': 'unif', 'lower': -1.0005e-10, 'upper': -9.995e-11}, 'F2': 0, 'Alpha': 1.4596048908088417, 'Delta': 0.38422376285103965}
tref = 1004320000.0
label = fully_coherent_search_using_MCMC
outdir = example_data/fully_coherent_search_using_MCMC
minStartTime = 1000000000
maxStartTime = 1008640000
sftfilepattern = example_data/fully_coherent_search_using_MCMC/*fully_coherent_search_using_MCMC*sft
detectors = None
nsteps = [300, 300]
nwalkers = 100
ntemps = 2
log10beta_min = -0.5
theta_initial = None
rhohatmax = 1000
binary = False
BSGL = False
SSBprec = None
minCoverFreq = None
maxCoverFreq = None
injectSources = None
assumeSqrtSX = None
transientWindowType = None
tCWFstatMapVersion = lal
earth_ephem = None
sun_ephem = None
```