### PR TITLE
Call computetransientfstatmap once

### DIFF
--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -1574,17 +1574,18 @@ class SemiCoherentSearch(ComputeFstat):
         self._semicoherent_window_trick = lalpulsar.transientWindowRange_t()
         self._semicoherent_window_trick.type = lalpulsar.TRANSIENT_RECTANGULAR
 
-        # Range [t0, t0+t0Band] step dt0 
+        # Range [t0, t0+t0Band] step dt0
         self._semicoherent_window_trick.t0 = int(self.tboundaries[0])
-        self._semicoherent_window_trick.t0Band = int(self.tboundaries[-1] - self.tboundaries[0] - 2 * self.Tcoh)
+        self._semicoherent_window_trick.t0Band = int(
+            self.tboundaries[-1] - self.tboundaries[0] - 2 * self.Tcoh
+        )
         self._semicoherent_window_trick.dt0 = int(self.Tcoh)
-        
+
         # Range [tau, tau + tauBand] step dtau
         # Watch out: dtau must be !=0, but tauBand==0 is allowed
         self._semicoherent_window_trick.tau = int(self.Tcoh)
         self._semicoherent_window_trick.tauBand = int(0)
-        self._semicoherent_window_trick.dtau = int(1) # Irrelevant
-
+        self._semicoherent_window_trick.dtau = int(1)  # Irrelevant
 
     def init_semicoherent_parameters(self):
         logging.info(
@@ -1658,7 +1659,6 @@ class SemiCoherentSearch(ComputeFstat):
         #                                       self.BSGLSetup)
         #    return log10_BSGL/np.log10(np.exp(1))
 
-
         det_stat_per_segment = self._get_per_segment_det_stat()
         detStat = det_stat_per_segment.sum()
         if record_segments:
@@ -1678,11 +1678,15 @@ class SemiCoherentSearch(ComputeFstat):
             FstatResults_single.lenth = 1
             FstatResults_single.data = self.FstatResults.multiFatoms[0].data[0]
             FS0 = lalpulsar.ComputeTransientFstatMap(
-                FstatResults_single.multiFatoms[0], self.windowRange, False
+                FstatResults_single.multiFatoms[0],
+                self._semicoherent_window_trick,
+                False,
             )
             FstatResults_single.data = self.FstatResults.multiFatoms[0].data[1]
             FS1 = lalpulsar.ComputeTransientFstatMap(
-                FstatResults_single.multiFatoms[0], self.windowRange, False
+                FstatResults_single.multiFatoms[0],
+                self._semicoherent_window_trick,
+                False,
             )
 
             self.twoFX[0] = 2 * FS0.F_mn.data[0][0]

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -1568,8 +1568,8 @@ class SemiCoherentSearch(ComputeFstat):
     def _init_semicoherent_window_trick(self):
         """
         Use this window to compute the semicoherent Fstat using TransientFstatMaps.
-        This way we are able to decouple this clever shenanigan from the actual
-        usage of a transient window.
+        This way we are able to decouple the semicoherent computation from the 
+        actual usage of a transient window.
         """
         self._semicoherent_window_trick = lalpulsar.transientWindowRange_t()
         self._semicoherent_window_trick.type = lalpulsar.TRANSIENT_RECTANGULAR
@@ -1673,6 +1673,7 @@ class SemiCoherentSearch(ComputeFstat):
 
         if self.BSGL is False:
             d_detStat = 2 * FS.F_mn.data[:, 0]
+        # FIXME: BSGL should not be compute per segment, but for summed F!
         else:
             FstatResults_single = copy.copy(self.FstatResults)
             FstatResults_single.lenth = 1
@@ -1696,7 +1697,7 @@ class SemiCoherentSearch(ComputeFstat):
             )
             d_detStat = log10_BSGL / np.log10(np.exp(1))
         if np.isnan(np.sum(d_detStat)):
-            logging.debug("NaNs in semi-coherent twoF treated as zero")
+            logging.debug("NaNs in semi-coherent detection statistic treated as zero")
             d_detStat = np.nan_to_num(d_detStat, nan=0.0)
 
         return d_detStat

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -1565,6 +1565,22 @@ class SemiCoherentSearch(ComputeFstat):
         self.init_computefstatistic()
         self.init_semicoherent_parameters()
 
+    def _init_semicoherent_window_trick(self):
+        """
+        Use this window to compute semicoherent Fstatistic using transient Fstat.
+        This basically intends to decouple this clever shenanigan from the actual
+        usage of a transient window.
+        """
+        self._semicoherent_window_trick = lalpulsar.transientWindowRange_t()
+        self._semicoherent_window_trick.type = lalpulsar.TRANSIENT_RECTANGULAR
+        self._semicoherent_window_trick.t0 = None
+        self._semicoherent_window_trick.t0Band = None
+        self._semicoherent_window_trick.dt0 = None
+        self._semicoherent_window_trick.tau = None
+        self._semicoherent_window_trick.tauBand = None
+        self._semicoherent_window_trick.dtau = None
+
+
     def init_semicoherent_parameters(self):
         logging.info(
             (

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -1565,27 +1565,27 @@ class SemiCoherentSearch(ComputeFstat):
         self.init_computefstatistic()
         self.init_semicoherent_parameters()
 
-    def _init_semicoherent_window_trick(self):
+    def _init_semicoherent_window_range(self):
         """
         Use this window to compute the semicoherent Fstat using TransientFstatMaps.
         This way we are able to decouple the semicoherent computation from the 
         actual usage of a transient window.
         """
-        self._semicoherent_window_trick = lalpulsar.transientWindowRange_t()
-        self._semicoherent_window_trick.type = lalpulsar.TRANSIENT_RECTANGULAR
+        self.semicoherentWindowRange = lalpulsar.transientWindowRange_t()
+        self.semicoherentWindowRange.type = lalpulsar.TRANSIENT_RECTANGULAR
 
         # Range [t0, t0+t0Band] step dt0
-        self._semicoherent_window_trick.t0 = int(self.tboundaries[0])
-        self._semicoherent_window_trick.t0Band = int(
+        self.semicoherentWindowRange.t0 = int(self.tboundaries[0])
+        self.semicoherentWindowRange.t0Band = int(
             self.tboundaries[-1] - self.tboundaries[0] - 2 * self.Tcoh
         )
-        self._semicoherent_window_trick.dt0 = int(self.Tcoh)
+        self.semicoherentWindowRange.dt0 = int(self.Tcoh)
 
         # Range [tau, tau + tauBand] step dtau
         # Watch out: dtau must be !=0, but tauBand==0 is allowed
-        self._semicoherent_window_trick.tau = int(self.Tcoh)
-        self._semicoherent_window_trick.tauBand = int(0)
-        self._semicoherent_window_trick.dtau = int(1)  # Irrelevant
+        self.semicoherentWindowRange.tau = int(self.Tcoh)
+        self.semicoherentWindowRange.tauBand = int(0)
+        self.semicoherentWindowRange.dtau = int(1)  # Irrelevant
 
     def init_semicoherent_parameters(self):
         logging.info(
@@ -1613,7 +1613,7 @@ class SemiCoherentSearch(ComputeFstat):
                         self.tboundaries[-1], self.SFT_timestamps[-1]
                     )
                 )
-        self._init_semicoherent_window_trick()
+        self._init_semicoherent_window_range()
 
     def get_semicoherent_twoF(
         self,
@@ -1668,7 +1668,7 @@ class SemiCoherentSearch(ComputeFstat):
 
     def _get_per_segment_det_stat(self):
         FS = lalpulsar.ComputeTransientFstatMap(
-            self.FstatResults.multiFatoms[0], self._semicoherent_window_trick, False
+            self.FstatResults.multiFatoms[0], self.semicoherentWindowRange, False
         )
 
         if self.BSGL is False:
@@ -1680,13 +1680,13 @@ class SemiCoherentSearch(ComputeFstat):
             FstatResults_single.data = self.FstatResults.multiFatoms[0].data[0]
             FS0 = lalpulsar.ComputeTransientFstatMap(
                 FstatResults_single.multiFatoms[0],
-                self._semicoherent_window_trick,
+                self.semicoherentWindowRange,
                 False,
             )
             FstatResults_single.data = self.FstatResults.multiFatoms[0].data[1]
             FS1 = lalpulsar.ComputeTransientFstatMap(
                 FstatResults_single.multiFatoms[0],
-                self._semicoherent_window_trick,
+                self.semicoherentWindowRange,
                 False,
             )
 

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -1661,6 +1661,12 @@ class SemiCoherentSearch(ComputeFstat):
 
         det_stat_per_segment = self._get_per_segment_det_stat()
         detStat = det_stat_per_segment.sum()
+
+        if np.isnan(detStat):
+            logging.debug("NaNs in semi-coherent detection statistic treated as zero")
+            det_stat_per_segment = np.nan_to_num(det_stat_per_segment, nan=0.0)
+            detStat = det_stat_per_segment.sum()
+
         if record_segments:
             self.detStat_per_segment = det_stat_per_segment
 
@@ -1679,15 +1685,11 @@ class SemiCoherentSearch(ComputeFstat):
             FstatResults_single.lenth = 1
             FstatResults_single.data = self.FstatResults.multiFatoms[0].data[0]
             FS0 = lalpulsar.ComputeTransientFstatMap(
-                FstatResults_single.multiFatoms[0],
-                self.semicoherentWindowRange,
-                False,
+                FstatResults_single.multiFatoms[0], self.semicoherentWindowRange, False,
             )
             FstatResults_single.data = self.FstatResults.multiFatoms[0].data[1]
             FS1 = lalpulsar.ComputeTransientFstatMap(
-                FstatResults_single.multiFatoms[0],
-                self.semicoherentWindowRange,
-                False,
+                FstatResults_single.multiFatoms[0], self.semicoherentWindowRange, False,
             )
 
             self.twoFX[0] = 2 * FS0.F_mn.data[0][0]
@@ -1696,9 +1698,6 @@ class SemiCoherentSearch(ComputeFstat):
                 2 * FS.F_mn.data[0][0], self.twoFX, self.BSGLSetup
             )
             d_detStat = log10_BSGL / np.log10(np.exp(1))
-        if np.isnan(np.sum(d_detStat)):
-            logging.debug("NaNs in semi-coherent detection statistic treated as zero")
-            d_detStat = np.nan_to_num(d_detStat, nan=0.0)
 
         return d_detStat
 


### PR DESCRIPTION
Semicoherent Fstat is computed using LALSuite's TransientFstatMap (there's no native implementation otherwise!); such implementation was properly documented in [the paper](https://arxiv.org/abs/1802.05450) through a characteristic time tau_T ~ 1.5e-8 (s), which conforms the main time contribution for all our purposes (i.e. Nsft ~ O(1e3 - 1e4) and Nsegments ~ O(1e2 - 1e3) ).

This PR improves tau_T by a factor of ~5 (tau_T ~ 2.8e-9 s) introducing the following changes:

- Given *nsegs* segments, we set up *nsegs* rectangular transient windows and call  `lalpulsar.ComputeTransientFstatMap` **once** (previous approach used *one* rectangular window and called the function *nsegs* times).

- We introduce a new variable `self._semicoherent_window_trick` to carry the transient window around, effectively uncoupling semicoherent and transient functionalities.

- NaN checks are marginally improved (we have to explicitly handle the array of coherent Fstat values).

- SemiCoherent Fstat is computed using numpy.ndarray.sum
 

