### PR TITLE
sync requirements.txt and setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ bashplotlib
 peakutils
 pathos
 lalsuite
+versioneer

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ tqdm
 bashplotlib
 peakutils
 pathos
-lalsuite
+lalsuite>=6.72
 versioneer

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,8 @@ setup(
     },
     python_requires=">=%s.%s.%s" % min_python_version[:3],
     install_requires=[
-        "matplotlib",
+        "numpy",
+        "matplotlib>=2.1",
         "scipy",
         "ptemcee",
         "corner",

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         "bashplotlib",
         "peakutils",
         "pathos",
-        "lalsuite",
+        "lalsuite>=6.72",
         "versioneer",
     ],
 )


### PR DESCRIPTION
Let's also require `lalsuite>=6.72` so nobody runs into "not a code object" from 6.71 again.