### PR TITLE
predict_fstat updates and require lalsuite >= 6.76

### DIFF
--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -571,7 +571,7 @@ class Writer(BaseSearchClass):
             Freq=self.F0,
             sftfilepattern=self.sftfilepath,
             minStartTime=self.tstart,
-            maxStartTime=self.tend(),
+            duration=self.duration,
             IFOs=self.detectors,
             assumeSqrtSX=(assumeSqrtSX or self.sqrtSX),
             tempory_filename=os.path.join(self.outdir, self.label + ".tmp"),

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ tqdm
 bashplotlib
 peakutils
 pathos
-lalsuite>=6.72
+lalsuite>=6.76
 versioneer

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         "bashplotlib",
         "peakutils",
         "pathos",
-        "lalsuite>=6.72",
+        "lalsuite>=6.76",
         "versioneer",
     ],
 )


### PR DESCRIPTION
 - since lalapps 6.26.1, PFS option combinations have changed a bit
  including new --duration when *not* using --DataFiles
 - now wrap the various combinations, making most arguments optional,
  in helper_functions.predict_fstat()
 - using maxStartTime=minStartTime+duration in with-DataFiles case
  is safe here following the usual [,) convention
 - but keep the original mode in Writer.predict_fstat():
  always use sftfilepattern, since (tstart,duration) do not
  fully prescribe the actual data set if we started from
  noiseSFTs with gaps
 - also improved documentation of helper_functions.predict_fstat()
 - closes  #132

@Rodrigo-Tenorio for review, but not very urgent.

PS: Forgot the most important bit: will bump lalsuite dependency to >= 6.76.