### PR TITLE
add more MCMC tests, fix some prior types

### DIFF
--- a/pyfstat/helper_functions.py
+++ b/pyfstat/helper_functions.py
@@ -398,9 +398,21 @@ def get_covering_band(
     psr.fkdotBand[1] = F1band
     psr.fkdotBand[2] = F2band
     psr.refTime = tref
-    return lalpulsar.CWSignalCoveringBand(
+    minCoverFreq, maxCoverFreq = lalpulsar.CWSignalCoveringBand(
         tstart, tend, psr, maxOrbitAsini, minOrbitPeriod, maxOrbitEcc
     )
+    if (
+        np.isnan(minCoverFreq)
+        or np.isnan(maxCoverFreq)
+        or minCoverFreq <= 0.0
+        or maxCoverFreq <= 0.0
+        or maxCoverFreq < minCoverFreq
+    ):
+        raise RuntimeError(
+            "Got invalid pair minCoverFreq={}, maxCoverFreq={} from"
+            " lalpulsar.CWSignalCoveringBand.".format(minCoverFreq, maxCoverFreq)
+        )
+    return minCoverFreq, maxCoverFreq
 
 
 def twoFDMoffThreshold(

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -1090,8 +1090,8 @@ class MCMCSearch(core.BaseSearchClass):
                 prior_bounds[key]["lower"] = prior_dict["lower"]
                 prior_bounds[key]["upper"] = prior_dict["upper"]
             elif prior_dict["type"] == "log10unif":
-                prior_bounds[key]["lower"] = prior_dict["log10lower"]
-                prior_bounds[key]["upper"] = prior_dict["log10upper"]
+                prior_bounds[key]["lower"] = 10 ** prior_dict["log10lower"]
+                prior_bounds[key]["upper"] = 10 ** prior_dict["log10upper"]
             elif prior_dict["type"] == "norm":
                 prior_bounds[key]["lower"] = (
                     prior_dict["loc"] - normal_stds * prior_dict["scale"]

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -1271,7 +1271,7 @@ class MCMCSearch(core.BaseSearchClass):
             )
         else:
             logging.info("kwargs:", kwargs)
-            raise ValueError("Print unrecognise distribution")
+            raise ValueError("Prior pdf type {:s} unknown.".format(kwargs["type"]))
 
     def _generate_rv(self, **kwargs):
         dist_type = kwargs.pop("type")

--- a/tests.py
+++ b/tests.py
@@ -835,7 +835,7 @@ class MCMCSearch(Test):
                 log10beta_min=-1,
             )
             search.run(plot_walkers=False)
-            _, twoF = search.get_max_twoF()
+            max_dict, twoF = search.get_max_twoF()
             diff = np.abs((twoF - twoF_predicted)) / twoF_predicted
 
             print(
@@ -844,7 +844,14 @@ class MCMCSearch(Test):
                     " relative difference: {}".format(twoF_predicted, twoF, diff)
                 )
             )
+            print("Maximum found at:", max_dict)
             self.assertTrue(diff < 0.3)
+            self.assertTrue(np.abs((max_dict["F0"] - Writer.F0) / Writer.F0) < 1e-3)
+            self.assertTrue(np.abs((max_dict["F1"] - Writer.F1) / Writer.F1) < 0.1)
+            if "Alpha" in max_dict.keys():
+                self.assertTrue(np.abs(max_dict["Alpha"] - Writer.Alpha) < 0.01)
+            if "Delta" in max_dict.keys():
+                self.assertTrue(np.abs(max_dict["Delta"] - Writer.Delta) < 0.01)
 
 
 class MCMCSemiCoherentSearch(Test):
@@ -919,6 +926,8 @@ class MCMCSemiCoherentSearch(Test):
         self.assertTrue(len(twoF_per_seg) == nsegs)
         twoF_summed = twoF_per_seg.sum()
         self.assertTrue(np.abs(twoF_summed - twoF_sc) / twoF_sc < 0.01)
+        self.assertTrue(np.abs((max_dict["F0"] - Writer.F0) / Writer.F0) < 1e-3)
+        self.assertTrue(np.abs((max_dict["F1"] - Writer.F1) / Writer.F1) < 0.1)
 
 
 class MCMCFollowUpSearch(Test):
@@ -979,8 +988,8 @@ class MCMCFollowUpSearch(Test):
         )
         print("Maximum found at:", max_dict)
         self.assertTrue(diff < 0.3)
-        self.assertTrue(np.abs((max_dict["F0"] - Writer.F0)) / Writer.F0 < 0.05)
-        self.assertTrue(np.abs((max_dict["F1"] - Writer.F1)) / Writer.F1 < 0.05)
+        self.assertTrue(np.abs((max_dict["F0"] - Writer.F0) / Writer.F0) < 1e-3)
+        self.assertTrue(np.abs((max_dict["F1"] - Writer.F1) / Writer.F1) < 0.1)
 
 
 class MCMCTransientSearch(Test):
@@ -1054,13 +1063,17 @@ class MCMCTransientSearch(Test):
         print("Maximum found at:", max_dict)
         self.assertTrue(diff < 0.3)
         self.assertTrue(
-            np.abs((max_dict["transient_tstart"] - Writer.transientStartTime))
-            / Writer.transientStartTime
+            np.abs(
+                (max_dict["transient_tstart"] - Writer.transientStartTime)
+                / Writer.transientStartTime
+            )
             < 0.05
         )
         self.assertTrue(
-            np.abs((max_dict["transient_duration"] - Writer.transientTau))
-            / Writer.transientTau
+            np.abs(
+                (max_dict["transient_duration"] - Writer.transientTau)
+                / Writer.transientTau
+            )
             < 0.05
         )
 

--- a/tests.py
+++ b/tests.py
@@ -605,8 +605,9 @@ class SemiCoherentSearch(Test):
 
         self.assertTrue(len(twoF_per_seg_computed) == len(twoF_per_seg_predicted))
         diffs = (
-            twoF_per_seg_computed - twoF_per_seg_predicted
-        ) / twoF_per_seg_predicted
+            np.abs(twoF_per_seg_computed - twoF_per_seg_predicted)
+            / twoF_per_seg_predicted
+        )
         print(
             (
                 "Predicted twoF per segment are {}"
@@ -617,7 +618,7 @@ class SemiCoherentSearch(Test):
             )
         )
         self.assertTrue(np.all(diffs < 0.2))
-        diff = (twoF_sc - twoF_predicted) / twoF_predicted
+        diff = np.abs(twoF_sc - twoF_predicted) / twoF_predicted
         print(
             (
                 "Predicted semicoherent twoF is {}"
@@ -740,7 +741,7 @@ class MCMCSearch(Test):
         )
         Writer.make_data()
 
-        predicted_FS = Writer.predict_fstat()
+        twoF_predicted = Writer.predict_fstat()
 
         # use a single test case with loop over multiple prior choices
         # this could be much more elegantly done with @pytest.mark.parametrize


### PR DESCRIPTION
This resolves #97.

- So far, I've taught the `MCMCSearch::test_fully_coherent_MCMC` test case to loop over multiple prior choices -- this could be much more elegantly done with `@pytest.mark.parametrize` but that cannot be mixed with unittest classes which is our standard approach otherwise. Porting the whole test suite to pure `pytest` would be another 2.0 wishlist feature.

- Fixed various issues for some of the more exotic prior types, including most significantly that the `lognorm` type was only implemented in some methods but not everywhere. It's an odd one because the standard parametrizations of scipy and numpy don't match too well, but as demonstrated by the attached separate [test script](https://github.com/PyFstat/PyFstat/files/5030324/test_numpy_scipy_lognorm.py.txt) and plots I think I've mapped them correctly. (Sanity check requested.)
![lognorm](https://user-images.githubusercontent.com/28396587/89402435-1da82580-d717-11ea-82d9-e27c40f23869.png)

- Next I also want to add (simpler, only one prior each) tests for `MCMCSemiCoherentSearch`, `MCMCTransientSearch` and `MCMCFollowUpSearch`.