### PR TITLE
Fix transient searches

### DIFF
--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -70,6 +70,8 @@ def translate_keys_to_lal(dictionary):
         "tp": "orbitTp",
         "argp": "orbitArgp",
         "ecc": "orbitEcc",
+        "transient_tstart": "transient-t0Epoch",
+        "transient_duration": "transient-tau",
     }
 
     keys_to_translate = [key for key in dictionary.keys() if key in translation]

--- a/pyfstat/grid_based_searches.py
+++ b/pyfstat/grid_based_searches.py
@@ -615,6 +615,7 @@ class TransientGridSearch(GridSearch):
         For all other parameters, see `pyfstat.ComputeFStat` for details
         """
 
+        self._set_init_params_dict(locals())
         self.nsegs = 1
         if os.path.isdir(outdir) is False:
             os.mkdir(outdir)

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -1791,7 +1791,8 @@ class MCMCSearch(core.BaseSearchClass):
             cmd += " --ephemEarth='{}'".format(self.earth_ephem)
         if self.sun_ephem is not None:
             cmd += " --ephemSun='{}'".format(self.sun_ephem)
-        subprocess.call([cmd], shell=True)
+        logging.info("Executing: {}".format(cmd))
+        subprocess.check_call([cmd], shell=True)
 
     def write_prior_table(self):
         """ Generate a .tex file of the prior """

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -1801,7 +1801,8 @@ class MCMCSearch(core.BaseSearchClass):
                 for key in signal_parameter_keys
             ]
         )
-
+        if self.transientWindowType is not None:
+            cmd += " --transient-WindowType='{}'".format(self.transientWindowType)
         if self.earth_ephem is not None:
             cmd += " --ephemEarth='{}'".format(self.earth_ephem)
         if self.sun_ephem is not None:


### PR DESCRIPTION
This will make the transient examples run through again, which first failed due to a `_set_init_params_dict()` call I had forgotten, but from that failure's output I luckily also noticed that CFSv2 errors in `MCMCSearch.generate_loudest()` were not actually caught by the subprocess call, and then I had to fix a bunch more commandline options in that call.

The examples will still produce inconsistent max2F values, which will need to be fixed next -> #54 