### PR TITLE
tests.py/Include test case using data with gaps

### DIFF
--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -559,8 +559,8 @@ class BinaryModulatedWriter(Writer):
     def __init__(
         self,
         label="Test",
-        tstart=700000000,
-        duration=100 * 86400,
+        tstart=None,
+        duration=None,
         tref=None,
         F0=30,
         F1=1e-10,


### PR DESCRIPTION
After #83, `noiseSFTs` are handled in a proper way (meaning things like #82 are  trivial to fix/modify since they are practically a method on their own.

This PR simply ensures that data with gaps (or non-contiguous data) is properly handled both by MFD and PyFstat (which needs to set the proper `sftfilepath` by counting the number of SFTs).