### PR TITLE
SemiCoherentSearch: fix off-by-one error in segments setup

### DIFF
--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -1577,7 +1577,7 @@ class SemiCoherentSearch(ComputeFstat):
         # Range [t0, t0+t0Band] step dt0
         self.semicoherentWindowRange.t0 = int(self.tboundaries[0])
         self.semicoherentWindowRange.t0Band = int(
-            self.tboundaries[-1] - self.tboundaries[0] - 2 * self.Tcoh
+            self.tboundaries[-1] - self.tboundaries[0] - self.Tcoh
         )
         self.semicoherentWindowRange.dt0 = int(self.Tcoh)
 


### PR DESCRIPTION
It seems that in #98 we introduced an error in the setup of the "window range" used for the semicoherent sum trick.

For N segments, we need to go N steps of length Tcoh each from Tstart to Tend-Tcoh, not only to Tend-2*Tcoh.

The first commit exposes this in the tests by explicitly checking the length of `search.twoF_per_segment` (error wasn't caught before because the computation and checking of relative errors doesn't mind if comparing length 1 against length 2). The second fixes it.

@Rodrigo-Tenorio please confirm there was no deeper reason for the factor 2 in the t0Band. I suspect you may have followed transient code somewhere where it has to make sure to only go to `Tend-2*Tsft`, because the Demod F-stat implementation deep down requires Nsft>=2 and hence otherwise the last window step would fail. But as long as `Tcoh>=2*Tsft`, which should always be the case in any sane search, this is not a concern for our semicoherent "trick" (ab-)use of the windowing.