### PR TITLE
pin lalsuite==6.70 to fix github pipelines

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         "bashplotlib",
         "peakutils",
         "pathos",
-        "lalsuite",
+        "lalsuite==6.70",
         "versioneer",
     ],
 )


### PR DESCRIPTION
Until we can figure out *why* the new 6.71 causes the weird
```
INTERNALERROR> TypeError: not a code object: <class 'pyfstat.make_sfts.Writer'>
```
on all pipelines (#52), this seems to do the trick.