### PR TITLE
MCMCSearch.generate_loudest(): warn for transients

### DIFF
--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -1769,6 +1769,11 @@ class MCMCSearch(core.BaseSearchClass):
             raise RuntimeError(
                 "CFSv2 --outputLoudest cannot deal with glitch parameters."
             )
+        if getattr(self, "transientWindowType", None) is not None:
+            logging.warning(
+                "CFSv2 --outputLoudest always reports the maximum of the"
+                " standard CW 2F-statistic, not the transient max2F."
+            )
         for key in self.theta_prior:
             if key not in params:
                 params[key] = self.theta_prior[key]


### PR DESCRIPTION
Since a proper `CFSv2 --outputLoudest` functionality for the transient max2F statistic (instead of regular CW 2F) would require changes to that code itself in lalapps, for now I'll "resolve" #54 simply by adding a warning.