### PR TITLE
fix semicoherent BSGL

### DIFF
--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -1677,7 +1677,7 @@ class SemiCoherentSearch(ComputeFstat):
                 )
                 self.twoFX[X] = 2 * FSX.F_mn.data[0][0]
             log10_BSGL = lalpulsar.ComputeBSGL(twoF, self.twoFX, self.BSGLSetup)
-            ln_BSGL = log10_BSGL / np.log10(np.exp(1))
+            ln_BSGL = log10_BSGL * np.log(10.)
             if np.isnan(ln_BSGL):
                 logging.debug("NaNs in semi-coherent ln(BSGL) treated as zero")
                 ln_BSGL = 0.0

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -785,7 +785,7 @@ class ComputeFstat(BaseSearchClass):
             if len(self.injectSqrtSX) != len(self.detector_names):
                 raise ValueError(
                     "injectSqrtSX must be of same length as detector_names ({}!={})".format(
-                        len(self.injectSqrtSX), len(detector_names)
+                        len(self.injectSqrtSX), len(self.detector_names)
                     )
                 )
             FstatOAs.injectSqrtSX = lalpulsar.MultiNoiseFloor()

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -1677,7 +1677,7 @@ class SemiCoherentSearch(ComputeFstat):
                 )
                 self.twoFX[X] = 2 * FSX.F_mn.data[0][0]
             log10_BSGL = lalpulsar.ComputeBSGL(twoF, self.twoFX, self.BSGLSetup)
-            ln_BSGL = log10_BSGL * np.log(10.)
+            ln_BSGL = log10_BSGL * np.log(10.0)
             if np.isnan(ln_BSGL):
                 logging.debug("NaNs in semi-coherent ln(BSGL) treated as zero")
                 ln_BSGL = 0.0

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -1661,7 +1661,7 @@ class SemiCoherentSearch(ComputeFstat):
             twoF = twoF_per_segment.sum()
 
         if record_segments:
-            self.detStat_per_segment = twoF_per_segment
+            self.twoF_per_segment = twoF_per_segment
 
         if self.BSGL is False:
             return twoF
@@ -1675,7 +1675,15 @@ class SemiCoherentSearch(ComputeFstat):
                     self.semicoherentWindowRange,
                     False,
                 )
-                self.twoFX[X] = 2 * FSX.F_mn.data[0][0]
+                twoFX_per_segment = 2 * FSX.F_mn.data[:, 0]
+                self.twoFX[X] = twoFX_per_segment.sum()
+                if np.isnan(self.twoFX[X]):
+                    logging.debug(
+                        "NaNs in per-segment per-detector 2F treated as zero"
+                        " and sum re-computed."
+                    )
+                    twoFX_per_segment = np.nan_to_num(twoFX_per_segment, nan=0.0)
+                    self.twoFX[X] = twoFX_per_segment.sum()
             log10_BSGL = lalpulsar.ComputeBSGL(twoF, self.twoFX, self.BSGLSetup)
             ln_BSGL = log10_BSGL * np.log(10.0)
             if np.isnan(ln_BSGL):

--- a/pyfstat/grid_based_searches.py
+++ b/pyfstat/grid_based_searches.py
@@ -163,7 +163,7 @@ class GridSearch(BaseSearchClass):
             )
 
             def cut_out_tstart_tend(*vals):
-                return self.search.get_semicoherent_twoF(*vals[2:])
+                return self.search.get_semicoherent_det_stat(*vals[2:])
 
             self.search.get_det_stat = cut_out_tstart_tend
 

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -2595,7 +2595,7 @@ class MCMCSemiCoherentSearch(MCMCSearch):
     def logl(self, theta, search):
         for j, theta_i in enumerate(self.theta_idxs):
             self.fixed_theta[theta_i] = theta[j]
-        twoF = search.get_semicoherent_twoF(*self.fixed_theta)
+        twoF = search.get_semicoherent_det_stat(*self.fixed_theta)
         return twoF / 2.0 + self.likelihoodcoef
 
 

--- a/tests.py
+++ b/tests.py
@@ -448,7 +448,7 @@ class ComputeFstat(Test):
             Delta=self.Delta,
         )
         self.assertTrue(lnBSGL < 0)
-        # now with an added signal, expect lnBSGL<0
+        # now with an added signal, expect lnBSGL>0
         search_H1L1 = pyfstat.ComputeFstat(
             tref=self.minStartTime,
             minStartTime=self.minStartTime,

--- a/tests.py
+++ b/tests.py
@@ -564,7 +564,7 @@ class SemiCoherentSearch(Test):
         )
         self.Writer.make_data()
 
-    def test_get_semicoherent_det_stat(self):
+    def test_get_semicoherent_twoF(self):
 
         search = pyfstat.SemiCoherentSearch(
             label=self.label,
@@ -578,6 +578,7 @@ class SemiCoherentSearch(Test):
             maxStartTime=self.Writer.tend,
             minCoverFreq=-0.5,
             maxCoverFreq=-0.5,
+            BSGL=False,
         )
 
         search.get_semicoherent_det_stat(
@@ -600,7 +601,7 @@ class SemiCoherentSearch(Test):
         FSB = self.Writer.predict_fstat()
 
         FSs = np.array([FSA, FSB])
-        diffs = (np.array(search.detStat_per_segment) - FSs) / FSs
+        diffs = (np.array(search.twoF_per_segment) - FSs) / FSs
         self.assertTrue(np.all(diffs < 0.3))
 
     def test_get_semicoherent_BSGL(self):

--- a/tests.py
+++ b/tests.py
@@ -508,7 +508,7 @@ class SemiCoherentSearch(Test):
         )
         self.Writer.make_data()
 
-    def test_get_semicoherent_twoF(self):
+    def test_get_semicoherent_det_stat(self):
 
         search = pyfstat.SemiCoherentSearch(
             label=self.label,
@@ -524,7 +524,7 @@ class SemiCoherentSearch(Test):
             maxCoverFreq=-0.5,
         )
 
-        search.get_semicoherent_twoF(
+        search.get_semicoherent_det_stat(
             self.Writer.F0,
             self.Writer.F1,
             self.Writer.F2,
@@ -564,7 +564,7 @@ class SemiCoherentSearch(Test):
             BSGL=True,
         )
 
-        BSGL = search.get_semicoherent_twoF(
+        BSGL = search.get_semicoherent_det_stat(
             self.Writer.F0,
             self.Writer.F1,
             self.Writer.F2,


### PR DESCRIPTION
Following up from #98:

 -should be computed from summed F-stats,
  not per segment and then summed itself
 -also fixed method names:
   get_semicoherent_twoF -> get_semicoherent_det_stat
  _get_per_segment_det_stat -> _get_per_segment_twoF
 -and made this one into a proper loop over arbitrary numDet,
  though rest of package doesn't fully support >2 yet