### PR TITLE
make_sfts.py/Split setup depending on noiseSFTs

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -69,12 +69,12 @@ class Test(unittest.TestCase):
 
 class Writer(Test):
     label = "TestWriter"
-    tested_class = pyfstat.Writer
+    writer_class_to_test = pyfstat.Writer
     tstart = 1094809861
     duration = 4 * 1800
 
     def test_make_cff(self):
-        Writer = self.tested_class(
+        Writer = self.writer_class_to_test(
             label=self.label,
             outdir=self.outdir,
             tstart=self.tstart,
@@ -87,7 +87,7 @@ class Writer(Test):
 
     def test_run_makefakedata(self):
         duration = 4 * 1800
-        Writer = self.tested_class(
+        Writer = self.writer_class_to_test(
             label=self.label, outdir=self.outdir, duration=duration, tstart=self.tstart
         )
         Writer.make_cff()
@@ -106,7 +106,7 @@ class Writer(Test):
         )
 
     def test_makefakedata_usecached(self):
-        Writer = self.tested_class(
+        Writer = self.writer_class_to_test(
             label=self.label, outdir=self.outdir, duration=3600, tstart=self.tstart
         )
         if os.path.isfile(Writer.sftfilepath):
@@ -136,7 +136,7 @@ class Writer(Test):
         detectors = "L1,H1"
 
         # create sfts with a strong signal in them
-        noise_and_signal_writer = self.tested_class(
+        noise_and_signal_writer = self.writer_class_to_test(
             label="test_noiseSFTs_noise_and_signal",
             outdir=self.outdir,
             h0=h0,
@@ -168,7 +168,7 @@ class Writer(Test):
         )
 
         # create noise sfts and then inject a strong signal
-        noise_writer = self.tested_class(
+        noise_writer = self.writer_class_to_test(
             label="test_noiseSFTs_only_noise",
             outdir=self.outdir,
             h0=0,
@@ -182,7 +182,7 @@ class Writer(Test):
         )
         noise_writer.make_data()
 
-        add_signal_writer = self.tested_class(
+        add_signal_writer = self.writer_class_to_test(
             label="test_noiseSFTs_add_signal",
             outdir=self.outdir,
             h0=h0,
@@ -219,7 +219,7 @@ class Writer(Test):
 
 class BinaryModulatedWriter(Writer):
     label = "TestBinaryModulatedWriter"
-    tested_class = pyfstat.BinaryModulatedWriter
+    writer_class_to_test = pyfstat.BinaryModulatedWriter
 
 
 class Bunch(Test):


### PR DESCRIPTION
Solve #84 by splitting the input data handling in two cases depending on whether `noiseSFTs` was given or not.

If the former, use `lalpulsar` tools to infer as much information from them as possible; if the latter, do what's been always done.

I'll have to think about how to deal with `tstart` and so on: I could ignore them if `noiseSFTs` are give, or change the default value to some `None` in order to prevent them from being used/confused (although that would probably imply dealing with the test suite and the infamous #71)