### PR TITLE
Fix periastron time format

### DIFF
--- a/examples/binary_examples/PyFstat_example_semi_coherent_binary_search_using_MCMC.py
+++ b/examples/binary_examples/PyFstat_example_semi_coherent_binary_search_using_MCMC.py
@@ -22,7 +22,7 @@ signal_parameters = {
     "F1": 0,
     "F2": 0,
     "Alpha": 0.15,
-    "Delta": 0.15,
+    "Delta": 0.45,
     "tp": mid_time,
     "argp": 0.3,
     "asini": 10.0,
@@ -48,8 +48,16 @@ theta_prior = {
     "F0": signal_parameters["F0"],
     "F1": signal_parameters["F1"],
     "F2": signal_parameters["F2"],
-    "Alpha": signal_parameters["Alpha"],
-    "Delta": signal_parameters["Delta"],
+    "Alpha": {
+        "type": "unif",
+        "lower": signal_parameters["Alpha"] - 0.01,
+        "upper": signal_parameters["Alpha"] + 0.01,
+    },
+    "Delta": {
+        "type": "unif",
+        "lower": signal_parameters["Delta"] - 0.01,
+        "upper": signal_parameters["Delta"] + 0.01,
+    },
     "asini": {"type": "unif", "lower": 9.9, "upper": 10.1},
     "period": {
         "type": "unif",

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -783,9 +783,14 @@ class BinaryModulatedWriter(Writer):
             key: value for key, value in signal_parameters.items() if value is not None
         }
 
-        signal_parameter_formats = (
-            [":10.6f"] + (len(signal_parameter_labels) - 2) * [":1.18e"] + [":s"]
-        )
+        signal_parameter_formats = (len(signal_parameter_labels) - 1) * [":1.18e"] + [
+            ":s"
+        ]
+        # Pledge MFD's way of parsing time-related variables in a .cff
+        for time_label in "tref", "tp":
+            signal_parameter_formats[
+                signal_parameter_labels.index(time_label)
+            ] = ":10.6f"
         signal_formats = dict(zip(signal_parameter_labels, signal_parameter_formats))
 
         self.signal_parameters = translate_keys_to_lal(self.signal_parameters)


### PR DESCRIPTION
`tp` suffers from the same problem as `tref` in #120 . This makes sense, as both of them [are parsed using the same function in MFD](https://lscsoft.docs.ligo.org/lalsuite/lal/_config_file_test_8c_source.html).

I'll check the rest of parsing functions to make sure nothing else is broken.