### PR TITLE
Create .zenodo.json

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -34,5 +34,14 @@
   ],
   "access_right": "open",
   "license": "MIT",
-  "upload_type": "software"
+  "upload_type": "software",
+  "language": "eng",
+  "related_identifiers": [
+        {
+            "scheme": "doi", 
+            "identifier": "10.5281/zenodo.1243930", 
+            "relation": "isNewVersionOf", 
+            "resource_type": "software"
+        }
+    ]
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -35,13 +35,5 @@
   "access_right": "open",
   "license": "MIT",
   "upload_type": "software",
-  "language": "eng",
-  "related_identifiers": [
-        {
-            "scheme": "doi", 
-            "identifier": "10.5281/zenodo.1243930", 
-            "relation": "isNewVersionOf", 
-            "resource_type": "software"
-        }
-    ]
+  "language": "eng"
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,38 @@
+{
+  "creators": [
+    {
+      "affiliation": "Monash University",
+      "name": "Ashton, Gregory",
+      "orcid": "0000-0001-7288-2231"
+    },
+    {
+      "affiliation": "Universitat de les Illes Balears",
+      "name": "Keitel, David",
+      "orcid": "0000-0002-2824-626X"
+    },
+    {
+      "affiliation": "Albert Einstein Institute",
+      "name": "Prix, Reinhard",
+      "orcid": "0000-0002-3582-2587"
+    },
+    {
+      "affiliation": "Universitat de les Illes Balears",
+      "name": "Tenorio, Rodrigo",
+      "orcid": "0000-0002-3789-6424"
+    }
+  ],
+  "keywords": [
+    "astrophysics",
+    "data analysis",
+    "gravity",
+    "gravitational waves",
+    "neutron stars",
+    "python3",
+    "ligo",
+    "virgo",
+    "pycuda"
+  ],
+  "access_right": "open",
+  "license": "MIT",
+  "upload_type": "software"
+}


### PR DESCRIPTION
- Zenodo can automatically pull version-independent metadata from this file for each release

- documentation: https://developers.zenodo.org/ (most of the page is aimed at the interactive requests API though)

- I've tested this with a [test repo](https://github.com/dbkeitel/test-zenodo-json) which gets pulled to a [Zenodo sandbox record](https://sandbox.zenodo.org/record/655360)

