### PR TITLE
Add docker workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,54 @@
+name: Docker
+
+on:
+  push:
+    # Publish `master` as Docker `latest` image.
+    branches:
+      - master
+
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+
+env:
+  # TODO: Change variable to your image's name.
+  IMAGE_NAME: pyfstat
+
+jobs:
+  # Push image to GitHub Packages.
+  # See also https://docs.docker.com/docker-hub/builds/
+  push:
+
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build image
+        run: docker build . --file Dockerfile --tag $IMAGE_NAME
+
+      - name: Log into registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+
+      - name: Push image
+        run: |
+          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+          
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "master" ] && VERSION=latest
+
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.8-buster
+
+WORKDIR /pyfstat
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+COPY . .
+RUN pip install .

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ demonstrating different use cases.
 
 ## Installation
 
+### Docker container
+Ready-to-use PyFstat containers are available at the [Packages](https://github.com/PyFstat/PyFstat/packages)
+page. A git-hub account together with a personal access token is required. See the available 
+[documentation](https://github.com/PyFstat/PyFstat/wiki/Containers) to learn how to pull them from the git-hub
+registry using Docker or Singularity.
+
 ### python installation
 This package requires `python3.6+`.
 While many systems come with a system wide python


### PR DESCRIPTION
Build a Docker container using Python 3.8 and the last commit in master branch.

Containers can be pulled using Docker/Singularity, requiring a Personal Access Token with "read:packages" privileges.

This is a nice-to-have feature, since allows PyFstat to be used out of the box in almost every feasible situation* without any painful dependency drama.


*Provided Singularity is available, which is sort of a current trend

- [x]  Check how to pull without PAT
- [x]  Check requirements.txt and setup.py
- [x] Add documentation on how to use a Personal Access Token