### PR TITLE
Add options to plot injection parameters for diagnosis

### DIFF
--- a/examples/binary_examples/PyFstat_example_semi_coherent_binary_search_using_MCMC.py
+++ b/examples/binary_examples/PyFstat_example_semi_coherent_binary_search_using_MCMC.py
@@ -99,5 +99,5 @@ mcmc.run(
     walker_plot_args={"plot_det_stat": True, "injection_parameters": signal_parameters},
 )
 mcmc.plot_corner(add_prior=True, truths=signal_parameters)
-mcmc.plot_prior_posterior()
+mcmc.plot_prior_posterior(injection_parameters=signal_parameters)
 mcmc.print_summary()

--- a/examples/binary_examples/PyFstat_example_semi_coherent_binary_search_using_MCMC.py
+++ b/examples/binary_examples/PyFstat_example_semi_coherent_binary_search_using_MCMC.py
@@ -24,9 +24,9 @@ signal_parameters = {
     "Alpha": 0.15,
     "Delta": 0.15,
     "tp": mid_time,
-    "argp": 0.0,
+    "argp": 0.3,
     "asini": 10.0,
-    "ecc": 0,
+    "ecc": 0.5,
     "period": 45 * 24 * 3600.0,
     "tref": mid_time,
     "h0": data_parameters["sqrtSX"] / depth,
@@ -56,19 +56,27 @@ theta_prior = {
         "lower": 44.99 * 24 * 3600.0,
         "upper": 45.01 * 24 * 3600.0,
     },
-    "ecc": signal_parameters["ecc"],
+    "ecc": {
+        "type": "unif",
+        "lower": signal_parameters["ecc"] - 5e-2,
+        "upper": signal_parameters["ecc"] + 5e-2,
+    },
+    "argp": {
+        "type": "unif",
+        "lower": signal_parameters["argp"] - np.pi / 2,
+        "upper": signal_parameters["argp"] + np.pi / 2,
+    },
     "tp": {
         "type": "unif",
         "lower": mid_time - signal_parameters["period"] / 2.0,
         "upper": mid_time + signal_parameters["period"] / 2.0,
     },
-    "argp": signal_parameters["argp"],
 }
 
 ntemps = 3
 log10beta_min = -1
 nwalkers = 150
-nsteps = [300]
+nsteps = [100, 200]
 
 mcmc = pyfstat.MCMCSemiCoherentSearch(
     label=label,
@@ -85,7 +93,11 @@ mcmc = pyfstat.MCMCSemiCoherentSearch(
     log10beta_min=log10beta_min,
     binary=True,
 )
-mcmc.run()
+
+mcmc.run(
+    plot_walkers=True,
+    walker_plot_args={"plot_det_stat": True, "injection_parameters": signal_parameters},
+)
 mcmc.plot_corner(add_prior=True, truths=signal_parameters)
 mcmc.plot_prior_posterior()
 mcmc.print_summary()

--- a/examples/binary_examples/PyFstat_example_semi_coherent_binary_search_using_MCMC.py
+++ b/examples/binary_examples/PyFstat_example_semi_coherent_binary_search_using_MCMC.py
@@ -57,7 +57,11 @@ theta_prior = {
         "upper": 45.01 * 24 * 3600.0,
     },
     "ecc": signal_parameters["ecc"],
-    "tp": {"type": "unif", "lower": 0.999 * mid_time, "upper": 1.001 * mid_time,},
+    "tp": {
+        "type": "unif",
+        "lower": mid_time - signal_parameters["period"] / 2.0,
+        "upper": mid_time + signal_parameters["period"] / 2.0,
+    },
     "argp": signal_parameters["argp"],
 }
 
@@ -82,6 +86,6 @@ mcmc = pyfstat.MCMCSemiCoherentSearch(
     binary=True,
 )
 mcmc.run()
-mcmc.plot_corner(add_prior=True)
+mcmc.plot_corner(add_prior=True, truths=signal_parameters)
 mcmc.plot_prior_posterior()
 mcmc.print_summary()

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -1132,7 +1132,7 @@ class MCMCSearch(core.BaseSearchClass):
                 )
         return prior_bounds, norm_trunc_warning
 
-    def plot_prior_posterior(self, normal_stds=2):
+    def plot_prior_posterior(self, normal_stds=2, injection_parameters=None):
         """ Plot the posterior in the context of the prior """
         fig, axes = plt.subplots(nrows=self.ndim, figsize=(8, 4 * self.ndim))
         N = 1000
@@ -1161,8 +1161,19 @@ class MCMCSearch(core.BaseSearchClass):
             ax2.set_yticklabels([])
             ax.set_yticklabels([])
 
+            if injection_parameters is not None:
+                injection = ax.axvline(
+                    injection_parameters[key],
+                    label="Injection",
+                    color="purple",
+                    ls="--",
+                )
+
         lns = priorln + postln
         labs = [l.get_label() for l in lns]
+        if injection_parameters is not None:
+            lns.append(injection)
+            labs.append("injection")
         axes[0].legend(lns, labs, loc=1, framealpha=0.8)
 
         fig.savefig(os.path.join(self.outdir, self.label + "_prior_posterior.png"))

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -1330,11 +1330,16 @@ class MCMCSearch(core.BaseSearchClass):
         fig=None,
         axes=None,
         xoffset=0,
+        injection_parameters=None,
         plot_det_stat=False,
         context="ggplot",
         labelpad=5,
     ):
         """ Plot all the chains from a sampler """
+        if injection_parameters is not None and not isinstance(
+            injection_parameters, dict
+        ):
+            raise ValueError("injection_parameters is not a dictionary")
 
         if symbols is None:
             symbols = self._get_labels()
@@ -1384,9 +1389,6 @@ class MCMCSearch(core.BaseSearchClass):
 
             idxs = np.arange(chain.shape[1])
             burnin_idx = chain.shape[1] - nprod
-            # if hasattr(self, 'convergence_idx'):
-            #    last_idx = self.convergence_idx
-            # else:
             last_idx = burnin_idx
             if ndim > 1:
                 for i in range(ndim):
@@ -1408,33 +1410,16 @@ class MCMCSearch(core.BaseSearchClass):
                         alpha=alpha,
                         lw=lw,
                     )
-
+                    if injection_parameters is not None:
+                        axes[i].axhline(
+                            injection_parameters[self.theta_keys[i]],
+                            ls="--",
+                            lw=2.0,
+                            color="orange",
+                        )
                     axes[i].set_xlim(0, xoffset + idxs[-1])
                     if symbols:
                         axes[i].set_ylabel(symbols[i], labelpad=labelpad)
-                        # if subtractions[i] == 0:
-                        #    axes[i].set_ylabel(symbols[i], labelpad=labelpad)
-                        # else:
-                        #    axes[i].set_ylabel(
-                        #        symbols[i]+'$-$'+symbols[i]+'$^\mathrm{s}$',
-                        #        labelpad=labelpad)
-
-            #                    if hasattr(self, 'convergence_diagnostic'):
-            #                        ax = axes[i].twinx()
-            #                        axes[i].set_zorder(ax.get_zorder()+1)
-            #                        axes[i].patch.set_visible(False)
-            #                        c_x = np.array(self.convergence_diagnosticx)
-            #                        c_y = np.array(self.convergence_diagnostic)
-            #                        break_idx = np.argmin(np.abs(c_x - burnin_idx))
-            #                        ax.plot(c_x[:break_idx], c_y[:break_idx, i], '-C0',
-            #                                zorder=-10)
-            #                        ax.plot(c_x[break_idx:], c_y[break_idx:, i], '-C0',
-            #                                zorder=-10)
-            #                        if self.convergence_test_type == 'autocorr':
-            #                            ax.set_ylabel(r'$\tau_\mathrm{exp}$')
-            #                        elif self.convergence_test_type == 'GR':
-            #                            ax.set_ylabel('PSRF')
-            #                        ax.ticklabel_format(useOffset=False)
             else:
                 axes[0].ticklabel_format(useOffset=False, axis="y")
                 cs = chain[:, :, temp].T
@@ -1449,6 +1434,13 @@ class MCMCSearch(core.BaseSearchClass):
                 axes[0].plot(
                     idxs[burnin_idx:], cs[burnin_idx:], color="k", alpha=alpha, lw=lw
                 )
+                if injection_parameters is not None:
+                    axes[0].axhline(
+                        injection_parameters[self.theta_keys[i]],
+                        ls="--",
+                        lw=5.0,
+                        color="orange",
+                    )
                 if symbols:
                     axes[0].set_ylabel(symbols[0], labelpad=labelpad)
 

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -883,9 +883,18 @@ class MCMCSearch(core.BaseSearchClass):
 
         """
 
-        if "truths" in kwargs and len(kwargs["truths"]) != self.ndim:
-            logging.warning("len(Truths) != ndim, Truths will be ignored")
-            kwargs["truths"] = None
+        if "truths" in kwargs:
+
+            if isinstance(kwargs["truths"], dict):
+                kwargs["truths"] = [kwargs["truths"][key] for key in self.theta_keys]
+
+            if len(kwargs["truths"]) != self.ndim:
+                logging.warning("len(Truths) != ndim, Truths will be ignored")
+                kwargs["truths"] = None
+            else:
+                kwargs["truths"] = self._scale_samples(
+                    np.reshape(kwargs["truths"], (1, -1)), self.theta_keys
+                ).ravel()
 
         if self.ndim < 2:
             with plt.rc_context(rc_context):


### PR DESCRIPTION
Work in #134 

- A *single* point can be added through the "truths" parameters (this is
due to the way corner is coded).
- If it's a list of values, plot straight.
- If it's a dictionary, get a list from it.