### PR TITLE
Make examples compatible again

### DIFF
--- a/examples/binary_examples/PyFstat_example_semi_coherent_binary_search_using_MCMC.py
+++ b/examples/binary_examples/PyFstat_example_semi_coherent_binary_search_using_MCMC.py
@@ -10,6 +10,7 @@ data_parameters = {
     "sqrtSX": 1e-23,
     "tstart": 1000000000,
     "duration": 100 * 86400,
+    "detectors": "H1",
 }
 tend = data_parameters["tstart"] + data_parameters["duration"]
 mid_time = 0.5 * (data_parameters["tstart"] + tend)
@@ -29,6 +30,7 @@ signal_parameters = {
     "period": 45 * 24 * 3600.0,
     "tref": mid_time,
     "h0": data_parameters["sqrtSX"] / depth,
+    "cosi": 1.0,
 }
 
 data = pyfstat.BinaryModulatedWriter(

--- a/examples/mcmc_examples/PyFstat_example_MCMC_search_using_initialisation.py
+++ b/examples/mcmc_examples/PyFstat_example_MCMC_search_using_initialisation.py
@@ -6,35 +6,30 @@ label = os.path.splitext(os.path.basename(__file__))[0]
 outdir = os.path.join("PyFstat_example_data", label)
 
 # Properties of the GW data
-sqrtSX = 1e-23
-tstart = 1000000000
-duration = 100 * 86400
-tend = tstart + duration
+data_parameters = {
+    "sqrtSX": 1e-23,
+    "tstart": 1000000000,
+    "duration": 100 * 86400,
+    "detectors": "H1",
+}
+tend = data_parameters["tstart"] + data_parameters["duration"]
+mid_time = 0.5 * (data_parameters["tstart"] + tend)
 
 # Properties of the signal
-F0 = 30.0
-F1 = -1e-10
-F2 = 0
-Alpha = np.radians(83.6292)
-Delta = np.radians(22.0144)
-tref = 0.5 * (tstart + tend)
-
 depth = 10
-h0 = sqrtSX / depth
+signal_parameters = {
+    "F0": 30.0,
+    "F1": -1e-10,
+    "F2": 0,
+    "Alpha": np.radians(83.6292),
+    "Delta": np.radians(22.0144),
+    "tref": mid_time,
+    "h0": data_parameters["sqrtSX"] / depth,
+    "cosi": 1.0,
+}
 
 data = pyfstat.Writer(
-    label=label,
-    outdir=outdir,
-    tref=tref,
-    tstart=tstart,
-    F0=F0,
-    F1=F1,
-    F2=F2,
-    duration=duration,
-    Alpha=Alpha,
-    Delta=Delta,
-    h0=h0,
-    sqrtSX=sqrtSX,
+    label=label, outdir=outdir, **data_parameters, **signal_parameters
 )
 data.make_data()
 
@@ -44,17 +39,24 @@ print("Predicted twoF value: {}\n".format(twoF))
 
 DeltaF0 = 1e-7
 DeltaF1 = 1e-13
-VF0 = (np.pi * duration * DeltaF0) ** 2 / 3.0
-VF1 = (np.pi * duration ** 2 * DeltaF1) ** 2 * 4 / 45.0
+VF0 = (np.pi * data_parameters["duration"] * DeltaF0) ** 2 / 3.0
+VF1 = (np.pi * data_parameters["duration"] ** 2 * DeltaF1) ** 2 * 4 / 45.0
 print("\nV={:1.2e}, VF0={:1.2e}, VF1={:1.2e}\n".format(VF0 * VF1, VF0, VF1))
 
 theta_prior = {
-    "F0": {"type": "unif", "lower": F0 - DeltaF0 / 2.0, "upper": F0 + DeltaF0 / 2.0},
-    "F1": {"type": "unif", "lower": F1 - DeltaF1 / 2.0, "upper": F1 + DeltaF1 / 2.0},
-    "F2": F2,
-    "Alpha": Alpha,
-    "Delta": Delta,
+    "F0": {
+        "type": "unif",
+        "lower": signal_parameters["F0"] - DeltaF0 / 2.0,
+        "upper": signal_parameters["F0"] + DeltaF0 / 2.0,
+    },
+    "F1": {
+        "type": "unif",
+        "lower": signal_parameters["F1"] - DeltaF1 / 2.0,
+        "upper": signal_parameters["F1"] + DeltaF1 / 2.0,
+    },
 }
+for key in "F2", "Alpha", "Delta":
+    theta_prior[key] = signal_parameters[key]
 
 ntemps = 1
 log10beta_min = -1
@@ -66,8 +68,8 @@ mcmc = pyfstat.MCMCSearch(
     outdir=outdir,
     sftfilepattern=os.path.join(outdir, "*{}*sft".format(label)),
     theta_prior=theta_prior,
-    tref=tref,
-    minStartTime=tstart,
+    tref=mid_time,
+    minStartTime=data_parameters["tstart"],
     maxStartTime=tend,
     nsteps=nsteps,
     nwalkers=nwalkers,

--- a/examples/mcmc_examples/PyFstat_example_fully_coherent_MCMC_search.py
+++ b/examples/mcmc_examples/PyFstat_example_fully_coherent_MCMC_search.py
@@ -6,35 +6,30 @@ label = os.path.splitext(os.path.basename(__file__))[0]
 outdir = os.path.join("PyFstat_example_data", label)
 
 # Properties of the GW data
-sqrtSX = 1e-23
-tstart = 1000000000
-duration = 100 * 86400
-tend = tstart + duration
+data_parameters = {
+    "sqrtSX": 1e-23,
+    "tstart": 1000000000,
+    "duration": 100 * 86400,
+    "detectors": "H1",
+}
+tend = data_parameters["tstart"] + data_parameters["duration"]
+mid_time = 0.5 * (data_parameters["tstart"] + tend)
 
 # Properties of the signal
-F0 = 30.0
-F1 = -1e-10
-F2 = 0
-Alpha = np.radians(83.6292)
-Delta = np.radians(22.0144)
-tref = 0.5 * (tstart + tend)
-
 depth = 10
-h0 = sqrtSX / depth
+signal_parameters = {
+    "F0": 30.0,
+    "F1": -1e-10,
+    "F2": 0,
+    "Alpha": np.radians(83.6292),
+    "Delta": np.radians(22.0144),
+    "tref": mid_time,
+    "h0": data_parameters["sqrtSX"] / depth,
+    "cosi": 1.0,
+}
 
 data = pyfstat.Writer(
-    label=label,
-    outdir=outdir,
-    tref=tref,
-    tstart=tstart,
-    F0=F0,
-    F1=F1,
-    F2=F2,
-    duration=duration,
-    Alpha=Alpha,
-    Delta=Delta,
-    h0=h0,
-    sqrtSX=sqrtSX,
+    label=label, outdir=outdir, **data_parameters, **signal_parameters
 )
 data.make_data()
 
@@ -44,17 +39,24 @@ print("Predicted twoF value: {}\n".format(twoF))
 
 DeltaF0 = 1e-7
 DeltaF1 = 1e-13
-VF0 = (np.pi * duration * DeltaF0) ** 2 / 3.0
-VF1 = (np.pi * duration ** 2 * DeltaF1) ** 2 * 4 / 45.0
+VF0 = (np.pi * data_parameters["duration"] * DeltaF0) ** 2 / 3.0
+VF1 = (np.pi * data_parameters["duration"] ** 2 * DeltaF1) ** 2 * 4 / 45.0
 print("\nV={:1.2e}, VF0={:1.2e}, VF1={:1.2e}\n".format(VF0 * VF1, VF0, VF1))
 
 theta_prior = {
-    "F0": {"type": "unif", "lower": F0 - DeltaF0 / 2.0, "upper": F0 + DeltaF0 / 2.0},
-    "F1": {"type": "unif", "lower": F1 - DeltaF1 / 2.0, "upper": F1 + DeltaF1 / 2.0},
-    "F2": F2,
-    "Alpha": Alpha,
-    "Delta": Delta,
+    "F0": {
+        "type": "unif",
+        "lower": signal_parameters["F0"] - DeltaF0 / 2.0,
+        "upper": signal_parameters["F0"] + DeltaF0 / 2.0,
+    },
+    "F1": {
+        "type": "unif",
+        "lower": signal_parameters["F1"] - DeltaF1 / 2.0,
+        "upper": signal_parameters["F1"] + DeltaF1 / 2.0,
+    },
 }
+for key in "F2", "Alpha", "Delta":
+    theta_prior[key] = signal_parameters[key]
 
 ntemps = 2
 log10beta_min = -0.5
@@ -66,8 +68,8 @@ mcmc = pyfstat.MCMCSearch(
     outdir=outdir,
     sftfilepattern=os.path.join(outdir, "*{}*sft".format(label)),
     theta_prior=theta_prior,
-    tref=tref,
-    minStartTime=tstart,
+    tref=mid_time,
+    minStartTime=data_parameters["tstart"],
     maxStartTime=tend,
     nsteps=nsteps,
     nwalkers=nwalkers,
@@ -75,8 +77,8 @@ mcmc = pyfstat.MCMCSearch(
     log10beta_min=log10beta_min,
 )
 mcmc.transform_dictionary = dict(
-    F0=dict(subtractor=F0, symbol="$f-f^\mathrm{s}$"),
-    F1=dict(subtractor=F1, symbol="$\dot{f}-\dot{f}^\mathrm{s}$"),
+    F0=dict(subtractor=signal_parameters["F0"], symbol="$f-f^\mathrm{s}$"),
+    F1=dict(subtractor=signal_parameters["F1"], symbol="$\dot{f}-\dot{f}^\mathrm{s}$"),
 )
 mcmc.run()
 mcmc.plot_corner(add_prior=True)

--- a/examples/mcmc_examples/PyFstat_example_semi_coherent_MCMC_search.py
+++ b/examples/mcmc_examples/PyFstat_example_semi_coherent_MCMC_search.py
@@ -6,35 +6,30 @@ label = os.path.splitext(os.path.basename(__file__))[0]
 outdir = os.path.join("PyFstat_example_data", label)
 
 # Properties of the GW data
-sqrtSX = 1e-23
-tstart = 1000000000
-duration = 100 * 86400
-tend = tstart + duration
+data_parameters = {
+    "sqrtSX": 1e-23,
+    "tstart": 1000000000,
+    "duration": 100 * 86400,
+    "detectors": "H1",
+}
+tend = data_parameters["tstart"] + data_parameters["duration"]
+mid_time = 0.5 * (data_parameters["tstart"] + tend)
 
 # Properties of the signal
-F0 = 30.0
-F1 = -1e-10
-F2 = 0
-Alpha = np.radians(83.6292)
-Delta = np.radians(22.0144)
-tref = 0.5 * (tstart + tend)
-
 depth = 10
-h0 = sqrtSX / depth
+signal_parameters = {
+    "F0": 30.0,
+    "F1": -1e-10,
+    "F2": 0,
+    "Alpha": np.radians(83.6292),
+    "Delta": np.radians(22.0144),
+    "tref": mid_time,
+    "h0": data_parameters["sqrtSX"] / depth,
+    "cosi": 1.0,
+}
 
 data = pyfstat.Writer(
-    label=label,
-    outdir=outdir,
-    tref=tref,
-    tstart=tstart,
-    F0=F0,
-    F1=F1,
-    F2=F2,
-    duration=duration,
-    Alpha=Alpha,
-    Delta=Delta,
-    h0=h0,
-    sqrtSX=sqrtSX,
+    label=label, outdir=outdir, **data_parameters, **signal_parameters
 )
 data.make_data()
 
@@ -44,17 +39,24 @@ print("Predicted twoF value: {}\n".format(twoF))
 
 DeltaF0 = 1e-7
 DeltaF1 = 1e-13
-VF0 = (np.pi * duration * DeltaF0) ** 2 / 3.0
-VF1 = (np.pi * duration ** 2 * DeltaF1) ** 2 * 4 / 45.0
+VF0 = (np.pi * data_parameters["duration"] * DeltaF0) ** 2 / 3.0
+VF1 = (np.pi * data_parameters["duration"] ** 2 * DeltaF1) ** 2 * 4 / 45.0
 print("\nV={:1.2e}, VF0={:1.2e}, VF1={:1.2e}\n".format(VF0 * VF1, VF0, VF1))
 
 theta_prior = {
-    "F0": {"type": "unif", "lower": F0 - DeltaF0 / 2.0, "upper": F0 + DeltaF0 / 2.0},
-    "F1": {"type": "unif", "lower": F1 - DeltaF1 / 2.0, "upper": F1 + DeltaF1 / 2.0},
-    "F2": F2,
-    "Alpha": Alpha,
-    "Delta": Delta,
+    "F0": {
+        "type": "unif",
+        "lower": signal_parameters["F0"] - DeltaF0 / 2.0,
+        "upper": signal_parameters["F0"] + DeltaF0 / 2.0,
+    },
+    "F1": {
+        "type": "unif",
+        "lower": signal_parameters["F1"] - DeltaF1 / 2.0,
+        "upper": signal_parameters["F1"] + DeltaF1 / 2.0,
+    },
 }
+for key in "F2", "Alpha", "Delta":
+    theta_prior[key] = signal_parameters[key]
 
 ntemps = 1
 log10beta_min = -1
@@ -67,8 +69,8 @@ mcmc = pyfstat.MCMCSemiCoherentSearch(
     nsegs=10,
     sftfilepattern=os.path.join(outdir, "*{}*sft".format(label)),
     theta_prior=theta_prior,
-    tref=tref,
-    minStartTime=tstart,
+    tref=mid_time,
+    minStartTime=data_parameters["tstart"],
     maxStartTime=tend,
     nsteps=nsteps,
     nwalkers=nwalkers,
@@ -76,8 +78,8 @@ mcmc = pyfstat.MCMCSemiCoherentSearch(
     log10beta_min=log10beta_min,
 )
 mcmc.transform_dictionary = dict(
-    F0=dict(subtractor=F0, symbol="$f-f^\mathrm{s}$"),
-    F1=dict(subtractor=F1, symbol="$\dot{f}-\dot{f}^\mathrm{s}$"),
+    F0=dict(subtractor=signal_parameters["F0"], symbol="$f-f^\mathrm{s}$"),
+    F1=dict(subtractor=signal_parameters["F1"], symbol="$\dot{f}-\dot{f}^\mathrm{s}$"),
 )
 mcmc.run()
 mcmc.plot_corner(add_prior=True)

--- a/examples/mcmc_vs_grid_simple_example/PyFstat_example_make_data_for_simple_mcmc_vs_grid.py
+++ b/examples/mcmc_vs_grid_simple_example/PyFstat_example_make_data_for_simple_mcmc_vs_grid.py
@@ -17,7 +17,7 @@ maxStartTime = minStartTime + duration
 tref = minStartTime
 
 h0 = 1e-23
-cosi = 0
+cosi = 1.0
 sqrtSX = 1e-22
 detectors = "H1,L1"
 

--- a/examples/other_examples/PyFstat_example_injecting_into_noise_sfts.py
+++ b/examples/other_examples/PyFstat_example_injecting_into_noise_sfts.py
@@ -10,6 +10,7 @@ outdir = os.path.join("PyFstat_example_data", label)
 tstart = 1269734418
 duration_Tsft = 100
 Tsft = 1800
+
 randSeed = 69420
 IFO = "H1"
 h0 = 1000

--- a/examples/other_examples/PyFstat_example_injecting_into_noise_sfts.py
+++ b/examples/other_examples/PyFstat_example_injecting_into_noise_sfts.py
@@ -10,7 +10,6 @@ outdir = os.path.join("PyFstat_example_data", label)
 tstart = 1269734418
 duration_Tsft = 100
 Tsft = 1800
-
 randSeed = 69420
 IFO = "H1"
 h0 = 1000
@@ -18,6 +17,8 @@ cosi = 0
 F0 = 30
 Alpha = 0
 Delta = 0
+
+Band = 2.
 
 # create sfts with a strong signal in them
 # window options are optional here
@@ -32,6 +33,7 @@ noise_and_signal_writer = pyfstat.Writer(
     tstart=tstart,
     duration=duration_Tsft * Tsft,
     Tsft=Tsft,
+    Band=Band,
     detectors=IFO,
     randSeed=randSeed,
     SFTWindowType="tukey",
@@ -48,8 +50,8 @@ noise_and_signal_writer.make_data()
 coherent_search = pyfstat.ComputeFstat(
     tref=noise_and_signal_writer.tref,
     sftfilepattern=sftfilepattern,
-    minCoverFreq=noise_and_signal_writer.F0 - 0.001,
-    maxCoverFreq=noise_and_signal_writer.F0 + 0.001,
+    minCoverFreq=-0.5,
+    maxCoverFreq=-0.5,
 )
 FS_1 = coherent_search.get_fullycoherent_twoF(
     noise_and_signal_writer.tstart,
@@ -71,6 +73,7 @@ noise_writer = pyfstat.Writer(
     tstart=tstart,
     duration=duration_Tsft * Tsft,
     Tsft=Tsft,
+    Band=Band,
     detectors=IFO,
     randSeed=randSeed,
     SFTWindowType="tukey",
@@ -83,14 +86,15 @@ noise_writer.make_data()
 add_signal_writer = pyfstat.Writer(
     label="test_noiseSFTs_add_signal",
     outdir=outdir,
-    h0=h0,
-    cosi=cosi,
     F0=F0,
     Alpha=Alpha,
     Delta=Delta,
+    h0=h0,
+    cosi=cosi,
     tstart=tstart,
     duration=duration_Tsft * Tsft,
     Tsft=Tsft,
+    Band=Band,
     detectors=IFO,
     sqrtSX=0,
     noiseSFTs=os.path.join(
@@ -109,8 +113,8 @@ add_signal_writer.make_data()
 coherent_search = pyfstat.ComputeFstat(
     tref=add_signal_writer.tref,
     sftfilepattern=sftfilepattern,
-    minCoverFreq=noise_and_signal_writer.F0 - 0.001,
-    maxCoverFreq=noise_and_signal_writer.F0 + 0.001,
+    minCoverFreq=-0.5,
+    maxCoverFreq=-0.5,
 )
 FS_2 = coherent_search.get_fullycoherent_twoF(
     add_signal_writer.tstart,

--- a/examples/other_examples/PyFstat_example_injecting_into_noise_sfts.py
+++ b/examples/other_examples/PyFstat_example_injecting_into_noise_sfts.py
@@ -18,7 +18,7 @@ F0 = 30
 Alpha = 0
 Delta = 0
 
-Band = 2.
+Band = 2.0
 
 # create sfts with a strong signal in them
 # window options are optional here

--- a/examples/other_examples/PyFstat_example_sliding_window.py
+++ b/examples/other_examples/PyFstat_example_sliding_window.py
@@ -10,6 +10,7 @@ sqrtSX = 1e-23
 tstart = 1000000000
 duration = 100 * 86400
 tend = tstart + duration
+detectors = "H1"
 
 # Properties of the signal
 F0 = 30.0
@@ -22,6 +23,7 @@ cosi = 0
 
 depth = 60
 h0 = sqrtSX / depth
+cosi = 1.0
 
 data = pyfstat.Writer(
     label=label,
@@ -32,6 +34,7 @@ data = pyfstat.Writer(
     F1=F1,
     F2=F2,
     duration=duration,
+    detectors=detectors,
     Alpha=Alpha,
     Delta=Delta,
     h0=h0,


### PR DESCRIPTION
After #125 #122 and #121 examples are likely to be broken due to some backwards incompatible changes in the default arguments.

Refer to #123 for a brief summary (i.e. sanity check) of examples' outputs.