### PR TITLE
cleanup: remove Bunch class, refactor some functions, remove deprecated options

### DIFF
--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -440,8 +440,9 @@ class ComputeFstat(BaseSearchClass):
             grid resolutions in transient start-time and duration,
             both default to Tsft
         detectors : str
-            Two character reference to the data to use, specify None for no
-            contraint. If multiple-separate by comma.
+            Two-character references to the detectors for which to use data.
+            Specify None for no constraint.
+            For multiple detectors, separate by comma.
         minCoverFreq, maxCoverFreq : float
             The min and max cover frequency passed to CreateFstatInput.
             For negative values, these will be used as offsets from the min/max
@@ -551,8 +552,8 @@ class ComputeFstat(BaseSearchClass):
         if self.detectors:
             if "," in self.detectors:
                 logging.warning(
-                    "Multiple detector selection not available,"
-                    " using all available data"
+                    "Multiple-detector constraints not available,"
+                    " using all available data."
                 )
             else:
                 constraints.detector = self.detectors
@@ -611,13 +612,12 @@ class ComputeFstat(BaseSearchClass):
             # maxStartTime must always be > last actual SFT timestamp
             self.maxStartTime = int(SFT_timestamps[-1]) + self.Tsft
 
-        detector_names = list(set([d.header.name for d in self.SFTCatalog.data]))
-        self.detector_names = detector_names
-        if len(detector_names) == 0:
+        self.detector_names = list(set([d.header.name for d in self.SFTCatalog.data]))
+        if len(self.detector_names) == 0:
             raise ValueError("No data loaded.")
         logging.info(
-            "Loaded {} data files from detectors {}".format(
-                len(SFT_timestamps), detector_names
+            "Loaded {} SFTs from detectors {}".format(
+                len(SFT_timestamps), self.detector_names
             )
         )
 

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -405,7 +405,6 @@ class ComputeFstat(BaseSearchClass):
         computeAtoms=False,
         earth_ephem=None,
         sun_ephem=None,
-        estimate_covering_band=None,
     ):
         """
         Parameters
@@ -489,18 +488,7 @@ class ComputeFstat(BaseSearchClass):
             Sun ephemeris file path
             if None, will check standard sources as per
             helper_functions.get_ephemeris_files()
-        estimate_covering_band : bool
-            DEPRECATED: default behaviour is now equivalent to old
-            estimate_covering_band=True.
         """
-
-        if estimate_covering_band is not None:
-            raise ValueError(
-                "Option 'estimate_covering_band' is no longer supported!"
-                " Default behaviour is now equivalent to old"
-                " estimate_covering_band=True,"
-                " unless [minCoverFreq,maxCoverFreq] are given."
-            )
 
         self._set_init_params_dict(locals())
         self.set_ephemeris_files(earth_ephem, sun_ephem)
@@ -1444,7 +1432,6 @@ class SemiCoherentSearch(ComputeFstat):
         RngMedWindow=None,
         earth_ephem=None,
         sun_ephem=None,
-        estimate_covering_band=None,
     ):
         """
         Parameters
@@ -1468,14 +1455,6 @@ class SemiCoherentSearch(ComputeFstat):
 
         For all other parameters, see pyfstat.ComputeFStat.
         """
-
-        if estimate_covering_band is not None:
-            raise ValueError(
-                "Option 'estimate_covering_band' is no longer supported!"
-                " Default behaviour is now equivalent to old"
-                " estimate_covering_band=True,"
-                " unless [minCoverFreq,maxCoverFreq] are given."
-            )
 
         self.fs_file_name = os.path.join(self.outdir, self.label + "_FS.dat")
         self.set_ephemeris_files(earth_ephem, sun_ephem)
@@ -1775,7 +1754,6 @@ class SemiCoherentGlitchSearch(SearchForSignalWithJumps, ComputeFstat):
         injectSources=None,
         earth_ephem=None,
         sun_ephem=None,
-        estimate_covering_band=None,
     ):
         """
         Parameters
@@ -1797,14 +1775,6 @@ class SemiCoherentGlitchSearch(SearchForSignalWithJumps, ComputeFstat):
 
         For all other parameters, see pyfstat.ComputeFStat.
         """
-
-        if estimate_covering_band is not None:
-            raise ValueError(
-                "Option 'estimate_covering_band' is no longer supported!"
-                " Default behaviour is now equivalent to old"
-                " estimate_covering_band=True,"
-                " unless [minCoverFreq,maxCoverFreq] are given."
-            )
 
         self.fs_file_name = os.path.join(self.outdir, self.label + "_FS.dat")
         self.set_ephemeris_files(earth_ephem, sun_ephem)

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -37,86 +37,6 @@ args, tqdm = helper_functions.set_up_command_line_arguments()
 detector_colors = {"h1": "C0", "l1": "C1"}
 
 
-def predict_fstat(
-    h0,
-    cosi,
-    psi,
-    Alpha,
-    Delta,
-    Freq,
-    sftfilepattern,
-    minStartTime,
-    maxStartTime,
-    IFOs=None,
-    assumeSqrtSX=None,
-    tempory_filename="fs.tmp",
-    earth_ephem=None,
-    sun_ephem=None,
-    transientWindowType="none",
-    transientStartTime=None,
-    transientTau=None,
-    **kwargs
-):
-    """ Wrapper to lalapps_PredictFstat
-
-    Parameters
-    ----------
-    h0, cosi, psi, Alpha, Delta, Freq : float
-        Signal properties, see `lalapps_PredictFstat --help` for more info.
-    sftfilepattern : str
-        Pattern matching the sftfiles to use.
-    minStartTime, maxStartTime : int
-    IFOs : str
-        See `lalapps_PredictFstat --help`
-    assumeSqrtSX : float or None
-        See `lalapps_PredictFstat --help`, if None this option is not used
-
-    Returns
-    -------
-    twoF_expected, twoF_sigma : float
-        The expectation and standard deviation of 2F
-
-    """
-
-    cl_pfs = []
-    cl_pfs.append("lalapps_PredictFstat")
-    cl_pfs.append("--h0={}".format(h0))
-    cl_pfs.append("--cosi={}".format(cosi))
-    cl_pfs.append("--psi={}".format(psi))
-    cl_pfs.append("--Alpha={}".format(Alpha))
-    cl_pfs.append("--Delta={}".format(Delta))
-    cl_pfs.append("--Freq={}".format(Freq))
-
-    cl_pfs.append("--DataFiles='{}'".format(sftfilepattern))
-    if assumeSqrtSX:
-        cl_pfs.append("--assumeSqrtSX={}".format(assumeSqrtSX))
-    # if IFOs:
-    #    cl_pfs.append("--IFOs={}".format(IFOs))
-
-    cl_pfs.append("--minStartTime={}".format(int(minStartTime)))
-    cl_pfs.append("--maxStartTime={}".format(int(maxStartTime)))
-    cl_pfs.append("--outputFstat={}".format(tempory_filename))
-
-    earth_ephem_default, sun_ephem_default = helper_functions.get_ephemeris_files()
-    if earth_ephem is None:
-        earth_ephem = earth_ephem_default
-    if sun_ephem is None:
-        sun_ephem = sun_ephem_default
-    cl_pfs.append("--ephemEarth='{}'".format(earth_ephem))
-    cl_pfs.append("--ephemSun='{}'".format(sun_ephem))
-
-    if transientWindowType != "none":
-        cl_pfs.append("--transientWindowType='{}'".format(transientWindowType))
-        cl_pfs.append("--transientStartTime='{}'".format(transientStartTime))
-        cl_pfs.append("--transientTau='{}'".format(transientTau))
-
-    cl_pfs = " ".join(cl_pfs)
-    helper_functions.run_commandline(cl_pfs)
-    d = helper_functions.read_par(filename=tempory_filename)
-    os.remove(tempory_filename)
-    return float(d["twoF_expected"]), float(d["twoF_sigma"])
-
-
 class BaseSearchClass(object):
     """ The base search class providing parent methods to other searches """
 
@@ -1115,7 +1035,7 @@ class ComputeFstat(BaseSearchClass):
         times = np.linspace(self.minStartTime, self.maxStartTime, N + 1)[1:]
         times = np.insert(times, 0, self.minStartTime + 86400 / 2.0)
         out = [
-            predict_fstat(
+            helper_functions.predict_fstat(
                 minStartTime=self.minStartTime,
                 maxStartTime=t,
                 sftfilepattern=self.sftfilepattern,

--- a/pyfstat/grid_based_searches.py
+++ b/pyfstat/grid_based_searches.py
@@ -20,7 +20,6 @@ from pyfstat.core import (
     SemiCoherentSearch,
     tqdm,
     args,
-    read_par,
 )
 import lalpulsar
 import lal
@@ -1721,7 +1720,7 @@ class DMoff_NO_SPIN(GridSearch):
         if type(par) == dict:
             self.par = par
         elif type(par) == str and os.path.isfile(par):
-            self.par = read_par(filename=par)
+            self.par = self.read_par(filename=par)
         else:
             raise ValueError("The .par file does not exist")
 

--- a/pyfstat/grid_based_searches.py
+++ b/pyfstat/grid_based_searches.py
@@ -72,7 +72,6 @@ class GridSearch(BaseSearchClass):
         assumeSqrtSX=None,
         earth_ephem=None,
         sun_ephem=None,
-        estimate_covering_band=None,
     ):
         """
         Parameters
@@ -141,7 +140,6 @@ class GridSearch(BaseSearchClass):
                 assumeSqrtSX=self.assumeSqrtSX,
                 earth_ephem=self.earth_ephem,
                 sun_ephem=self.sun_ephem,
-                estimate_covering_band=self.estimate_covering_band,
             )
             self.search.get_det_stat = self.search.get_fullycoherent_twoF
         else:
@@ -159,7 +157,6 @@ class GridSearch(BaseSearchClass):
                 search_ranges=search_ranges,
                 detectors=self.detectors,
                 injectSources=self.injectSources,
-                estimate_covering_band=self.estimate_covering_band,
             )
 
             def cut_out_tstart_tend(*vals):
@@ -608,7 +605,6 @@ class TransientGridSearch(GridSearch):
         cudaDeviceName=None,
         earth_ephem=None,
         sun_ephem=None,
-        estimate_covering_band=None,
     ):
         """
         Parameters
@@ -701,7 +697,6 @@ class TransientGridSearch(GridSearch):
             computeAtoms=self.outputAtoms,
             earth_ephem=self.earth_ephem,
             sun_ephem=self.sun_ephem,
-            estimate_covering_band=self.estimate_covering_band,
         )
         self.search.get_det_stat = self.search.get_fullycoherent_twoF
 
@@ -840,7 +835,6 @@ class SliceGridSearch(GridSearch):
         Lambda0=None,
         earth_ephem=None,
         sun_ephem=None,
-        estimate_covering_band=None,
     ):
         """
         Parameters
@@ -910,7 +904,6 @@ class SliceGridSearch(GridSearch):
             maxStartTime=self.maxStartTime,
             earth_ephem=self.earth_ephem,
             sun_ephem=self.sun_ephem,
-            estimate_covering_band=self.estimate_covering_band,
         )
 
         for i, ikey in enumerate(self.search_keys):
@@ -1008,7 +1001,6 @@ class GridUniformPriorSearch:
         injectSources=None,
         earth_ephem=None,
         sun_ephem=None,
-        estimate_covering_band=None,
     ):
         dF0 = (theta_prior["F0"]["upper"] - theta_prior["F0"]["lower"]) / NF0
         dF1 = (theta_prior["F1"]["upper"] - theta_prior["F1"]["lower"]) / NF1
@@ -1035,7 +1027,6 @@ class GridUniformPriorSearch:
             RngMedWindow=RngMedWindow,
             earth_ephem=earth_ephem,
             sun_ephem=sun_ephem,
-            estimate_covering_band=self.estimate_covering_band,
         )
 
     def run(self):
@@ -1070,7 +1061,6 @@ class GridGlitchSearch(GridSearch):
         detectors=None,
         earth_ephem=None,
         sun_ephem=None,
-        estimate_covering_band=None,
     ):
         """
         Run a single-glitch grid search
@@ -1128,7 +1118,6 @@ class GridGlitchSearch(GridSearch):
             BSGL=self.BSGL,
             earth_ephem=earth_ephem,
             sun_ephem=sun_ephem,
-            estimate_covering_band=self.estimate_covering_band,
         )
         self.search.get_det_stat = self.search.get_semicoherent_nglitch_twoF
 
@@ -1175,7 +1164,6 @@ class SlidingWindow(GridSearch):
         injectSources=None,
         earth_ephem=None,
         sun_ephem=None,
-        estimate_covering_band=None,
     ):
         """
         Parameters
@@ -1223,7 +1211,6 @@ class SlidingWindow(GridSearch):
             injectSources=self.injectSources,
             earth_ephem=self.earth_ephem,
             sun_ephem=self.sun_ephem,
-            estimate_covering_band=self.estimate_covering_band,
         )
 
     def check_old_data_is_okay_to_use(self, out_file):
@@ -1317,7 +1304,6 @@ class FrequencySlidingWindow(GridSearch):
         injectSources=None,
         earth_ephem=None,
         sun_ephem=None,
-        estimate_covering_band=None,
     ):
         """
         Parameters
@@ -1376,7 +1362,6 @@ class FrequencySlidingWindow(GridSearch):
             injectSources=self.injectSources,
             earth_ephem=self.earth_ephem,
             sun_ephem=self.sun_ephem,
-            estimate_covering_band=self.estimate_covering_band,
         )
         self.search.get_det_stat = self.search.get_fullycoherent_twoF
 

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -74,8 +74,6 @@ class Writer(BaseSearchClass):
         detectors=None,
         earth_ephem=None,
         sun_ephem=None,
-        minStartTime=None,
-        maxStartTime=None,
         transientWindowType="none",
         transientStartTime=None,
         transientTau=None,
@@ -114,16 +112,8 @@ class Writer(BaseSearchClass):
             If None and no noiseSFTs given,
             a minimal covering band for a perfectly-matched
             single-template ComputeFstat analysis is estimated.
-        minStartTime, maxStartTime: float
-            DEPRECATED, use [tstart,duration] and/or
-            [transientWindowType,transientStartTime,transientTau] instead!    
         see `lalapps_Makefakedata_v5 --help` for help with the other paramaters
         """
-
-        if minStartTime is not None or maxStartTime is not None:
-            raise ValueError(
-                "Options 'minStartTime' and 'maxStartTime' are no longer supported!"
-            )
 
         self.set_ephemeris_files(earth_ephem, sun_ephem)
         self.basic_setup()
@@ -629,8 +619,6 @@ class BinaryModulatedWriter(Writer):
         detectors=None,
         earth_ephem=None,
         sun_ephem=None,
-        minStartTime=None,
-        maxStartTime=None,
         transientWindowType="none",
         transientStartTime=None,
         transientTau=None,
@@ -650,9 +638,6 @@ class BinaryModulatedWriter(Writer):
             frequency, sky-position, binary orbit and amplitude parameters
         Tsft: float
             the sft duration
-        minStartTime, maxStartTime: float
-            DEPRECATED, use [tstart,duration] and/or
-            [transientWindowType,transientStartTime,transientTau] instead!
         see `lalapps_Makefakedata_v5 --help` for help with the other paramaters
         """
         self.signal_parameter_labels = super().signal_parameter_labels + [
@@ -728,8 +713,6 @@ class GlitchWriter(SearchForSignalWithJumps, Writer):
         detectors=None,
         earth_ephem=None,
         sun_ephem=None,
-        minStartTime=None,
-        maxStartTime=None,
         transientWindowType="rect",
         randSeed=None,
     ):
@@ -752,16 +735,9 @@ class GlitchWriter(SearchForSignalWithJumps, Writer):
             frequency, sky-position, and amplitude parameters
         Tsft: float
             the sft duration
-        minStartTime, maxStartTime: float
-            DEPRECATED, use [tstart,duration] instead!
 
         see `lalapps_Makefakedata_v5 --help` for help with the other paramaters
         """
-
-        if minStartTime is not None or maxStartTime is not None:
-            raise ValueError(
-                "Options 'minStartTime' and 'maxStartTime' are no longer supported!"
-            )
 
         self.set_ephemeris_files(earth_ephem, sun_ephem)
         self.basic_setup()
@@ -968,8 +944,6 @@ class FrequencyModulatedArtifactWriter(Writer):
         Pmod_amp=1,
         Alpha=None,
         Delta=None,
-        minStartTime=None,
-        maxStartTime=None,
         detectors=None,
         earth_ephem=None,
         sun_ephem=None,
@@ -989,16 +963,9 @@ class FrequencyModulatedArtifactWriter(Writer):
             the sft duration
         sqrtSX: float
             Background IFO noise
-        minStartTime, maxStartTime: float
-            DEPRECATED, use [tstart,duration] instead!
 
         see `lalapps_Makefakedata_v4 --help` for help with the other paramaters
         """
-
-        if minStartTime is not None or maxStartTime is not None:
-            raise ValueError(
-                "Options 'minStartTime' and 'maxStartTime' are no longer supported!"
-            )
 
         self.phi = 0
         self.F2 = 0

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -16,7 +16,6 @@ from pyfstat.core import (
     tqdm,
     args,
     predict_fstat,
-    translate_keys_to_lal,
 )
 import pyfstat.helper_functions as helper_functions
 
@@ -284,7 +283,7 @@ class Writer(BaseSearchClass):
         return self.tstart + self.duration
 
     def parse_args_consistent_with_mfd(self):
-        self.signal_parameters = translate_keys_to_lal(
+        self.signal_parameters = self.translate_keys_to_lal(
             {
                 key: self.__dict__[key]
                 for key in self.signal_parameter_labels

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -15,7 +15,6 @@ from pyfstat.core import (
     SearchForSignalWithJumps,
     tqdm,
     args,
-    predict_fstat,
 )
 import pyfstat.helper_functions as helper_functions
 
@@ -562,7 +561,7 @@ class Writer(BaseSearchClass):
 
     def predict_fstat(self, assumeSqrtSX=None):
         """ Wrapper to lalapps_PredictFstat """
-        twoF_expected, twoF_sigma = predict_fstat(
+        twoF_expected, twoF_sigma = helper_functions.predict_fstat(
             h0=self.h0,
             cosi=self.cosi,
             psi=self.psi,

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -16,12 +16,12 @@ import dill as pickle
 from scipy.stats import lognorm
 
 import pyfstat.core as core
-from pyfstat.core import tqdm, args, read_par, translate_keys_to_lal
+from pyfstat.core import BaseSearchClass, tqdm, args
 import pyfstat.optimal_setup_functions as optimal_setup_functions
 import pyfstat.helper_functions as helper_functions
 
 
-class MCMCSearch(core.BaseSearchClass):
+class MCMCSearch(BaseSearchClass):
     """MCMC search using ComputeFstat
 
     Parameters
@@ -1871,7 +1871,7 @@ class MCMCSearch(core.BaseSearchClass):
         """ Use lalapps_ComputeFstatistic_v2 to produce a .loudest file """
         logging.info("Running CFSv2 to get .loudest file")
         self.write_par(method="twoFmax")
-        params = read_par(label=self.label + "_max2F", outdir=self.outdir)
+        params = self.read_par(label=self.label + "_max2F")
         if np.any([key in params for key in ["delta_F0", "delta_F1", "tglitch"]]):
             raise RuntimeError(
                 "CFSv2 --outputLoudest cannot deal with glitch parameters."
@@ -1884,7 +1884,7 @@ class MCMCSearch(core.BaseSearchClass):
         for key in self.theta_prior:
             if key not in params:
                 params[key] = self.theta_prior[key]
-        params_sanitised = translate_keys_to_lal(params)
+        params_sanitised = self.translate_keys_to_lal(params)
         for key in ["transient-t0Epoch", "transient-t0Offset", "transient-tau"]:
             if (
                 key in params_sanitised
@@ -1897,7 +1897,7 @@ class MCMCSearch(core.BaseSearchClass):
                     )
                 )
                 params_sanitised[key] = rounded
-        signal_parameter_keys = translate_keys_to_lal(self.theta_prior).keys()
+        signal_parameter_keys = self.translate_keys_to_lal(self.theta_prior).keys()
 
         self.loudest_file = os.path.join(self.outdir, self.label + ".loudest")
         cmd = "lalapps_ComputeFstatistic_v2 "

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -1770,35 +1770,6 @@ class MCMCSearch(core.BaseSearchClass):
             d[k] = self.samples[jmax][i]
         return d, maxtwoF
 
-    def get_median_stds(self):
-        """ Returns a dict of the median and std of all production samples """
-        logging.warning(
-            "get_median_stds() method is deprecated"
-            " and will be removed in future releases,"
-            " use get_summary_stats() instead"
-            " and choose an appropriate set of estimators!"
-            " (Recommended: mean,std or median,lower90,upper90)"
-        )
-        d = OrderedDict()
-        repeats = []
-        for s, k in zip(self.samples.T, self.theta_keys):
-            if k in d and k not in repeats:
-                d[k + "_0"] = d[k]  # relabel the old key
-                d[k + "_0_std"] = d[k + "_std"]
-                d.pop(k)
-                d.pop(k + "_std")
-                repeats.append(k)
-            if k in repeats:
-                k = k + "_0"
-                count = 1
-                while k in d:
-                    k = k.replace("_{}".format(count - 1), "_{}".format(count))
-                    count += 1
-
-            d[k] = np.median(s)
-            d[k + "_std"] = np.std(s)
-        return d
-
     def get_summary_stats(self):
         """ Returns a dict of point estimates for all production samples """
         d = OrderedDict()

--- a/tests.py
+++ b/tests.py
@@ -483,26 +483,18 @@ class TestGlitchWriter(TestWriter):
         self.assertTrue(max_freq_glitch[-1] > max_freq_noglitch[-1])
 
 
-class TestBunch(unittest.TestCase):
-    def test_bunch(self):
-        b = pyfstat.core.Bunch(dict(x=10))
-        self.assertTrue(b.x == 10)
-
-
-class TestPar(BaseForTestsWithOutdir):
-    label = "TestPar"
+class TestReadParFile(BaseForTestsWithOutdir):
+    label = "TestReadParFile"
 
     def test(self):
         parfile = os.path.join(self.outdir, self.label + ".par")
         os.system('echo "x=100\ny=10" > ' + parfile)
 
-        par = pyfstat.core.read_par(parfile, return_type="Bunch")
-        self.assertTrue(par.x == 100)
-        self.assertTrue(par.y == 10)
+        par = pyfstat.helper_functions.read_par(filename=parfile)
+        self.assertTrue(par["x"] == 100)
+        self.assertTrue(par["y"] == 10)
 
-        par = pyfstat.core.read_par(
-            outdir=self.outdir, label=self.label, return_type="dict"
-        )
+        par = pyfstat.helper_functions.read_par(outdir=self.outdir, label=self.label)
         self.assertTrue(par["x"] == 100)
         self.assertTrue(par["y"] == 10)
 
@@ -623,7 +615,7 @@ class TestComputeFstat(BaseForTestsWithData):
         )
         self.assertTrue(np.abs(predicted_FS - FS_from_file) / FS_from_file < 0.3)
 
-        injectSourcesdict = pyfstat.core.read_par(injectSources)
+        injectSourcesdict = search.read_par(filename=injectSources)
         injectSourcesdict["F0"] = injectSourcesdict["Freq"]
         injectSourcesdict["F1"] = injectSourcesdict["f1dot"]
         injectSourcesdict["F2"] = injectSourcesdict["f2dot"]


### PR DESCRIPTION
- some minor help/logging improvements

- remove the various options/methods deprecated in the 1.5.x series.

- more significant cleanup of core module:
     - remove Bunch class which wasn't used except for an isolated test case
     - turn translate_keys_to_lal() into a BaseSearchClass method
     - move read_par() to helper_functions but also add a BaseSearchClass method
     - simplify read_par() by always returning a regular dict

- move predict_fstat() from core to helper_functions