### PR TITLE
core.py: fix "SyntaxError: Non-ASCII character '\xc3'"

### DIFF
--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -56,7 +56,7 @@ def translate_keys_to_lal(dictionary):
     Returns
     -------
     translated_dict: dict
-        Copy of `dictìonary` with new keys according to lal.
+        Copy of "dictionary" with new keys according to lal.
     """
 
     translation = {


### PR DESCRIPTION
Encountered this while accidentally running python 2.7 which we no longer support, but best to fix encoding issues anyway since they may cause whatever later.