### PR TITLE
add mcmc_vs_grid_simple_example

### DIFF
--- a/examples/mcmc_vs_grid_simple_example/PyFstat_example_make_data_for_simple_mcmc_vs_grid.py
+++ b/examples/mcmc_vs_grid_simple_example/PyFstat_example_make_data_for_simple_mcmc_vs_grid.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+
+import pyfstat
+import os
+
+outdir = os.path.join("PyFstat_example_data", "PyFstat_example_simple_mcmc_vs_grid")
+
+F0 = 30.0
+F1 = -1e-10
+F2 = 0
+Alpha = 0.5
+Delta = 1
+
+minStartTime = 1000000000
+duration = 2 * 86400
+maxStartTime = minStartTime + duration
+tref = minStartTime
+
+h0 = 1e-23
+sqrtSX = 1e-22
+detectors = "H1,L1"
+
+Tsft = 1800
+
+transient = pyfstat.Writer(
+    label="simulated_signal",
+    outdir=outdir,
+    tref=tref,
+    tstart=minStartTime,
+    duration=duration,
+    F0=F0,
+    F1=F1,
+    F2=F2,
+    Alpha=Alpha,
+    Delta=Delta,
+    h0=h0,
+    detectors=detectors,
+    sqrtSX=sqrtSX,
+    Tsft=Tsft,
+)
+transient.make_data()

--- a/examples/mcmc_vs_grid_simple_example/PyFstat_example_plot_grid_vs_mcmc_comparison.py
+++ b/examples/mcmc_vs_grid_simple_example/PyFstat_example_plot_grid_vs_mcmc_comparison.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+import pyfstat
+import os
+import numpy as np
+import matplotlib.pyplot as plt
+
+outdir = os.path.join("PyFstat_example_data", "PyFstat_example_simple_mcmc_vs_grid")
+
+F0_inj = 30.0
+F1_inj = -1e-10
+
+grid = pyfstat.helper_functions.read_txt_file_with_header(
+    os.path.join(outdir, "grid_search_NA_GridSearch.txt")
+)
+mcmc = pyfstat.helper_functions.read_txt_file_with_header(
+    os.path.join(outdir, "mcmc_search_samples.dat")
+)
+
+grid_maxidx = np.argmax(grid["twoF"])
+mcmc_maxidx = np.argmax(mcmc["twoF"])
+
+zoomx = [mcmc["F0"][mcmc_maxidx] - 6e-6, mcmc["F0"][mcmc_maxidx] + 6e-6]
+zoomy = [mcmc["F1"][mcmc_maxidx] - 8e-11, mcmc["F1"][mcmc_maxidx] + 8e-11]
+
+plt.plot(grid["F0"], grid["F1"], ".", label="grid")
+plt.plot(mcmc["F0"], mcmc["F1"], ".", label="mcmc")
+plt.plot(F0_inj, F1_inj, "*k", label="injection")
+plt.plot(grid["F0"][grid_maxidx], grid["F1"][grid_maxidx], "+k", label="max2F(grid)")
+plt.plot(mcmc["F0"][mcmc_maxidx], mcmc["F1"][mcmc_maxidx], "xk", label="max2F(mcmc)")
+plt.xlabel("F0")
+plt.ylabel("F1")
+plt.legend()
+plt.savefig(os.path.join(outdir, "grid_vs_Mcmc_F01F1.png"))
+
+plt.xlim(zoomx)
+plt.ylim(zoomy)
+plt.savefig(os.path.join(outdir, "grid_vs_Mcmc_F01F1_zoom.png"))
+plt.close()
+
+sc = plt.scatter(grid["F0"], grid["F1"], c=grid["twoF"], s=3)
+cb = plt.colorbar(sc)
+plt.xlabel("F0")
+plt.ylabel("F1")
+cb.set_label("2F")
+plt.title("grid")
+plt.plot(F0_inj, F1_inj, "*k", label="injection")
+plt.plot(grid["F0"][grid_maxidx], grid["F1"][grid_maxidx], "+k", label="max2F")
+plt.legend()
+plt.xlim(zoomx)
+plt.ylim(zoomy)
+plt.savefig(os.path.join(outdir, "grid_F01F1_2F_zoom.png"))
+plt.close()
+
+# can't yet do same plot for MCMC because twoF not stored in samples .dat file!
+sc = plt.scatter(mcmc["F0"], mcmc["F1"], c=mcmc["twoF"], s=1)
+cb = plt.colorbar(sc)
+plt.xlabel("F0")
+plt.ylabel("F1")
+cb.set_label("2F")
+plt.title("MCMC")
+plt.plot(F0_inj, F1_inj, "*k", label="injection")
+plt.plot(mcmc["F0"][mcmc_maxidx], mcmc["F1"][mcmc_maxidx], "xk", label="max2F")
+plt.legend()
+plt.xlim(zoomx)
+plt.ylim(zoomy)
+plt.savefig(os.path.join(outdir, "mcmc_F01F1_2F_zoom.png"))
+plt.close()

--- a/examples/mcmc_vs_grid_simple_example/PyFstat_example_simple_grid_search.py
+++ b/examples/mcmc_vs_grid_simple_example/PyFstat_example_simple_grid_search.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+
+import pyfstat
+import os
+import numpy as np
+
+try:
+    from gridcorner import gridcorner
+except ImportError:
+    raise ImportError(
+        "Python module 'gridcorner' not found, please install from "
+        "https://gitlab.aei.uni-hannover.de/GregAshton/gridcorner"
+    )
+
+outdir = os.path.join("PyFstat_example_data", "PyFstat_example_simple_mcmc_vs_grid")
+if not os.path.isdir(outdir) or not np.any(
+    [f.endswith(".sft") for f in os.listdir(outdir)]
+):
+    raise RuntimeError(
+        "Please first run PyFstat_example_make_data_for_simple_mcmc_vs_grid.py !"
+    )
+
+F0 = 30.0
+F1 = -1e-10
+F2 = 0
+Alpha = 0.5
+Delta = 1
+
+minStartTime = 1000000000
+duration = 2 * 86400
+maxStartTime = minStartTime + duration
+tref = minStartTime
+
+Tsft = 1800
+
+m = 0.001
+dF0 = np.sqrt(12 * m) / (np.pi * duration)
+dF1 = np.sqrt(180 * m) / (np.pi * duration ** 2)
+DeltaF0 = 500 * dF0
+DeltaF1 = 200 * dF1
+F0s = [F0 - DeltaF0 / 2.0, F0 + DeltaF0 / 2.0, dF0]
+F1s = [F1 - DeltaF1 / 2.0, F1 + DeltaF1 / 2.0, dF1]
+F2s = [F2]
+Alphas = [Alpha]
+Deltas = [Delta]
+
+print("Standard grid search:")
+search = pyfstat.GridSearch(
+    label="grid_search",
+    outdir=outdir,
+    sftfilepattern=os.path.join(outdir, "*simulated_signal*sft"),
+    F0s=F0s,
+    F1s=F1s,
+    F2s=F2s,
+    Alphas=Alphas,
+    Deltas=Deltas,
+    tref=tref,
+    minStartTime=minStartTime,
+    maxStartTime=maxStartTime,
+    BSGL=False,
+)
+search.run()
+search.print_max_twoF()
+search.save_array_to_disk(search.data)
+
+print("Plotting 2F(F0)...")
+search.plot_1D(xkey="F0", xlabel="freq [Hz]", ylabel="$2\mathcal{F}$")
+
+print("Making F0-F1 corner plot of 2F...")
+F0_vals = np.unique(search.data[:, 2]) - F0
+F1_vals = np.unique(search.data[:, 3]) - F1
+twoF = search.data[:, -1].reshape((len(F0_vals), len(F1_vals)))
+xyz = [F0_vals, F1_vals]
+labels = [
+    "$f - f_0$",
+    "$\dot{f} - \dot{f}_0$",
+    "$\widetilde{2\mathcal{F}}$",
+]
+fig, axes = gridcorner(
+    twoF, xyz, projection="log_mean", labels=labels, whspace=0.1, factor=1.8
+)
+fig.savefig(os.path.join(outdir, search.label + "_corner.png"))

--- a/examples/mcmc_vs_grid_simple_example/PyFstat_example_simple_mcmc_search.py
+++ b/examples/mcmc_vs_grid_simple_example/PyFstat_example_simple_mcmc_search.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+import pyfstat
+import os
+import numpy as np
+
+outdir = os.path.join("PyFstat_example_data", "PyFstat_example_simple_mcmc_vs_grid")
+if not os.path.isdir(outdir) or not np.any(
+    [f.endswith(".sft") for f in os.listdir(outdir)]
+):
+    raise RuntimeError(
+        "Please first run PyFstat_example_make_data_for_simple_mcmc_vs_grid.py !"
+    )
+
+F0 = 30.0
+F1 = -1e-10
+F2 = 0
+Alpha = 0.5
+Delta = 1
+
+minStartTime = 1000000000
+duration = 2 * 86400
+maxStartTime = minStartTime + duration
+tref = minStartTime
+
+Tsft = 1800
+
+m = 0.001
+dF0 = np.sqrt(12 * m) / (np.pi * duration)
+dF1 = np.sqrt(180 * m) / (np.pi * duration ** 2)
+DeltaF0 = 500 * dF0
+DeltaF1 = 200 * dF1
+
+theta_prior = {
+    "F0": {"type": "unif", "lower": F0 - DeltaF0 / 2.0, "upper": F0 + DeltaF0 / 2.0},
+    "F1": {"type": "unif", "lower": F1 - DeltaF1 / 2.0, "upper": F1 + DeltaF1 / 2.0},
+    "F2": F2,
+    "Alpha": Alpha,
+    "Delta": Delta,
+}
+
+ntemps = 2
+log10beta_min = -1
+nwalkers = 100
+nsteps = [200, 200]  # [burnin,production]
+
+mcmc = pyfstat.MCMCSearch(
+    label="mcmc_search",
+    outdir=outdir,
+    sftfilepattern=os.path.join(outdir, "*simulated_signal*sft"),
+    theta_prior=theta_prior,
+    tref=tref,
+    minStartTime=minStartTime,
+    maxStartTime=maxStartTime,
+    nsteps=nsteps,
+    nwalkers=nwalkers,
+    ntemps=ntemps,
+    log10beta_min=log10beta_min,
+)
+mcmc.run()
+mcmc.plot_corner()
+mcmc.print_summary()
+mcmc.plot_prior_posterior()


### PR DESCRIPTION
@Rodrigo-Tenorio here's the comparison examples I mentioned, but apparently never committed.

Taking the basic signal parameters from one of the transient examples. 2 days of data, depth 10, MCMC priors are a uniform box exactly covering the same range as the grid. This runs super fast and produces very consistent outputs:

grid:
```
Grid point with max(twoF) for grid_search:
  minStartTime=1000000000.0
  maxStartTime=1000172800.0
  F0=29.999997578534796
  F1=-7.286372986119523e-11
  F2=0.0
  Alpha=0.5
  Delta=1.0
  twoF=227.90359497070312
```

MCMC:
```
13:51 INFO    : Plotting temperature 0 chains
13:51 INFO    : Summary:
13:51 INFO    : Max twoF: 227.98948669433594 with parameters:
  F0         = 2.999999759e+01
  F1         = -7.228125065e-11
13:51 INFO    : Median +/- std for production values
13:51 INFO    :   F0         = 2.999999750e+01 +/- 1.094920819e-06
13:51 INFO    :   F1         = -7.108107283e-11 +/- 1.370313567e-11
13:51 INFO    : 
```

There's also a separate plotting script doing zoomed-in direct comparison plots. But I'll need to do a separate fix first to actually store the twoF values in the mcmc `.dat` file outputs.