### PR TITLE
Writer: default to sqrtSX=0

### DIFF
--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -428,20 +428,24 @@ transientTau = {:10.0f}\n"""
         if check_ok is False:
             helper_functions.run_commandline(cl_mfd)
 
-    def predict_fstat(self):
+    def predict_fstat(self, assumeSqrtSX=None):
         """ Wrapper to lalapps_PredictFstat """
+        if assumeSqrtSX:
+            sqrtSX = assumeSqrtSX
+        else:
+            sqrtSX = self.sqrtSX
         twoF_expected, twoF_sigma = predict_fstat(
-            self.h0,
-            self.cosi,
-            self.psi,
-            self.Alpha,
-            self.Delta,
-            self.F0,
-            self.sftfilepath,
-            self.minStartTime,
-            self.maxStartTime,
-            self.detectors,
-            self.sqrtSX,
+            h0=self.h0,
+            cosi=self.cosi,
+            psi=self.psi,
+            Alpha=self.Alpha,
+            Delta=self.Delta,
+            Freq=self.F0,
+            sftfilepattern=self.sftfilepath,
+            minStartTime=self.minStartTime,
+            maxStartTime=self.maxStartTime,
+            IFOs=self.detectors,
+            assumeSqrtSX=sqrtSX,
             tempory_filename=os.path.join(self.outdir, self.label + ".tmp"),
             earth_ephem=self.earth_ephem,
             sun_ephem=self.sun_ephem,

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -430,10 +430,6 @@ transientTau = {:10.0f}\n"""
 
     def predict_fstat(self, assumeSqrtSX=None):
         """ Wrapper to lalapps_PredictFstat """
-        if assumeSqrtSX:
-            sqrtSX = assumeSqrtSX
-        else:
-            sqrtSX = self.sqrtSX
         twoF_expected, twoF_sigma = predict_fstat(
             h0=self.h0,
             cosi=self.cosi,
@@ -445,7 +441,7 @@ transientTau = {:10.0f}\n"""
             minStartTime=self.minStartTime,
             maxStartTime=self.maxStartTime,
             IFOs=self.detectors,
-            assumeSqrtSX=sqrtSX,
+            assumeSqrtSX=(assumeSqrtSX or self.sqrtSX),
             tempory_filename=os.path.join(self.outdir, self.label + ".tmp"),
             earth_ephem=self.earth_ephem,
             sun_ephem=self.sun_ephem,

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -45,7 +45,7 @@ class Writer(BaseSearchClass):
         phi=0,
         Tsft=1800,
         outdir=".",
-        sqrtSX=1,
+        sqrtSX=0.0,
         noiseSFTs=None,
         SFTWindowType=None,
         SFTWindowBeta=0.0,
@@ -382,16 +382,17 @@ transientTau = {:10.0f}\n"""
                     "to produce noiseSFTs."
                 )
             elif self.noiseSFTs is not None:
+                if self.sqrtSX is not None:
+                    logging.warning(
+                        "In addition to using noiseSFTs, you are adding "
+                        "Gaussian noise with sqrtSX={} "
+                        "Please, make sure this is what you intend to do.".format(
+                            self.sqrtSX
+                        )
+                    )
                 cl_mfd.append('--noiseSFTs="{}"'.format(self.noiseSFTs))
             else:
                 cl_mfd.append("--IFOs={}".format(self.IFOs))
-
-            logging.warning(
-                "Gaussian noise *is added* by default due to "
-                "consistency issues. Please, make sure sqrtSX value is "
-                "consistent with what you intend to do (0=No Gaussian noise). "
-                "Currently, sqrtSX={}".format(self.sqrtSX)
-            )
             cl_mfd.append('--sqrtSX="{}"'.format(self.sqrtSX))
         else:
             cl_mfd.append("--IFOs={}".format(self.IFOs))
@@ -474,7 +475,7 @@ class BinaryModulatedWriter(Writer):
         phi=0,
         Tsft=1800,
         outdir=".",
-        sqrtSX=1,
+        sqrtSX=0.0,
         noiseSFTs=None,
         SFTWindowType=None,
         SFTWindowBeta=0.0,
@@ -636,7 +637,7 @@ class GlitchWriter(Writer):
         phi=0,
         Tsft=1800,
         outdir=".",
-        sqrtSX=1,
+        sqrtSX=0.0,
         noiseSFTs=None,
         SFTWindowType=None,
         SFTWindowBeta=0.0,
@@ -758,7 +759,7 @@ class FrequencyModulatedArtifactWriter(Writer):
         tref=None,
         h0=10,
         Tsft=1800,
-        sqrtSX=1,
+        sqrtSX=0.0,
         Band=4,
         Pmod=lal.DAYSID_SI,
         Pmod_phi=0,

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -382,7 +382,7 @@ transientTau = {:10.0f}\n"""
                     "to produce noiseSFTs."
                 )
             elif self.noiseSFTs is not None:
-                if self.sqrtSX is not None:
+                if self.sqrtSX > 0.0:
                     logging.warning(
                         "In addition to using noiseSFTs, you are adding "
                         "Gaussian noise with sqrtSX={} "


### PR DESCRIPTION
As pointed out by @Rodrigo-Tenorio in #50, the Writer default of `sqrtSX=1` is odd, and particularly dangerous now that we also allow for noiseSFTs. Historically it was probably introduced to match the `assumeSqrtSX=1` default of the F-stat codes (Compute & Predict), but as far as I can see that isn't really necessary, as one can always manually set `assumeSqrtSX=1` for those even if the SFTs actually contain 0 noise.

This PR:
-  changes the Writer default
-  adapts the warning message introduced in #41
-  adds the missing feature for setting assumeSqrtSX when wanting to predict F directly from the Writer
-  improves the test suite

In particular, the only test failing after the first commit was `test_get_semicoherent_twoF`, because it picked up spurious SFTs from the other test case in the same class. So I've now cleared up sftfilepatterns, separated two classes, and introduced joint setup methods where appropriate. Also repurposed the `no_noise` tests to actually do exactly that, and use the PFS trick as described above.

The test suite is still messy and could do with a full rewrite matching `pytest` best practices, but for now it works.

Will need to test some examples before merging, too.

Comments @Rodrigo-Tenorio @GregoryAshton @ReinhardPrix ?