### PR TITLE
BinaryModulatedWriter: fix refTime format in .cff

### DIFF
--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -671,9 +671,9 @@ class BinaryModulatedWriter(Writer):
             key: value for key, value in signal_parameters.items() if value is not None
         }
 
-        signal_parameter_formats = (len(signal_parameter_labels) - 1) * [":1.18e"] + [
-            ":s"
-        ]
+        signal_parameter_formats = (
+            [":10.6f"] + (len(signal_parameter_labels) - 2) * [":1.18e"] + [":s"]
+        )
         signal_formats = dict(zip(signal_parameter_labels, signal_parameter_formats))
 
         self.signal_parameters = translate_keys_to_lal(self.signal_parameters)


### PR DESCRIPTION
@Rodrigo-Tenorio  this was ":1.18e" as for Doppler parameters,  which apparently trips lalpulsar up
 and makes it extrapolate to nonsense frequencies. This made some changes I'm working on with automatic `--Band` estimation fail in very confusing ways, but best to merge it in first separately. Let's see if the master version of the test suite likes it...
