### PR TITLE
expose and fix bug in estimate_min_max_CoverFreq for non-fixed sky locations

### DIFF
--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -1063,12 +1063,12 @@ class ComputeFstat(BaseSearchClass):
         scanInit.stepSizes.Alpha = (
             self.search_ranges["Alpha"][-1]
             if len(self.search_ranges["Alpha"]) == 3
-            else 0.001
+            else 0.001  # fallback, irrelevant for band estimate but must be > 0
         )
         scanInit.stepSizes.Delta = (
             self.search_ranges["Delta"][-1]
             if len(self.search_ranges["Delta"]) == 3
-            else 0.001
+            else 0.001  # fallback, irrelevant for band estimate but must be > 0
         )
         scanInit.stepSizes.fkdot = np.zeros(lalpulsar.PULSAR_MAX_SPINS)
         for k in range(3):

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -942,7 +942,7 @@ class ComputeFstat(BaseSearchClass):
                 "[minCoverFreq,maxCoverFreq] not provided, trying to estimate"
                 " from search ranges."
             )
-            self.estimate_min_max_CoverFreq(self.SFTCatalog)
+            self.estimate_min_max_CoverFreq()
         elif (self.minCoverFreq < 0.0) or (self.maxCoverFreq < 0.0):
             if self.sftfilepattern is None:
                 raise ValueError(
@@ -993,7 +993,7 @@ class ComputeFstat(BaseSearchClass):
         maxFreq_SFTs = np.max(fBs)
         return minFreq_SFTs, maxFreq_SFTs
 
-    def estimate_min_max_CoverFreq(self, catalog):
+    def estimate_min_max_CoverFreq(self):
         # extract spanned spin-range at reference-time from the template-bank
         # input self.search_ranges must be a dictionary of lists per search parameter
         # which can be either [single_value], [min,max] or [min,max,step].
@@ -1019,9 +1019,9 @@ class ComputeFstat(BaseSearchClass):
                     " (either [single_value], [min,max]"
                     " or [min,max,step]): {}".format(key, self.search_ranges[key])
                 )
-        Tsft = 1.0 / catalog.data[0].header.deltaF
-        startTime = catalog.data[0].header.epoch
-        endTime = catalog.data[-1].header.epoch + Tsft
+        Tsft = 1.0 / self.SFTCatalog.data[0].header.deltaF
+        startTime = self.SFTCatalog.data[0].header.epoch
+        endTime = self.SFTCatalog.data[-1].header.epoch + Tsft
         # start by constructing a DopplerRegion structure
         # which will be needed to conservatively account for sky-position dependent
         # Doppler shifts of the frequency range to be covered

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -235,8 +235,8 @@ class MCMCSearch(core.BaseSearchClass):
                 )
             # first start with parameters that have non-delta prior ranges
             search_ranges = {
-                key: [prior_bounds[key]["lower"], prior_bounds[key]["upper"], 0]
-                for key in prior_bounds.keys()
+                key: [bound["lower"], bound["upper"]]
+                for key, bound in prior_bounds.items()
             }
             # then add fixed-point (delta prior) parameters
             for key in self.theta_prior:

--- a/tests.py
+++ b/tests.py
@@ -784,8 +784,16 @@ class MCMCSearch(Test):
             "F0": {"type": "norm", "loc": self.F0, "scale": np.abs(1e-10 * self.F0)},
             "F1": {"type": "norm", "loc": self.F1, "scale": np.abs(1e-10 * self.F1)},
             "F2": self.F2,
-            "Alpha": {"type": "norm", "loc": self.Alpha, "scale": 0.01},
-            "Delta": {"type": "norm", "loc": self.Delta, "scale": 0.02},
+            "Alpha": {
+                "type": "unif",
+                "lower": self.Alpha - 0.01,
+                "upper": self.Alpha + 0.01,
+            },
+            "Delta": {
+                "type": "unif",
+                "lower": self.Delta - 0.01,
+                "upper": self.Delta + 0.01,
+            },
         }
 
         search = pyfstat.MCMCSearch(

--- a/tests.py
+++ b/tests.py
@@ -697,54 +697,105 @@ class SemiCoherentGlitchSearch(Test):
 
 class MCMCSearch(Test):
     label = "TestMCMCSearch"
+    h0 = 1
+    sqrtSX = 1
+    F0 = 30
+    F1 = -1e-10
+    F2 = 0
+    minStartTime = 700000000
+    duration = 1 * 86400
+    maxStartTime = minStartTime + duration
+    Alpha = 5e-3
+    Delta = 1.2
+    tref = minStartTime
 
-    def test_fully_coherent(self):
-        h0 = 1
-        sqrtSX = 1
-        F0 = 30
-        F1 = -1e-10
-        F2 = 0
-        minStartTime = 700000000
-        duration = 1 * 86400
-        maxStartTime = minStartTime + duration
-        Alpha = 5e-3
-        Delta = 1.2
-        tref = minStartTime
+    def test_fully_coherent_MCMC_fixedsky(self):
+
         Writer = pyfstat.Writer(
-            F0=F0,
-            F1=F1,
-            F2=F2,
+            F0=self.F0,
+            F1=self.F1,
+            F2=self.F2,
             label=self.label,
-            h0=h0,
-            sqrtSX=sqrtSX,
+            h0=self.h0,
+            sqrtSX=self.sqrtSX,
             outdir=self.outdir,
-            tstart=minStartTime,
-            Alpha=Alpha,
-            Delta=Delta,
-            tref=tref,
-            duration=duration,
+            tstart=self.minStartTime,
+            Alpha=self.Alpha,
+            Delta=self.Delta,
+            tref=self.tref,
+            duration=self.duration,
             Band=4,
         )
-
         Writer.make_data()
+
         predicted_FS = Writer.predict_fstat()
 
         theta = {
-            "F0": {"type": "norm", "loc": F0, "scale": np.abs(1e-10 * F0)},
-            "F1": {"type": "norm", "loc": F1, "scale": np.abs(1e-10 * F1)},
-            "F2": F2,
-            "Alpha": Alpha,
-            "Delta": Delta,
+            "F0": {"type": "norm", "loc": self.F0, "scale": np.abs(1e-10 * self.F0)},
+            "F1": {"type": "norm", "loc": self.F1, "scale": np.abs(1e-10 * self.F1)},
+            "F2": self.F2,
+            "Alpha": self.Alpha,
+            "Delta": self.Delta,
         }
 
         search = pyfstat.MCMCSearch(
-            label=self.label,
+            label=self.label + "FixedSky",
             outdir=self.outdir,
             theta_prior=theta,
-            tref=tref,
-            sftfilepattern=os.path.join(Writer.outdir, "*{}-*sft".format(Writer.label)),
-            minStartTime=minStartTime,
-            maxStartTime=maxStartTime,
+            tref=self.tref,
+            sftfilepattern=os.path.join(self.outdir, "*{}-*sft".format(self.label)),
+            minStartTime=self.minStartTime,
+            maxStartTime=self.maxStartTime,
+            nsteps=[100, 100],
+            nwalkers=100,
+            ntemps=2,
+            log10beta_min=-1,
+        )
+        search.run(plot_walkers=False)
+        _, FS = search.get_max_twoF()
+
+        print(("Predicted twoF is {} while recovered is {}".format(predicted_FS, FS)))
+        self.assertTrue(
+            FS > predicted_FS or np.abs((FS - predicted_FS)) / predicted_FS < 0.3
+        )
+
+    def test_fully_coherent_MCMC_skyprior(self):
+
+        Writer = pyfstat.Writer(
+            F0=self.F0,
+            F1=self.F1,
+            F2=self.F2,
+            label=self.label,
+            h0=self.h0,
+            sqrtSX=self.sqrtSX,
+            outdir=self.outdir,
+            tstart=self.minStartTime,
+            Alpha=self.Alpha,
+            Delta=self.Delta,
+            tref=self.tref,
+            duration=self.duration,
+            Band=4,
+        )
+        Writer.make_data()
+
+        predicted_FS = Writer.predict_fstat()
+
+        theta = {
+            "F0": {"type": "norm", "loc": self.F0, "scale": np.abs(1e-10 * self.F0)},
+            "F1": {"type": "norm", "loc": self.F1, "scale": np.abs(1e-10 * self.F1)},
+            "F2": self.F2,
+            "Alpha": {"type": "norm", "loc": self.Alpha, "scale": 0.01},
+            "Delta": {"type": "norm", "loc": self.Delta, "scale": 0.02},
+        }
+
+        search = pyfstat.MCMCSearch(
+            label=self.label + "SkyPrior",
+            outdir=self.outdir,
+            theta_prior=theta,
+            tref=self.tref,
+            sftfilepattern=os.path.join(self.outdir, "*{}-*sft".format(self.label)),
+            minStartTime=self.minStartTime,
+            maxStartTime=self.maxStartTime,
             nsteps=[100, 100],
             nwalkers=100,
             ntemps=2,


### PR DESCRIPTION
First commit splits the MCMCSearch test case into two: 
 - test_fully_coherent_MCMC_fixedsky
 - test_fully_coherent_MCMC_skyprior
 - the latter exposes bug from https://github.com/PyFstat/PyFstat/issues/106

@Rodrigo-Tenorio will look into a fix