### PR TITLE
Include logging print after every instantiation

### DIFF
--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -40,6 +40,11 @@ detector_colors = {"h1": "C0", "l1": "C1"}
 class BaseSearchClass(object):
     """ The base search class providing parent methods to other searches """
 
+    def __new__(cls, *args, **kwargs):
+        logging.info(f"Creating {cls.__name__} object...")
+        instance = super().__new__(cls)
+        return instance
+
     def _add_log_file(self, header=None):
         """ Log output to a file, requires class to have outdir and label """
         header = [] if header is None else header
@@ -1043,7 +1048,7 @@ class ComputeFstat(BaseSearchClass):
                 maxStartTime=t,
                 sftfilepattern=self.sftfilepattern,
                 IFO=IFO,
-                **pfs_input
+                **pfs_input,
             )
             for t in times
         ]
@@ -1062,7 +1067,7 @@ class ComputeFstat(BaseSearchClass):
         savefig=True,
         title=None,
         plt_label=None,
-        **kwargs
+        **kwargs,
     ):
         """Plot the twoF value cumulatively
 

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -37,7 +37,7 @@ args, tqdm = helper_functions.set_up_command_line_arguments()
 detector_colors = {"h1": "C0", "l1": "C1"}
 
 
-class BaseSearchClass(object):
+class BaseSearchClass:
     """ The base search class providing parent methods to other searches """
 
     def __new__(cls, *args, **kwargs):

--- a/pyfstat/tcw_fstat_map_funcs.py
+++ b/pyfstat/tcw_fstat_map_funcs.py
@@ -37,7 +37,7 @@ def _optional_import(modulename, shorthand=None):
     return success
 
 
-class pyTransientFstatMap(object):
+class pyTransientFstatMap:
     """
     simplified object class for a F(t0,tau) F-stat map (not 2F!)
     based on LALSuite's transientFstatMap_t type


### PR DESCRIPTION
This solves part of #163 : Every single class will announce itself before doing any action.

Also cleans up inheritances from `object`, which are not needed anymore (welcome to Python3, PyFstat!)