### PR TITLE
adopt flake8 linting

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -29,6 +29,10 @@ jobs:
         wget $EPHEM_SRC/sun00-40-DE405.dat.gz -P $LALPULSAR_DATADIR
         echo "Successfully downloaded ephemerides:"
         ls -l $LALPULSAR_DATADIR
+    - name: Linting with flake8
+      run: |
+        pip install flake8
+        flake8 --count --statistics .
     - name: Style check with black
       run: |
         pip install black

--- a/README.md
+++ b/README.md
@@ -151,13 +151,17 @@ For a general introduction to installing modules, see
 [here](https://docs.python.org/3/installing/index.html).
 
 *Optional dependencies*:
-* [pycuda](https://pypi.org/project/pycuda/), required for the `tCWFstatMapVersion=pycuda`
+* [pycuda](https://pypi.org/project/pycuda/),
+  required for the `tCWFstatMapVersion=pycuda`
   option of the `TransientGridSearch` class.
   (Note: `pip install pycuda` requires a working `nvcc` compiler in your path.)
-* [pytest](https://docs.pytest.org) for running the test suite locally (`python -m pytest tests.py`)
-* Developers are also highly encouraged to use the [black](https://black.readthedocs.io) style checker locally
-(`black --check --diff .`),
-as it is required to pass by the online integration pipeline.
+* [pytest](https://docs.pytest.org) for running the test suite locally
+  (`python -m pytest tests.py`)
+* Developers are also highly encouraged to use
+  the [flake8](https://flake8.pycqa.org/en/latest/) linter
+  and [black](https://black.readthedocs.io) style checker
+  locally,
+  as these checks are required to pass by the online integration pipeline.
 * Some of the [examples](./examples) require [gridcorner](https://gitlab.aei.uni-hannover.de/GregAshton/gridcorner);
 for `pip` users this is most conveniently installed by
 ```
@@ -272,7 +276,13 @@ for advice or just jump in and submit an
 
 Here's what you need to know:
 * The github automated tests currently run on `python` [3.6,3.7,3.8] and new PRs need to pass all these.
-* The automated test also runs the [black](https://black.readthedocs.io) style checker. If possible, please run this locally before pushing changes / submitting PRs: `black --check --diff .` to show the required changes, or `black .` to automatically apply them.
+* The automated test also runs
+  the [black](https://black.readthedocs.io) style checker
+  and the [flake8](https://flake8.pycqa.org/en/latest/) linter.
+  If at all possible, please run these two tools locally before pushing changes / submitting PRs:
+  `flake8 --count --statistics .` to find common coding errors and then fix them manually,
+  and then
+  `black --check --diff .` to show the required style changes, or `black .` to automatically apply them.
 
 ## Citing this work
 

--- a/examples/glitch_examples/PyFstat_example_glitch_robust_directed_MCMC_search_on_1_glitch.py
+++ b/examples/glitch_examples/PyFstat_example_glitch_robust_directed_MCMC_search_on_1_glitch.py
@@ -58,21 +58,21 @@ mcmc = pyfstat.MCMCGlitchSearch(
     nglitch=1,
 )
 mcmc.transform_dictionary["F0"] = dict(
-    subtractor=F0, multiplier=1e6, symbol=r"$f-f_\mathrm{s}$"
+    subtractor=F0, multiplier=1e6, symbol="$f-f_\\mathrm{s}$"
 )
-mcmc.unit_dictionary["F0"] = r"$\mu$Hz"
+mcmc.unit_dictionary["F0"] = "$\\mu$Hz"
 mcmc.transform_dictionary["F1"] = dict(
-    subtractor=F1, multiplier=1e12, symbol=r"$\dot{f}-\dot{f}_\mathrm{s}$"
+    subtractor=F1, multiplier=1e12, symbol="$\\dot{f}-\\dot{f}_\\mathrm{s}$"
 )
 mcmc.unit_dictionary["F1"] = "$p$Hz/s"
 mcmc.transform_dictionary["delta_F0"] = dict(
-    multiplier=1e6, subtractor=delta_F0, symbol=r"$\delta f-\delta f_\mathrm{s}$"
+    multiplier=1e6, subtractor=delta_F0, symbol="$\\delta f-\\delta f_\\mathrm{s}$"
 )
-mcmc.unit_dictionary["delta_F0"] = r"$\mu$Hz/s"
+mcmc.unit_dictionary["delta_F0"] = "$\\mu$Hz/s"
 mcmc.transform_dictionary["tglitch"]["subtractor"] = tstart + dtglitch
 mcmc.transform_dictionary["tglitch"][
     "label"
-] = r"$t^\mathrm{g}-t^\mathrm{g}_\mathrm{s}$\n[d]"
+] = "$t^\\mathrm{g}-t^\\mathrm{g}_\\mathrm{s}$\n[d]"
 
 t1 = time.time()
 mcmc.run(save_loudest=False)  # uses CFSv2 which doesn't support glitch parameters

--- a/examples/glitch_examples/PyFstat_example_glitch_robust_directed_MCMC_search_on_1_glitch.py
+++ b/examples/glitch_examples/PyFstat_example_glitch_robust_directed_MCMC_search_on_1_glitch.py
@@ -17,7 +17,6 @@ from PyFstat_example_make_data_for_search_on_1_glitch import (
 )
 import os
 
-outdir = os.path.join("PyFstat_example_data", "PyFstat_example_glitch_robust_search")
 label = "semicoherent_glitch_robust_directed_MCMC_search_on_1_glitch"
 
 Nstar = 1000

--- a/examples/glitch_examples/PyFstat_example_glitch_robust_directed_MCMC_search_on_1_glitch.py
+++ b/examples/glitch_examples/PyFstat_example_glitch_robust_directed_MCMC_search_on_1_glitch.py
@@ -58,21 +58,21 @@ mcmc = pyfstat.MCMCGlitchSearch(
     nglitch=1,
 )
 mcmc.transform_dictionary["F0"] = dict(
-    subtractor=F0, multiplier=1e6, symbol="$f-f_\mathrm{s}$"
+    subtractor=F0, multiplier=1e6, symbol=r"$f-f_\mathrm{s}$"
 )
-mcmc.unit_dictionary["F0"] = "$\mu$Hz"
+mcmc.unit_dictionary["F0"] = r"$\mu$Hz"
 mcmc.transform_dictionary["F1"] = dict(
-    subtractor=F1, multiplier=1e12, symbol="$\dot{f}-\dot{f}_\mathrm{s}$"
+    subtractor=F1, multiplier=1e12, symbol=r"$\dot{f}-\dot{f}_\mathrm{s}$"
 )
 mcmc.unit_dictionary["F1"] = "$p$Hz/s"
 mcmc.transform_dictionary["delta_F0"] = dict(
-    multiplier=1e6, subtractor=delta_F0, symbol="$\delta f-\delta f_\mathrm{s}$"
+    multiplier=1e6, subtractor=delta_F0, symbol=r"$\delta f-\delta f_\mathrm{s}$"
 )
-mcmc.unit_dictionary["delta_F0"] = "$\mu$Hz/s"
+mcmc.unit_dictionary["delta_F0"] = r"$\mu$Hz/s"
 mcmc.transform_dictionary["tglitch"]["subtractor"] = tstart + dtglitch
 mcmc.transform_dictionary["tglitch"][
     "label"
-] = "$t^\mathrm{g}-t^\mathrm{g}_\mathrm{s}$\n[d]"
+] = r"$t^\mathrm{g}-t^\mathrm{g}_\mathrm{s}$\n[d]"
 
 t1 = time.time()
 mcmc.run(save_loudest=False)  # uses CFSv2 which doesn't support glitch parameters

--- a/examples/glitch_examples/PyFstat_example_glitch_robust_directed_grid_search_on_1_glitch.py
+++ b/examples/glitch_examples/PyFstat_example_glitch_robust_directed_grid_search_on_1_glitch.py
@@ -24,7 +24,6 @@ except ImportError:
         "https://gitlab.aei.uni-hannover.de/GregAshton/gridcorner"
     )
 
-outdir = os.path.join("PyFstat_example_data", "PyFstat_example_glitch_robust_search")
 label = "semicoherent_glitch_robust_directed_grid_search_on_1_glitch"
 
 Nstar = 1000

--- a/examples/glitch_examples/PyFstat_example_glitch_robust_directed_grid_search_on_1_glitch.py
+++ b/examples/glitch_examples/PyFstat_example_glitch_robust_directed_grid_search_on_1_glitch.py
@@ -73,11 +73,12 @@ twoF = search.data[:, -1].reshape(
 )
 xyz = [F0_vals * 1e6, F1_vals * 1e12, delta_F0s_vals * 1e6, tglitch_vals_days]
 labels = [
-    r"$f - f_\mathrm{s}$\n[$\mu$Hz]",
-    r"$\dot{f} - \dot{f}_\mathrm{s}$\n[$p$Hz/s]",
-    r"$\delta f-\delta f_\mathrm{s}$\n[$\mu$Hz]",
-    r"$t^\mathrm{g} - t^\mathrm{g}_\mathrm{s}$\n[d]",
-    r"$\widehat{2\mathcal{F}}$",
+    "$f - f_\\mathrm{s}$\n[$\\mu$Hz]",
+    "$\\dot{f} - \\dot{f}_\\mathrm{s}$\n[$p$Hz/s]",
+    "$\\delta f-\\delta f_\\mathrm{s}$\n[$\\mu$Hz]",
+    "$t^\\mathrm{g} - t^\\mathrm{g}_\\mathrm{s}$\n[d]",
+    "$t^\\mathrm{g} - t^\\mathrm{g}_\\mathrm{s}$\n[d]",
+    "$\\widehat{2\\mathcal{F}}$",
 ]
 fig, axes = gridcorner(
     twoF,

--- a/examples/glitch_examples/PyFstat_example_glitch_robust_directed_grid_search_on_1_glitch.py
+++ b/examples/glitch_examples/PyFstat_example_glitch_robust_directed_grid_search_on_1_glitch.py
@@ -73,11 +73,11 @@ twoF = search.data[:, -1].reshape(
 )
 xyz = [F0_vals * 1e6, F1_vals * 1e12, delta_F0s_vals * 1e6, tglitch_vals_days]
 labels = [
-    "$f - f_\mathrm{s}$\n[$\mu$Hz]",
-    "$\dot{f} - \dot{f}_\mathrm{s}$\n[$p$Hz/s]",
-    "$\delta f-\delta f_\mathrm{s}$\n[$\mu$Hz]",
-    "$t^\mathrm{g} - t^\mathrm{g}_\mathrm{s}$\n[d]",
-    "$\widehat{2\mathcal{F}}$",
+    r"$f - f_\mathrm{s}$\n[$\mu$Hz]",
+    r"$\dot{f} - \dot{f}_\mathrm{s}$\n[$p$Hz/s]",
+    r"$\delta f-\delta f_\mathrm{s}$\n[$\mu$Hz]",
+    r"$t^\mathrm{g} - t^\mathrm{g}_\mathrm{s}$\n[d]",
+    r"$\widehat{2\mathcal{F}}$",
 ]
 fig, axes = gridcorner(
     twoF,

--- a/examples/glitch_examples/PyFstat_example_standard_directed_MCMC_search_on_1_glitch.py
+++ b/examples/glitch_examples/PyFstat_example_standard_directed_MCMC_search_on_1_glitch.py
@@ -13,7 +13,6 @@ from PyFstat_example_make_data_for_search_on_1_glitch import (
 )
 import os
 
-outdir = os.path.join("PyFstat_example_data", "PyFstat_example_glitch_robust_search")
 label = "standard_directed_MCMC_search_on_1_glitch"
 
 Nstar = 10000

--- a/examples/glitch_examples/PyFstat_example_standard_directed_MCMC_search_on_1_glitch.py
+++ b/examples/glitch_examples/PyFstat_example_standard_directed_MCMC_search_on_1_glitch.py
@@ -46,9 +46,9 @@ mcmc = pyfstat.MCMCSearch(
     log10beta_min=log10beta_min,
 )
 
-mcmc.transform_dictionary["F0"] = dict(subtractor=F0, symbol="$f-f^\mathrm{s}$")
+mcmc.transform_dictionary["F0"] = dict(subtractor=F0, symbol=r"$f-f^\mathrm{s}$")
 mcmc.transform_dictionary["F1"] = dict(
-    subtractor=F1, symbol="$\dot{f}-\dot{f}^\mathrm{s}$"
+    subtractor=F1, symbol=r"$\dot{f}-\dot{f}^\mathrm{s}$"
 )
 
 mcmc.run()

--- a/examples/glitch_examples/PyFstat_example_standard_directed_MCMC_search_on_1_glitch.py
+++ b/examples/glitch_examples/PyFstat_example_standard_directed_MCMC_search_on_1_glitch.py
@@ -46,9 +46,9 @@ mcmc = pyfstat.MCMCSearch(
     log10beta_min=log10beta_min,
 )
 
-mcmc.transform_dictionary["F0"] = dict(subtractor=F0, symbol=r"$f-f^\mathrm{s}$")
+mcmc.transform_dictionary["F0"] = dict(subtractor=F0, symbol="$f-f^\\mathrm{s}$")
 mcmc.transform_dictionary["F1"] = dict(
-    subtractor=F1, symbol=r"$\dot{f}-\dot{f}^\mathrm{s}$"
+    subtractor=F1, symbol="$\\dot{f}-\\dot{f}^\\mathrm{s}$"
 )
 
 mcmc.run()

--- a/examples/grid_examples/PyFstat_example_grid_search_F0.py
+++ b/examples/grid_examples/PyFstat_example_grid_search_F0.py
@@ -80,13 +80,13 @@ DeltaF = frequencies - F0
 sinc = np.sin(np.pi * DeltaF * duration) / (np.pi * DeltaF * duration)
 A = np.abs((np.max(twoF) - 4) * sinc ** 2 + 4)
 ax.plot(frequencies, A, "-r", lw=1)
-ax.set_ylabel("$\widetilde{2\mathcal{F}}$")
+ax.set_ylabel(r"$\widetilde{2\mathcal{F}}$")
 ax.set_xlabel("Frequency")
 ax.set_xlim(F0s[0], F0s[1])
 dF0 = np.sqrt(12 * 1) / (np.pi * duration)
 xticks = [F0 - 10 * dF0, F0, F0 + 10 * dF0]
 ax.set_xticks(xticks)
-xticklabels = ["$f_0 {-} 10\Delta f$", "$f_0$", "$f_0 {+} 10\Delta f$"]
+xticklabels = [r"$f_0 {-} 10\Delta f$", r"$f_0$", r"$f_0 {+} 10\Delta f$"]
 ax.set_xticklabels(xticklabels)
 plt.tight_layout()
 fig.savefig(os.path.join(outdir, label + "_1D.png"), dpi=300)

--- a/examples/grid_examples/PyFstat_example_grid_search_F0.py
+++ b/examples/grid_examples/PyFstat_example_grid_search_F0.py
@@ -80,13 +80,13 @@ DeltaF = frequencies - F0
 sinc = np.sin(np.pi * DeltaF * duration) / (np.pi * DeltaF * duration)
 A = np.abs((np.max(twoF) - 4) * sinc ** 2 + 4)
 ax.plot(frequencies, A, "-r", lw=1)
-ax.set_ylabel(r"$\widetilde{2\mathcal{F}}$")
+ax.set_ylabel("$\\widetilde{2\\mathcal{F}}$")
 ax.set_xlabel("Frequency")
 ax.set_xlim(F0s[0], F0s[1])
 dF0 = np.sqrt(12 * 1) / (np.pi * duration)
 xticks = [F0 - 10 * dF0, F0, F0 + 10 * dF0]
 ax.set_xticks(xticks)
-xticklabels = [r"$f_0 {-} 10\Delta f$", r"$f_0$", r"$f_0 {+} 10\Delta f$"]
+xticklabels = ["$f_0 {-} 10\\Delta f$", "$f_0$", "$f_0 {+} 10\\Delta f$"]
 ax.set_xticklabels(xticklabels)
 plt.tight_layout()
 fig.savefig(os.path.join(outdir, label + "_1D.png"), dpi=300)

--- a/examples/grid_examples/PyFstat_example_grid_search_F0F1.py
+++ b/examples/grid_examples/PyFstat_example_grid_search_F0F1.py
@@ -1,6 +1,5 @@
 import pyfstat
 import numpy as np
-import matplotlib.pyplot as plt
 import os
 
 try:

--- a/examples/grid_examples/PyFstat_example_grid_search_F0F1.py
+++ b/examples/grid_examples/PyFstat_example_grid_search_F0F1.py
@@ -77,7 +77,7 @@ search = pyfstat.GridSearch(
 )
 search.run()
 
-search.plot_1D(xkey="F0", xlabel="freq [Hz]", ylabel="$2\mathcal{F}$")
+search.plot_1D(xkey="F0", xlabel="freq [Hz]", ylabel=r"$2\mathcal{F}$")
 search.plot_1D(xkey="F1")
 search.plot_2D(xkey="F0", ykey="F1", colorbar=True)
 
@@ -86,9 +86,9 @@ F1_vals = np.unique(search.data[:, 3]) - F1
 twoF = search.data[:, -1].reshape((len(F0_vals), len(F1_vals)))
 xyz = [F0_vals, F1_vals]
 labels = [
-    "$f - f_0$",
-    "$\dot{f} - \dot{f}_0$",
-    "$\widetilde{2\mathcal{F}}$",
+    r"$f - f_0$",
+    r"$\dot{f} - \dot{f}_0$",
+    r"$\widetilde{2\mathcal{F}}$",
 ]
 fig, axes = gridcorner(
     twoF, xyz, projection="log_mean", labels=labels, whspace=0.1, factor=1.8

--- a/examples/grid_examples/PyFstat_example_grid_search_F0F1.py
+++ b/examples/grid_examples/PyFstat_example_grid_search_F0F1.py
@@ -77,7 +77,7 @@ search = pyfstat.GridSearch(
 )
 search.run()
 
-search.plot_1D(xkey="F0", xlabel="freq [Hz]", ylabel=r"$2\mathcal{F}$")
+search.plot_1D(xkey="F0", xlabel="freq [Hz]", ylabel="$2\\mathcal{F}$")
 search.plot_1D(xkey="F1")
 search.plot_2D(xkey="F0", ykey="F1", colorbar=True)
 
@@ -86,9 +86,9 @@ F1_vals = np.unique(search.data[:, 3]) - F1
 twoF = search.data[:, -1].reshape((len(F0_vals), len(F1_vals)))
 xyz = [F0_vals, F1_vals]
 labels = [
-    r"$f - f_0$",
-    r"$\dot{f} - \dot{f}_0$",
-    r"$\widetilde{2\mathcal{F}}$",
+    "$f - f_0$",
+    "$\\dot{f} - \\dot{f}_0$",
+    "$\\widetilde{2\\mathcal{F}}$",
 ]
 fig, axes = gridcorner(
     twoF, xyz, projection="log_mean", labels=labels, whspace=0.1, factor=1.8

--- a/examples/grid_examples/PyFstat_example_grid_search_F0F1F2.py
+++ b/examples/grid_examples/PyFstat_example_grid_search_F0F1F2.py
@@ -82,7 +82,7 @@ search.run()
 agg_chunksize = 10000
 
 search.plot_1D(
-    xkey="F0", xlabel="freq [Hz]", ylabel="$2\mathcal{F}$", agg_chunksize=agg_chunksize
+    xkey="F0", xlabel="freq [Hz]", ylabel=r"$2\mathcal{F}$", agg_chunksize=agg_chunksize
 )
 search.plot_1D(xkey="F1", agg_chunksize=agg_chunksize)
 search.plot_1D(xkey="F2", agg_chunksize=agg_chunksize)
@@ -99,10 +99,10 @@ F2_vals = np.unique(search.data[:, 4]) - F2
 twoF = search.data[:, -1].reshape((len(F0_vals), len(F1_vals), len(F2_vals)))
 xyz = [F0_vals, F1_vals, F2_vals]
 labels = [
-    "$f - f_0$",
-    "$\dot{f} - \dot{f}_0$",
-    "$\ddot{f} - \ddot{f}_0$",
-    "$\widetilde{2\mathcal{F}}$",
+    r"$f - f_0$",
+    r"$\dot{f} - \dot{f}_0$",
+    r"$\ddot{f} - \ddot{f}_0$",
+    r"$\widetilde{2\mathcal{F}}$",
 ]
 fig, axes = gridcorner(
     twoF, xyz, projection="log_mean", labels=labels, whspace=0.1, factor=1.8

--- a/examples/grid_examples/PyFstat_example_grid_search_F0F1F2.py
+++ b/examples/grid_examples/PyFstat_example_grid_search_F0F1F2.py
@@ -1,6 +1,5 @@
 import pyfstat
 import numpy as np
-import matplotlib.pyplot as plt
 import os
 
 try:

--- a/examples/grid_examples/PyFstat_example_grid_search_F0F1F2.py
+++ b/examples/grid_examples/PyFstat_example_grid_search_F0F1F2.py
@@ -82,7 +82,7 @@ search.run()
 agg_chunksize = 10000
 
 search.plot_1D(
-    xkey="F0", xlabel="freq [Hz]", ylabel=r"$2\mathcal{F}$", agg_chunksize=agg_chunksize
+    xkey="F0", xlabel="freq [Hz]", ylabel="$2\\mathcal{F}$", agg_chunksize=agg_chunksize
 )
 search.plot_1D(xkey="F1", agg_chunksize=agg_chunksize)
 search.plot_1D(xkey="F2", agg_chunksize=agg_chunksize)
@@ -99,10 +99,10 @@ F2_vals = np.unique(search.data[:, 4]) - F2
 twoF = search.data[:, -1].reshape((len(F0_vals), len(F1_vals), len(F2_vals)))
 xyz = [F0_vals, F1_vals, F2_vals]
 labels = [
-    r"$f - f_0$",
-    r"$\dot{f} - \dot{f}_0$",
-    r"$\ddot{f} - \ddot{f}_0$",
-    r"$\widetilde{2\mathcal{F}}$",
+    "$f - f_0$",
+    "$\\dot{f} - \\dot{f}_0$",
+    "$\\ddot{f} - \\ddot{f}_0$",
+    "$\\widetilde{2\\mathcal{F}}$",
 ]
 fig, axes = gridcorner(
     twoF, xyz, projection="log_mean", labels=labels, whspace=0.1, factor=1.8

--- a/examples/mcmc_examples/PyFstat_example_fully_coherent_MCMC_search.py
+++ b/examples/mcmc_examples/PyFstat_example_fully_coherent_MCMC_search.py
@@ -77,8 +77,8 @@ mcmc = pyfstat.MCMCSearch(
     log10beta_min=log10beta_min,
 )
 mcmc.transform_dictionary = dict(
-    F0=dict(subtractor=signal_parameters["F0"], symbol="$f-f^\mathrm{s}$"),
-    F1=dict(subtractor=signal_parameters["F1"], symbol="$\dot{f}-\dot{f}^\mathrm{s}$"),
+    F0=dict(subtractor=signal_parameters["F0"], symbol=r"$f-f^\mathrm{s}$"),
+    F1=dict(subtractor=signal_parameters["F1"], symbol=r"$\dot{f}-\dot{f}^\mathrm{s}$"),
 )
 mcmc.run()
 mcmc.plot_corner(add_prior=True)

--- a/examples/mcmc_examples/PyFstat_example_fully_coherent_MCMC_search.py
+++ b/examples/mcmc_examples/PyFstat_example_fully_coherent_MCMC_search.py
@@ -77,8 +77,10 @@ mcmc = pyfstat.MCMCSearch(
     log10beta_min=log10beta_min,
 )
 mcmc.transform_dictionary = dict(
-    F0=dict(subtractor=signal_parameters["F0"], symbol=r"$f-f^\mathrm{s}$"),
-    F1=dict(subtractor=signal_parameters["F1"], symbol=r"$\dot{f}-\dot{f}^\mathrm{s}$"),
+    F0=dict(subtractor=signal_parameters["F0"], symbol="$f-f^\\mathrm{s}$"),
+    F1=dict(
+        subtractor=signal_parameters["F1"], symbol="$\\dot{f}-\\dot{f}^\\mathrm{s}$"
+    ),
 )
 mcmc.run()
 mcmc.plot_corner(add_prior=True)

--- a/examples/mcmc_examples/PyFstat_example_semi_coherent_MCMC_search.py
+++ b/examples/mcmc_examples/PyFstat_example_semi_coherent_MCMC_search.py
@@ -78,8 +78,10 @@ mcmc = pyfstat.MCMCSemiCoherentSearch(
     log10beta_min=log10beta_min,
 )
 mcmc.transform_dictionary = dict(
-    F0=dict(subtractor=signal_parameters["F0"], symbol=r"$f-f^\mathrm{s}$"),
-    F1=dict(subtractor=signal_parameters["F1"], symbol=r"$\dot{f}-\dot{f}^\mathrm{s}$"),
+    F0=dict(subtractor=signal_parameters["F0"], symbol="$f-f^\\mathrm{s}$"),
+    F1=dict(
+        subtractor=signal_parameters["F1"], symbol="$\\dot{f}-\\dot{f}^\\mathrm{s}$"
+    ),
 )
 mcmc.run()
 mcmc.plot_corner(add_prior=True)

--- a/examples/mcmc_examples/PyFstat_example_semi_coherent_MCMC_search.py
+++ b/examples/mcmc_examples/PyFstat_example_semi_coherent_MCMC_search.py
@@ -78,8 +78,8 @@ mcmc = pyfstat.MCMCSemiCoherentSearch(
     log10beta_min=log10beta_min,
 )
 mcmc.transform_dictionary = dict(
-    F0=dict(subtractor=signal_parameters["F0"], symbol="$f-f^\mathrm{s}$"),
-    F1=dict(subtractor=signal_parameters["F1"], symbol="$\dot{f}-\dot{f}^\mathrm{s}$"),
+    F0=dict(subtractor=signal_parameters["F0"], symbol=r"$f-f^\mathrm{s}$"),
+    F1=dict(subtractor=signal_parameters["F1"], symbol=r"$\dot{f}-\dot{f}^\mathrm{s}$"),
 )
 mcmc.run()
 mcmc.plot_corner(add_prior=True)

--- a/examples/mcmc_vs_grid_simple_example/PyFstat_example_simple_grid_search.py
+++ b/examples/mcmc_vs_grid_simple_example/PyFstat_example_simple_grid_search.py
@@ -64,7 +64,7 @@ search.print_max_twoF()
 search.save_array_to_disk(search.data)
 
 print("Plotting 2F(F0)...")
-search.plot_1D(xkey="F0", xlabel="freq [Hz]", ylabel="$2\mathcal{F}$")
+search.plot_1D(xkey="F0", xlabel="freq [Hz]", ylabel=r"$2\mathcal{F}$")
 
 print("Making F0-F1 corner plot of 2F...")
 F0_vals = np.unique(search.data[:, 2]) - F0
@@ -72,9 +72,9 @@ F1_vals = np.unique(search.data[:, 3]) - F1
 twoF = search.data[:, -1].reshape((len(F0_vals), len(F1_vals)))
 xyz = [F0_vals, F1_vals]
 labels = [
-    "$f - f_0$",
-    "$\dot{f} - \dot{f}_0$",
-    "$\widetilde{2\mathcal{F}}$",
+    r"$f - f_0$",
+    r"$\dot{f} - \dot{f}_0$",
+    r"$\widetilde{2\mathcal{F}}$",
 ]
 fig, axes = gridcorner(
     twoF, xyz, projection="log_mean", labels=labels, whspace=0.1, factor=1.8

--- a/examples/mcmc_vs_grid_simple_example/PyFstat_example_simple_grid_search.py
+++ b/examples/mcmc_vs_grid_simple_example/PyFstat_example_simple_grid_search.py
@@ -64,7 +64,7 @@ search.print_max_twoF()
 search.save_array_to_disk(search.data)
 
 print("Plotting 2F(F0)...")
-search.plot_1D(xkey="F0", xlabel="freq [Hz]", ylabel=r"$2\mathcal{F}$")
+search.plot_1D(xkey="F0", xlabel="freq [Hz]", ylabel="$2\\mathcal{F}$")
 
 print("Making F0-F1 corner plot of 2F...")
 F0_vals = np.unique(search.data[:, 2]) - F0
@@ -72,9 +72,9 @@ F1_vals = np.unique(search.data[:, 3]) - F1
 twoF = search.data[:, -1].reshape((len(F0_vals), len(F1_vals)))
 xyz = [F0_vals, F1_vals]
 labels = [
-    r"$f - f_0$",
-    r"$\dot{f} - \dot{f}_0$",
-    r"$\widetilde{2\mathcal{F}}$",
+    "$f - f_0$",
+    "$\\dot{f} - \\dot{f}_0$",
+    "$\\widetilde{2\\mathcal{F}}$",
 ]
 fig, axes = gridcorner(
     twoF, xyz, projection="log_mean", labels=labels, whspace=0.1, factor=1.8

--- a/examples/other_examples/PyFstat_example_injecting_into_noise_sfts.py
+++ b/examples/other_examples/PyFstat_example_injecting_into_noise_sfts.py
@@ -1,7 +1,5 @@
 import os
-import sys
 import numpy as np
-import lalpulsar
 import pyfstat
 
 label = os.path.splitext(os.path.basename(__file__))[0]

--- a/examples/run_all_examples.py
+++ b/examples/run_all_examples.py
@@ -66,6 +66,8 @@ for case in os.listdir(basedir):
                 print("FAILED to run {}".format(script))
                 failures.append(script)
                 if exit_on_first_failure:
+                    print("Exception was:")
+                    print(e)
                     raise RuntimeError("Exiting on first failure as requested.")
                 else:
                     print("\n")

--- a/examples/transient_examples/PyFstat_example_short_transient_grid_search.py
+++ b/examples/transient_examples/PyFstat_example_short_transient_grid_search.py
@@ -53,7 +53,7 @@ search1.run()
 search1.print_max_twoF()
 search1.save_array_to_disk(search1.data)
 
-search1.plot_1D(xkey="F0", xlabel="freq [Hz]", ylabel=r"$2\mathcal{F}$")
+search1.plot_1D(xkey="F0", xlabel="freq [Hz]", ylabel="$2\\mathcal{F}$")
 
 print("with t0,tau bands:")
 search2 = pyfstat.TransientGridSearch(
@@ -79,4 +79,4 @@ search2.run()
 search2.print_max_twoF()
 search2.save_array_to_disk(search2.data)
 
-search2.plot_1D(xkey="F0", xlabel="freq [Hz]", ylabel=r"$2\mathcal{F}$")
+search2.plot_1D(xkey="F0", xlabel="freq [Hz]", ylabel="$2\\mathcal{F}$")

--- a/examples/transient_examples/PyFstat_example_short_transient_grid_search.py
+++ b/examples/transient_examples/PyFstat_example_short_transient_grid_search.py
@@ -53,7 +53,7 @@ search1.run()
 search1.print_max_twoF()
 search1.save_array_to_disk(search1.data)
 
-search1.plot_1D(xkey="F0", xlabel="freq [Hz]", ylabel="$2\mathcal{F}$")
+search1.plot_1D(xkey="F0", xlabel="freq [Hz]", ylabel=r"$2\mathcal{F}$")
 
 print("with t0,tau bands:")
 search2 = pyfstat.TransientGridSearch(
@@ -79,4 +79,4 @@ search2.run()
 search2.print_max_twoF()
 search2.save_array_to_disk(search2.data)
 
-search2.plot_1D(xkey="F0", xlabel="freq [Hz]", ylabel="$2\mathcal{F}$")
+search2.plot_1D(xkey="F0", xlabel="freq [Hz]", ylabel=r"$2\mathcal{F}$")

--- a/pyfstat/grid_based_searches.py
+++ b/pyfstat/grid_based_searches.py
@@ -214,7 +214,7 @@ class GridSearch(BaseSearchClass):
             helper_functions.read_parameters_dict_lines_from_file_header(self.out_file)
         )
         new_params_dict_str_list = [
-            l.strip(" ") for l in self.pprint_init_params_dict()[1:-1]
+            line.strip(" ") for line in self.pprint_init_params_dict()[1:-1]
         ]
         unmatched = np.setxor1d(old_params_dict_str_list, new_params_dict_str_list)
         if len(unmatched) > 0:

--- a/pyfstat/helper_functions.py
+++ b/pyfstat/helper_functions.py
@@ -141,7 +141,7 @@ def get_ephemeris_files():
         try:
             earth_ephem = d["earth_ephem"]
             sun_ephem = d["sun_ephem"]
-        except:
+        except KeyError:
             logging.warning(
                 "No [earth/sun]_ephem found in " + config_file + ". " + please
             )
@@ -307,7 +307,7 @@ def run_commandline(cl, log_level=20, raise_error=True, return_output=True):
                 universal_newlines=True,  # properly display linebreaks in error/output printing
             )
         else:
-            process = subprocess.check_call(cl, shell=True)
+            subprocess.check_call(cl, shell=True)
     except subprocess.CalledProcessError as e:
         logging.log(40, "Execution failed: {}".format(e))
         if e.output:

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -169,6 +169,10 @@ class Writer(BaseSearchClass):
             for ind, dets in enumerate(IFOs)
         ]
 
+    def _gps_to_int(self, tGPS):
+        """Simple LIGOTimeGPS helper, SWIG-LAL does not import this functionality"""
+        return tGPS.gpsSeconds
+
     def _get_setup_from_noiseSFTs(self):
         """
         If noiseSFTs are given, use them to obtain relevant data parameters (tstart,
@@ -191,16 +195,13 @@ class Writer(BaseSearchClass):
         Tsft = []
         self.sftfilenames = []  # This refers to the MFD output!
 
-        # SWIG-LAL does not import this functionality
-        gps_to_int = lambda x: x.gpsSeconds
-
         for ifo_catalog in noise_multi_sft_catalog.data:
             ifo_name = lalpulsar.ListIFOsInCatalog(ifo_catalog).data[0]
 
             time_stamps = lalpulsar.TimestampsFromSFTCatalog(ifo_catalog)
             this_Tsft = int(round(1.0 / ifo_catalog.data[0].header.deltaF))
-            this_start_time = gps_to_int(time_stamps.data[0])
-            this_end_time = gps_to_int(time_stamps.data[-1]) + this_Tsft
+            this_start_time = self._gps_to_int(time_stamps.data[0])
+            this_end_time = self._gps_to_int(time_stamps.data[-1]) + this_Tsft
 
             self.sftfilenames.append(
                 lalpulsar.OfficialSFTFilename(

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -1159,12 +1159,12 @@ class MCMCSearch(BaseSearchClass):
                     ls="--",
                 )
 
-        lns = priorln + postln
-        labs = [l.get_label() for l in lns]
+        plotlines = priorln + postln
+        labs = [plotline.get_label() for plotline in plotlines]
         if injection_parameters is not None:
-            lns.append(injection)
+            plotlines.append(injection)
             labs.append("injection")
-        axes[0].legend(lns, labs, loc=1, framealpha=0.8)
+        axes[0].legend(plotlines, labs, loc=1, framealpha=0.8)
 
         fig.savefig(os.path.join(self.outdir, self.label + "_prior_posterior.png"))
 
@@ -1813,10 +1813,10 @@ class MCMCSearch(BaseSearchClass):
                 prior_range = prior["upper"] - prior["lower"]
                 edges = []
                 fracs = []
-                for l in ["lower", "upper"]:
-                    bools = np.abs(s - prior[l]) / prior_range < threshold
+                for bound in ["lower", "upper"]:
+                    bools = np.abs(s - prior[bound]) / prior_range < threshold
                     if np.any(bools):
-                        edges.append(l)
+                        edges.append(bound)
                         fracs.append(str(100 * float(np.sum(bools)) / len(bools)))
                 if len(edges) > 0:
                     logging.warning(

--- a/pyfstat/tcw_fstat_map_funcs.py
+++ b/pyfstat/tcw_fstat_map_funcs.py
@@ -30,7 +30,7 @@ def _optional_import(modulename, shorthand=None):
         globals()[shorthand] = imp.import_module(modulename)
         logging.debug("Successfully imported module %s%s." % (modulename, shorthandbit))
         success = True
-    except ImportError as e:
+    except ImportError:
         logging.debug("Failed to import module {:s}.".format(modulename))
         success = False
 
@@ -94,7 +94,8 @@ def init_transient_fstat_map_features(wantCuda=False, cudaDeviceName=None):
     have_pycuda_tools = _optional_import("pycuda.tools", "cudatools")
     have_pycuda_compiler = _optional_import("pycuda.compiler", "cudacomp")
     features["pycuda"] = (
-        have_pycuda_drv
+        have_pycuda
+        and have_pycuda_drv
         and have_pycuda_gpuarray
         and have_pycuda_tools
         and have_pycuda_compiler

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 license_file = LICENSE
 
 [flake8]
-exclude = .git,docs,build,dist,tests,*__init__.py
+exclude = .git,docs,build,dist,tests,*__init__.py,versioneer.py
 max-line-length = 80
 select = C,E,F,W,B,B950
 ignore = E501,W503,E203

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 license_file = LICENSE
 
 [flake8]
-exclude = .git,docs,build,dist,tests,*__init__.py,versioneer.py
+exclude = .git,docs,build,dist,tests,*__init__.py,versioneer.py,pyfstat/tcw_fstat_map_funcs.py
 max-line-length = 80
 select = C,E,F,W,B,B950
 ignore = E501,W503,E203

--- a/tests.py
+++ b/tests.py
@@ -116,17 +116,6 @@ class TestWriter(BaseForTestsWithData):
     label = "TestWriter"
     writer_class_to_test = pyfstat.Writer
 
-    # def setup_method(self, method):
-    ## only setting up here, not actually running anything
-    # self.Writer = self.writer_class_to_test(
-    # label=self.label,
-    # outdir=self.outdir,
-    # tstart=self.tstart,
-    # duration=self.duration,
-    # detectors=self.detectors,
-    # **default_signal_params,
-    # )
-
     def test_make_cff(self):
         self.Writer.make_cff(verbose=True)
         self.assertTrue(

--- a/tests.py
+++ b/tests.py
@@ -1384,7 +1384,6 @@ class TestMCMCTransientSearch(BaseForMCMCSearchTests):
                 "upper": self.Writer.duration - 2 * self.Writer.Tsft,
             },
         }
-        nsegs = 10
         self.search = pyfstat.MCMCTransientSearch(
             label=self.label,
             outdir=self.outdir,


### PR DESCRIPTION
We've had `flake8` config settings in `setup.cfg` for a while since `black` also uses them, but we have not actually run this linter. Locally I get at the moment:
```
1     E266 too many leading '#' for block comment
1     E722 do not use bare 'except'
1     E731 do not assign a lambda expression, use a def
3     E741 ambiguous variable name 'l'
5     F401 'matplotlib.pyplot as plt' imported but unused
3     F811 redefinition of unused 'outdir' from line 5
28    F821 undefined name 'sampler'
5     F841 local variable 'e' is assigned to but never used
66    W605 invalid escape sequence '\m'
```