### PR TITLE
integration.yml: pin black to 19.10b0

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -31,7 +31,7 @@ jobs:
         ls -l $LALPULSAR_DATADIR
     - name: Style check with black
       run: |
-        pip install black
+        pip install black==19.10b0
         black --check --diff .
     - name: Test with pytest
       run: |


### PR DESCRIPTION
 - new version 20.8b0 which came out *just today* seems to be much stricter
 - should update only when no PRs are pending

--> https://pypi.org/project/black/#history

![Screenshot_20200826_175646](https://user-images.githubusercontent.com/28396587/91327192-82f6b000-e7c5-11ea-891b-9db9076b1e70.png)
