### PR TITLE
output file headers: include search class name and init arguments dict

### DIFF
--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -431,6 +431,13 @@ class BaseSearchClass(object):
         pretty_init_parameters = pformat(
             self.init_params_dict, indent=2, width=74
         ).split("\n")
+        pretty_init_parameters = (
+            ["{"]
+            + [pretty_init_parameters[0].replace("{", " ")]
+            + pretty_init_parameters[1:-2]
+            + [pretty_init_parameters[-1].rstrip("}")]
+            + ["}"]
+        )
 
         header = [
             "date: {}".format(str(datetime.now())),

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -4,6 +4,7 @@
 import os
 import logging
 import copy
+from pprint import pformat
 
 import glob
 import numpy as np
@@ -426,14 +427,19 @@ class BaseSearchClass(object):
         self.init_params_dict = argsdict
 
     def get_output_file_header(self):
+
+        pretty_init_parameters = pformat(
+            self.init_params_dict, indent=2, sort_dicts=True, width=74
+        ).split("\n")
+
         header = [
             "date: {}".format(str(datetime.now())),
             "user: {}".format(getpass.getuser()),
             "hostname: {}".format(socket.gethostname()),
             "PyFstat: {}".format(helper_functions.get_version_string()),
             "search: {}".format(type(self).__name__),
-            "parameters: {}".format(self.init_params_dict),
-        ]
+            "parameters: ",
+        ] + pretty_init_parameters
         lalVCSinfo = lal.VCSInfoString(lalpulsar.PulsarVCSInfoList, 0, "")
         header += filter(None, lalVCSinfo.split("\n"))
         return header

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -437,11 +437,14 @@ class BaseSearchClass(object):
             "user: {}".format(getpass.getuser()),
             "hostname: {}".format(socket.gethostname()),
             "PyFstat: {}".format(helper_functions.get_version_string()),
-            "search: {}".format(type(self).__name__),
-            "parameters: ",
-        ] + pretty_init_parameters
+        ]
         lalVCSinfo = lal.VCSInfoString(lalpulsar.PulsarVCSInfoList, 0, "")
         header += filter(None, lalVCSinfo.split("\n"))
+        header += [
+            "search: {}".format(type(self).__name__),
+            "parameters: ",
+        ]
+        header += pretty_init_parameters
         return header
 
 

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -429,7 +429,7 @@ class BaseSearchClass(object):
     def get_output_file_header(self):
 
         pretty_init_parameters = pformat(
-            self.init_params_dict, indent=2, sort_dicts=True, width=74
+            self.init_params_dict, indent=2, width=74
         ).split("\n")
 
         header = [

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -421,12 +421,18 @@ class BaseSearchClass(object):
         else:
             self.sun_ephem = sun_ephem
 
+    def _set_init_params_dict(self, argsdict):
+        argsdict.pop("self")
+        self.init_params_dict = argsdict
+
     def get_output_file_header(self):
         header = [
             "date: {}".format(str(datetime.now())),
             "user: {}".format(getpass.getuser()),
             "hostname: {}".format(socket.gethostname()),
             "PyFstat: {}".format(helper_functions.get_version_string()),
+            "search: {}".format(type(self).__name__),
+            "parameters: {}".format(self.init_params_dict),
         ]
         lalVCSinfo = lal.VCSInfoString(lalpulsar.PulsarVCSInfoList, 0, "")
         header += filter(None, lalVCSinfo.split("\n"))
@@ -532,6 +538,7 @@ class ComputeFstat(BaseSearchClass):
 
         """
 
+        self._set_init_params_dict(locals())
         self.set_ephemeris_files(earth_ephem, sun_ephem)
         self.init_computefstatistic_single_point()
         self.output_file_header = self.get_output_file_header()

--- a/pyfstat/grid_based_searches.py
+++ b/pyfstat/grid_based_searches.py
@@ -95,6 +95,7 @@ class GridSearch(BaseSearchClass):
         with the `clean` option which uses a generator instead.
         """
 
+        self._set_init_params_dict(locals())
         if os.path.isdir(outdir) is False:
             os.mkdir(outdir)
         self.set_out_file()
@@ -796,6 +797,7 @@ class SliceGridSearch(GridSearch):
         For all other parameters, see `pyfstat.ComputeFStat` for details
         """
 
+        self._set_init_params_dict(locals())
         if os.path.isdir(outdir) is False:
             os.mkdir(outdir)
         self.set_out_file()
@@ -1019,6 +1021,7 @@ class GridGlitchSearch(GridSearch):
         For all other parameters, see pyfstat.ComputeFStat.
         """
 
+        self._set_init_params_dict(locals())
         self.BSGL = False
         self.input_arrays = False
         if tglitchs is None:
@@ -1114,6 +1117,7 @@ class SlidingWindow(GridSearch):
         For all other parameters, see `pyfstat.ComputeFStat` for details
         """
 
+        self._set_init_params_dict(locals())
         if os.path.isdir(outdir) is False:
             os.mkdir(outdir)
         self.set_out_file()
@@ -1251,6 +1255,7 @@ class FrequencySlidingWindow(GridSearch):
         For all other parameters, see `pyfstat.ComputeFStat` for details
         """
 
+        self._set_init_params_dict(locals())
         self.transientWindowType = "rect"
         self.nsegs = 1
         self.t0Band = None
@@ -1408,6 +1413,7 @@ class EarthTest(GridSearch):
 
         For all other parameters, see `pyfstat.ComputeFStat` for details
         """
+        self._set_init_params_dict(locals())
         self.transientWindowType = None
         self.t0Band = None
         self.tauBand = None
@@ -1636,6 +1642,7 @@ class DMoff_NO_SPIN(GridSearch):
         For all other parameters, see `pyfstat.ComputeFStat` for details
         """
 
+        self._set_init_params_dict(locals())
         if os.path.isdir(outdir) is False:
             os.mkdir(outdir)
 

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -156,6 +156,7 @@ class MCMCSearch(core.BaseSearchClass):
         sun_ephem=None,
     ):
 
+        self._set_init_params_dict(locals())
         self.theta_prior = theta_prior
         self.tref = tref
         self.label = label
@@ -2056,6 +2057,7 @@ class MCMCGlitchSearch(MCMCSearch):
         sun_ephem=None,
     ):
 
+        self._set_init_params_dict(locals())
         if os.path.isdir(outdir) is False:
             os.mkdir(outdir)
         self.output_file_header = self.get_output_file_header()
@@ -2391,6 +2393,7 @@ class MCMCSemiCoherentSearch(MCMCSearch):
         sun_ephem=None,
     ):
 
+        self._set_init_params_dict(locals())
         self.theta_prior = theta_prior
         self.tref = tref
         self.label = label
@@ -2596,6 +2599,7 @@ class MCMCFollowUpSearch(MCMCSemiCoherentSearch):
         sun_ephem=None,
     ):
 
+        self._set_init_params_dict(locals())
         self.theta_prior = theta_prior
         self.tref = tref
         self.label = label


### PR DESCRIPTION
As a solution to #35, actually I think this is better than #45. Not a separate dump file, but adding the parameter dict to the existing header of each output file. Similar to the lalapps convention.

@GregoryAshton @ReinhardPrix @Rodrigo-Tenorio how does this look?

example output from the fully_coherent_search_using_MCMC.py example:
```
# date: 2020-06-03 11:48:41.727082
# user: dkeitel
# hostname: T490UIB
# PyFstat: UNCLEAN 16b9dda 2020-06-03 11:27:38 +0200
# search: MCMCSearch
# parameters: {'theta_prior': {'F0': {'type': 'unif', 'lower': 29.99999995, 'upper': 30.00000005}, 'F1': {'type': 'unif', 'lower': -1.0005e-10, 'upper': -9.995e-11}, 'F2': 0, 'Alpha': 1.4596048908088417, 'Delta': 0.38422376285103965}, 'tref': 1004320000.0, 'label': 'fully_coherent_search_using_MCMC', 'outdir': 'example_data/fully_coherent_search_using_MCMC', 'minStartTime': 1000000000, 'maxStartTime': 1008640000, 'sftfilepattern': 'example_data/fully_coherent_search_using_MCMC/*fully_coherent_search_using_MCMC*sft', 'detectors': None, 'nsteps': [10, 10], 'nwalkers': 100, 'ntemps': 2, 'log10beta_min': -0.5, 'theta_initial': None, 'rhohatmax': 1000, 'binary': False, 'BSGL': False, 'SSBprec': None, 'minCoverFreq': None, 'maxCoverFreq': None, 'injectSources': None, 'assumeSqrtSX': None, 'transientWindowType': None, 'tCWFstatMapVersion': 'lal', 'earth_ephem': None, 'sun_ephem': None}
# LAL: 6.21.0 (CLEAN c6afb0789517073ea7423d2422b1ba844a050ef9)
# LALPulsar: 1.18.2 (CLEAN c6afb0789517073ea7423d2422b1ba844a050ef9)
# F0 F1
30.00000000356636 -1.00003001670372e-10
[...]
```