### PR TITLE
publish releases to real PyPI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -51,3 +51,9 @@ jobs:
         user: __token__
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
+    - name: Publish package to PyPI
+      if: matrix.python-version == 3.8 && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}\


### PR DESCRIPTION
First to TestPyPI, then the real one, with same logic (only on tagged releases and only for newest python version).