### PR TITLE
docker build: Fetch all history using checkout@v2

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,7 +11,6 @@ on:
       - v*
 
 env:
-  # TODO: Change variable to your image's name.
   IMAGE_NAME: pyfstat
 
 jobs:
@@ -24,6 +23,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+            fetch-depth: 0
 
       - name: Build image
         run: docker build . --file Dockerfile --tag $IMAGE_NAME


### PR DESCRIPTION
checkout@v2 only picks up the last commit by default [see the official docs](https://github.com/actions/checkout#Fetch-all-history-for-all-tags-and-branches). Add the suitable argument to the action file and #76 is done!