### PR TITLE
Estimate coverage bands by default, extend feature to binaries

### DIFF
--- a/pyfstat/helper_functions.py
+++ b/pyfstat/helper_functions.py
@@ -354,9 +354,9 @@ def get_covering_band(
     F0band=0.0,
     F1band=0.0,
     F2band=0.0,
-    orbitasini=0.0,
-    orbitPeriod=0.0,
-    orbitEcc=0.0,
+    maxOrbitAsini=0.0,
+    minOrbitPeriod=0.0,
+    maxOrbitEcc=0.0,
 ):
     """ Get the covering band using XLALCWSignalCoveringBand
 
@@ -364,8 +364,16 @@ def get_covering_band(
     ----------
     tref, tstart, tend: int
         The reference, start, and end times of interest
-    F0, F1, F1:
-        Frequency and spin-down of the signal
+    F0, F1, F1: float
+        Minimum frequency and spin-down of signals to be covered
+    F0band, F1band, F1band: float
+        Ranges of frequency and spin-down of signals to be covered
+    maxOrbitAsini: float
+        Largest orbital projected semi-major axis to be covered
+    minOrbitPeriod: float
+        Shortest orbital period to be covered
+    maxOrbitEcc: float
+        Highest orbital eccentricity to be covered
 
     Note: this is similar to the function
     `injection_helper_functions.get_frequency_range_of_signal`, however this
@@ -391,7 +399,7 @@ def get_covering_band(
     psr.fkdotBand[2] = F2band
     psr.refTime = tref
     return lalpulsar.CWSignalCoveringBand(
-        tstart, tend, psr, orbitasini, orbitPeriod, orbitEcc
+        tstart, tend, psr, maxOrbitAsini, minOrbitPeriod, maxOrbitEcc
     )
 
 

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -220,13 +220,32 @@ class MCMCSearch(core.BaseSearchClass):
         logging.info("ntemps = {}".format(self.ntemps))
         logging.info("log10beta_min = {}".format(self.log10beta_min))
 
+    def _get_search_ranges(self):
+        """ take prior widths as proxy "search ranges" to allow covering band estimate """
+        if (self.minCoverFreq is None) or (self.maxCoverFreq is None):
+            prior_bounds = self._get_prior_bounds()
+            # first start with parameters that have non-delta prior ranges
+            search_ranges = {
+                key: [prior_bounds[key]["lower"], prior_bounds[key]["upper"], 0]
+                for key in prior_bounds.keys()
+            }
+            # then add fixed-point (delta prior) parameters
+            for key in self.theta_prior:
+                if key not in self.theta_keys:
+                    search_ranges[key] = [self.theta_prior[key]]
+            return search_ranges
+        else:
+            return None
+
     def _initiate_search_object(self):
         logging.info("Setting up search object")
+        search_ranges = self._get_search_ranges()
         self.search = core.ComputeFstat(
             tref=self.tref,
             sftfilepattern=self.sftfilepattern,
             minCoverFreq=self.minCoverFreq,
             maxCoverFreq=self.maxCoverFreq,
+            search_ranges=search_ranges,
             detectors=self.detectors,
             BSGL=self.BSGL,
             transientWindowType=self.transientWindowType,
@@ -1033,44 +1052,57 @@ class MCMCSearch(core.BaseSearchClass):
             for k in range(0, i):
                 axes[i][k].set_ylim(xlim[0], xlim[1])
 
+    def _get_prior_bounds(self, normal_stds=2):
+        """ Get the lower/upper bounds of all priors """
+        prior_bounds = {}
+        for key in self.theta_keys:
+            prior_bounds[key] = {}
+            prior_dict = self.theta_prior[key]
+            if prior_dict["type"] == "unif":
+                prior_bounds[key]["lower"] = prior_dict["lower"]
+                prior_bounds[key]["upper"] = prior_dict["upper"]
+            elif prior_dict["type"] == "log10unif":
+                prior_bounds[key]["lower"] = prior_dict["log10lower"]
+                prior_bounds[key]["upper"] = prior_dict["log10upper"]
+            elif prior_dict["type"] == "norm":
+                prior_bounds[key]["lower"] = (
+                    prior_dict["loc"] - normal_stds * prior_dict["scale"]
+                )
+                prior_bounds[key]["upper"] = (
+                    prior_dict["loc"] + normal_stds * prior_dict["scale"]
+                )
+            elif prior_dict["type"] == "halfnorm":
+                prior_bounds[key]["lower"] = prior_dict["loc"]
+                prior_bounds[key]["upper"] = (
+                    prior_dict["loc"] + normal_stds * prior_dict["scale"]
+                )
+            elif prior_dict["type"] == "neghalfnorm":
+                prior_bounds[key]["upper"] = prior_dict["loc"]
+                prior_bounds[key]["lower"] = (
+                    prior_dict["loc"] - normal_stds * prior_dict["scale"]
+                )
+            else:
+                raise ValueError(
+                    "Not implemented for prior type {}".format(prior_dict["type"])
+                )
+        return prior_bounds
+
     def plot_prior_posterior(self, normal_stds=2):
         """ Plot the posterior in the context of the prior """
         fig, axes = plt.subplots(nrows=self.ndim, figsize=(8, 4 * self.ndim))
         N = 1000
         from scipy.stats import gaussian_kde
 
+        prior_bounds = self._get_prior_bounds(normal_stds)
         for i, (ax, key) in enumerate(zip(axes, self.theta_keys)):
             prior_dict = self.theta_prior[key]
             prior_func = self._generic_lnprior(**prior_dict)
+            x = np.linspace(prior_bounds[key]["lower"], prior_bounds[key]["upper"], N)
+            prior = [prior_func(xi) for xi in x]  # may not be vectorized
             if prior_dict["type"] == "unif":
-                x = np.linspace(prior_dict["lower"], prior_dict["upper"], N)
-                prior = prior_func(x)
                 prior[0] = 0
                 prior[-1] = 0
-            elif prior_dict["type"] == "log10unif":
-                upper = prior_dict["log10upper"]
-                lower = prior_dict["log10lower"]
-                x = np.linspace(lower, upper, N)
-                prior = [prior_func(xi) for xi in x]
-            elif prior_dict["type"] == "norm":
-                lower = prior_dict["loc"] - normal_stds * prior_dict["scale"]
-                upper = prior_dict["loc"] + normal_stds * prior_dict["scale"]
-                x = np.linspace(lower, upper, N)
-                prior = prior_func(x)
-            elif prior_dict["type"] == "halfnorm":
-                lower = prior_dict["loc"]
-                upper = prior_dict["loc"] + normal_stds * prior_dict["scale"]
-                x = np.linspace(lower, upper, N)
-                prior = [prior_func(xi) for xi in x]
-            elif prior_dict["type"] == "neghalfnorm":
-                upper = prior_dict["loc"]
-                lower = prior_dict["loc"] - normal_stds * prior_dict["scale"]
-                x = np.linspace(lower, upper, N)
-                prior = [prior_func(xi) for xi in x]
-            else:
-                raise ValueError(
-                    "Not implemented for prior type {}".format(prior_dict["type"])
-                )
+
             priorln = ax.plot(x, prior, "C3", label="prior")
             ax.set_xlabel(self.theta_symbols[i])
 
@@ -2117,6 +2149,7 @@ class MCMCGlitchSearch(MCMCSearch):
 
     def _initiate_search_object(self):
         logging.info("Setting up search object")
+        search_ranges = self._get_search_ranges()
         self.search = core.SemiCoherentGlitchSearch(
             label=self.label,
             outdir=self.outdir,
@@ -2126,6 +2159,7 @@ class MCMCGlitchSearch(MCMCSearch):
             maxStartTime=self.maxStartTime,
             minCoverFreq=self.minCoverFreq,
             maxCoverFreq=self.maxCoverFreq,
+            search_ranges=search_ranges,
             detectors=self.detectors,
             BSGL=self.BSGL,
             nglitch=self.nglitch,
@@ -2498,6 +2532,7 @@ class MCMCSemiCoherentSearch(MCMCSearch):
 
     def _initiate_search_object(self):
         logging.info("Setting up search object")
+        search_ranges = self._get_search_ranges()
         self.search = core.SemiCoherentSearch(
             label=self.label,
             outdir=self.outdir,
@@ -2510,6 +2545,7 @@ class MCMCSemiCoherentSearch(MCMCSearch):
             maxStartTime=self.maxStartTime,
             minCoverFreq=self.minCoverFreq,
             maxCoverFreq=self.maxCoverFreq,
+            search_ranges=search_ranges,
             detectors=self.detectors,
             injectSources=self.injectSources,
             assumeSqrtSX=self.assumeSqrtSX,
@@ -3128,11 +3164,13 @@ class MCMCTransientSearch(MCMCSearch):
         logging.info("Setting up search object")
         if not self.transientWindowType:
             self.transientWindowType = "rect"
+        search_ranges = self._get_search_ranges()
         self.search = core.ComputeFstat(
             tref=self.tref,
             sftfilepattern=self.sftfilepattern,
             minCoverFreq=self.minCoverFreq,
             maxCoverFreq=self.maxCoverFreq,
+            search_ranges=search_ranges,
             detectors=self.detectors,
             transientWindowType=self.transientWindowType,
             minStartTime=self.minStartTime,

--- a/tests.py
+++ b/tests.py
@@ -142,7 +142,10 @@ class Writer(Test):
 
         # compute Fstat
         coherent_search = pyfstat.ComputeFstat(
-            tref=noise_and_signal_writer.tref, sftfilepattern=sftfilepattern
+            tref=noise_and_signal_writer.tref,
+            sftfilepattern=sftfilepattern,
+            minCoverFreq=-0.5,
+            maxCoverFreq=-0.5,
         )
         FS_1 = coherent_search.get_fullycoherent_twoF(
             noise_and_signal_writer.tstart,
@@ -189,7 +192,10 @@ class Writer(Test):
 
         # compute Fstat
         coherent_search = pyfstat.ComputeFstat(
-            tref=add_signal_writer.tref, sftfilepattern=sftfilepattern
+            tref=add_signal_writer.tref,
+            sftfilepattern=sftfilepattern,
+            minCoverFreq=-0.5,
+            maxCoverFreq=-0.5,
         )
         FS_2 = coherent_search.get_fullycoherent_twoF(
             add_signal_writer.tstart,
@@ -320,7 +326,10 @@ class ComputeFstat(Test):
         sftfilepattern = os.path.join(Writer.outdir, "*{}-*sft".format(Writer.label))
 
         search_H1L1 = pyfstat.ComputeFstat(
-            tref=Writer.tref, sftfilepattern=sftfilepattern,
+            tref=Writer.tref,
+            sftfilepattern=sftfilepattern,
+            minCoverFreq=-0.5,
+            maxCoverFreq=-0.5,
         )
         FS = search_H1L1.get_fullycoherent_twoF(
             Writer.tstart,
@@ -340,6 +349,8 @@ class ComputeFstat(Test):
             detectors="H1",
             sftfilepattern=sftfilepattern,
             SSBprec=lalpulsar.SSBPREC_RELATIVISTIC,
+            minCoverFreq=-0.5,
+            maxCoverFreq=-0.5,
         )
         FS = search_H1.get_fullycoherent_twoF(
             Writer.tstart,
@@ -437,6 +448,8 @@ class ComputeFstatNoNoise(Test):
             sftfilepattern=os.path.join(
                 self.Writer.outdir, "*{}-*sft".format(self.Writer.label)
             ),
+            minCoverFreq=-0.5,
+            maxCoverFreq=-0.5,
         )
         FS = search.get_fullycoherent_twoF(
             self.Writer.tstart,
@@ -466,6 +479,8 @@ class ComputeFstatNoNoise(Test):
             ),
             earth_ephem=earth_ephem_default,
             sun_ephem=sun_ephem_default,
+            minCoverFreq=-0.5,
+            maxCoverFreq=-0.5,
         )
         FS = search.get_fullycoherent_twoF(
             self.Writer.tstart,
@@ -505,6 +520,8 @@ class SemiCoherentSearch(Test):
             tref=self.Writer.tref,
             minStartTime=self.Writer.tstart,
             maxStartTime=self.Writer.tend,
+            minCoverFreq=-0.5,
+            maxCoverFreq=-0.5,
         )
 
         search.get_semicoherent_twoF(
@@ -542,6 +559,8 @@ class SemiCoherentSearch(Test):
             tref=self.Writer.tref,
             minStartTime=self.Writer.tstart,
             maxStartTime=self.Writer.tend,
+            minCoverFreq=-0.5,
+            maxCoverFreq=-0.5,
             BSGL=True,
         )
 
@@ -577,6 +596,14 @@ class SemiCoherentGlitchSearch(Test):
 
         Writer.make_data()
 
+        keys = ["F0", "F1", "F2", "Alpha", "Delta"]
+        search_ranges = {
+            key: [
+                getattr(Writer, key),
+                getattr(Writer, key) + getattr(Writer, "delta_" + key, 0.0),
+            ]
+            for key in keys
+        }
         search = pyfstat.SemiCoherentGlitchSearch(
             label=self.label,
             outdir=self.outdir,
@@ -585,6 +612,7 @@ class SemiCoherentGlitchSearch(Test):
             minStartTime=Writer.tstart,
             maxStartTime=Writer.tend,
             nglitch=1,
+            search_ranges=search_ranges,
         )
 
         FS = search.get_semicoherent_nglitch_twoF(
@@ -709,7 +737,6 @@ class GridSearch(Test):
             Alphas=[0],
             Deltas=[0],
             tref=self.tref,
-            estimate_covering_band=True,
         )
         search.run()
         self.assertTrue(os.path.isfile(search.out_file))
@@ -776,11 +803,11 @@ class GridSearch(Test):
             self.sftfilepath,
             F0s=self.F0s,
             F1s=self.F1s,
-            F2s=[0],
-            Alphas=[0],
-            Deltas=[0],
+            F2s=[0.0],
+            Alphas=[0.0],
+            Deltas=[0.0],
             tref=self.tref,
-            Lambda0=[30, 0, 0, 0],
+            Lambda0=[30.0, 0.0, 0.0, 0.0],
         )
         fig, axes = search.run(save=False)
         self.assertTrue(fig is not None)


### PR DESCRIPTION
Another big-ish change. A while ago in a9e993dddae9424d4f01d3f24d42435228e348e8 I introduced the possibility to call an XLAL function to estimate the "covering band" to actually grab from the given SFTs. This is essential in being able to 1:1 reproduce results from CFSv2, and also should be more robust and general than the previous practice of estimating as `[min(SFTs)+0.5,max(SFTs)-0.5]` if the user didn't give manual options.

New behaviour now:

- use `estimate_min_max_CoverFreq()` by default,  based on search ranges (grid boundaries for grid searches / prior bounds for MCMC searches)
- deprecate `estimate_covering_band` user-facing option (has only been live for a month, so shouldn't break too much)
- old behaviour of SFT ranges +- 0.5 can now be reproduced by passing negative minCoverFreq,maxCoverFreq (or more flexible offsets from SFT boundaries)
- binary parameters are added in the second commit, please check @Rodrigo-Tenorio 
- on the other hand, ignoring transient parameters is conservative and hence should be safe

Once again I hacked the specialised search classes (glitches, slices, sliding windows) until tests and examples worked, but I don't understand all their details and can't guarantee they still work fully as intended.