### PR TITLE
make start, tend optional in get_fullycoherent_twoF()

### DIFF
--- a/examples/glitch_examples/PyFstat_example_glitch_robust_directed_grid_search_on_1_glitch.py
+++ b/examples/glitch_examples/PyFstat_example_glitch_robust_directed_grid_search_on_1_glitch.py
@@ -62,13 +62,13 @@ search = pyfstat.GridGlitchSearch(
 search.run()
 dT = time.time() - t1
 
-F0_vals = np.unique(search.data[:, 0]) - F0
-F1_vals = np.unique(search.data[:, 1]) - F1
-delta_F0s_vals = np.unique(search.data[:, 5]) - delta_F0
-tglitch_vals = np.unique(search.data[:, 7])
+F0_vals = np.unique(search.data["F0"]) - F0
+F1_vals = np.unique(search.data["F1"]) - F1
+delta_F0s_vals = np.unique(search.data["delta_F0"]) - delta_F0
+tglitch_vals = np.unique(search.data["tglitch"])
 tglitch_vals_days = (tglitch_vals - tstart) / 86400.0 - dtglitch / 86400.0
 
-twoF = search.data[:, -1].reshape(
+twoF = search.data["twoF"].reshape(
     (len(F0_vals), len(F1_vals), len(delta_F0s_vals), len(tglitch_vals))
 )
 xyz = [F0_vals * 1e6, F1_vals * 1e12, delta_F0s_vals * 1e6, tglitch_vals_days]

--- a/examples/grid_examples/PyFstat_example_grid_search_F0.py
+++ b/examples/grid_examples/PyFstat_example_grid_search_F0.py
@@ -69,11 +69,10 @@ search = pyfstat.GridSearch(
 )
 search.run()
 
+print("Plotting 2F(F0)...")
 fig, ax = plt.subplots()
-xidx = search.keys.index("F0")
-frequencies = np.unique(search.data[:, xidx])
-twoF = search.data[:, -1]
-
+frequencies = search.data["F0"]
+twoF = search.data["twoF"]
 # mismatch = np.sign(x-F0)*(duration * np.pi * (x - F0))**2 / 12.0
 ax.plot(frequencies, twoF, "k", lw=1)
 DeltaF = frequencies - F0

--- a/examples/grid_examples/PyFstat_example_grid_search_F0F1.py
+++ b/examples/grid_examples/PyFstat_example_grid_search_F0F1.py
@@ -77,13 +77,17 @@ search = pyfstat.GridSearch(
 )
 search.run()
 
+print("Plotting 2F(F0)...")
 search.plot_1D(xkey="F0", xlabel="freq [Hz]", ylabel="$2\\mathcal{F}$")
+print("Plotting 2F(F1)...")
 search.plot_1D(xkey="F1")
+print("Plotting 2F(F0,F1)...")
 search.plot_2D(xkey="F0", ykey="F1", colorbar=True)
 
-F0_vals = np.unique(search.data[:, 2]) - F0
-F1_vals = np.unique(search.data[:, 3]) - F1
-twoF = search.data[:, -1].reshape((len(F0_vals), len(F1_vals)))
+print("Making corner plot...")
+F0_vals = np.unique(search.data["F0"]) - F0
+F1_vals = np.unique(search.data["F1"]) - F1
+twoF = search.data["twoF"].reshape((len(F0_vals), len(F1_vals)))
 xyz = [F0_vals, F1_vals]
 labels = [
     "$f - f_0$",

--- a/examples/grid_examples/PyFstat_example_grid_search_F0F1F2.py
+++ b/examples/grid_examples/PyFstat_example_grid_search_F0F1F2.py
@@ -81,22 +81,28 @@ search.run()
 # FIXME: workaround for matplotlib "Exceeded cell block limit" errors
 agg_chunksize = 10000
 
+print("Plotting 2F(F0)...")
 search.plot_1D(
     xkey="F0", xlabel="freq [Hz]", ylabel="$2\\mathcal{F}$", agg_chunksize=agg_chunksize
 )
+print("Plotting 2F(F1)...")
 search.plot_1D(xkey="F1", agg_chunksize=agg_chunksize)
+print("Plotting 2F(F2)...")
 search.plot_1D(xkey="F2", agg_chunksize=agg_chunksize)
+print("Plotting 2F(Alpha)...")
 search.plot_1D(xkey="Alpha", agg_chunksize=agg_chunksize)
+print("Plotting 2F(Delta)...")
 search.plot_1D(xkey="Delta", agg_chunksize=agg_chunksize)
 # 2D plots will currently not work for >2 non-trivial (gridded) search dimensions
 # search.plot_2D(xkey="F0",ykey="F1",colorbar=True)
 # search.plot_2D(xkey="F0",ykey="F2",colorbar=True)
 # search.plot_2D(xkey="F1",ykey="F2",colorbar=True)
 
-F0_vals = np.unique(search.data[:, 2]) - F0
-F1_vals = np.unique(search.data[:, 3]) - F1
-F2_vals = np.unique(search.data[:, 4]) - F2
-twoF = search.data[:, -1].reshape((len(F0_vals), len(F1_vals), len(F2_vals)))
+print("Making corner plot...")
+F0_vals = np.unique(search.data["F0"]) - F0
+F1_vals = np.unique(search.data["F1"]) - F1
+F2_vals = np.unique(search.data["F2"]) - F2
+twoF = search.data["twoF"].reshape((len(F0_vals), len(F1_vals), len(F2_vals)))
 xyz = [F0_vals, F1_vals, F2_vals]
 labels = [
     "$f - f_0$",

--- a/examples/mcmc_vs_grid_simple_example/PyFstat_example_simple_mcmc_vs_grid_comparison.py
+++ b/examples/mcmc_vs_grid_simple_example/PyFstat_example_simple_mcmc_vs_grid_comparison.py
@@ -110,7 +110,6 @@ gridsearch = pyfstat.GridSearch(
 )
 gridsearch.run()
 gridsearch.print_max_twoF()
-gridsearch.save_array_to_disk(gridsearch.data)
 
 # do some plots of the GridSearch results
 if not sky:  # this plotter can't currently deal with too large result arrays
@@ -119,11 +118,8 @@ if not sky:  # this plotter can't currently deal with too large result arrays
         gridsearch.plot_1D(xkey=key, xlabel=labels[key], ylabel=labels["2F"])
 
 print("Making GridSearch {:s} corner plot...".format("-".join(search_keys)))
-vals = [
-    np.unique(gridsearch.data[:, gridsearch.keys.index(key)]) - inj[key]
-    for key in search_keys
-]
-twoF = gridsearch.data[:, -1].reshape([len(kval) for kval in vals])
+vals = [np.unique(gridsearch.data[key]) - inj[key] for key in search_keys]
+twoF = gridsearch.data["twoF"].reshape([len(kval) for kval in vals])
 corner_labels = [
     "$f - f_0$ [Hz]",
     "$\\dot{f} - \\dot{f}_0$ [Hz/s]",
@@ -290,11 +286,17 @@ print()
 print("Loading grid and MCMC search results for custom comparison plots...")
 gridfile = os.path.join(outdir, gridsearch.label + "_NA_GridSearch.txt")
 if not os.path.isfile(gridfile):
-    raise RuntimeError("Please first run PyFstat_example_simple_grid_search.py !")
+    raise RuntimeError(
+        "Failed to load GridSearch results from file '{:s}',"
+        " something must have gone wrong!".format(gridfile)
+    )
 grid_res = pyfstat.helper_functions.read_txt_file_with_header(gridfile)
 mcmc_file = os.path.join(outdir, mcmcsearch.label + "_samples.dat")
 if not os.path.isfile(mcmc_file):
-    raise RuntimeError("Please first run PyFstat_example_simple_mcmc_search.py !")
+    raise RuntimeError(
+        "Failed to load MCMCSearch results from file '{:s}',"
+        " something must have gone wrong!".format(mcmc_file)
+    )
 mcmc_res = pyfstat.helper_functions.read_txt_file_with_header(mcmc_file)
 
 zoom = {

--- a/examples/other_examples/PyFstat_example_injecting_into_noise_sfts.py
+++ b/examples/other_examples/PyFstat_example_injecting_into_noise_sfts.py
@@ -52,8 +52,6 @@ coherent_search = pyfstat.ComputeFstat(
     maxCoverFreq=-0.5,
 )
 FS_1 = coherent_search.get_fullycoherent_twoF(
-    noise_and_signal_writer.tstart,
-    noise_and_signal_writer.tend,
     noise_and_signal_writer.F0,
     noise_and_signal_writer.F1,
     noise_and_signal_writer.F2,
@@ -115,8 +113,6 @@ coherent_search = pyfstat.ComputeFstat(
     maxCoverFreq=-0.5,
 )
 FS_2 = coherent_search.get_fullycoherent_twoF(
-    add_signal_writer.tstart,
-    add_signal_writer.tend,
     add_signal_writer.F0,
     add_signal_writer.F1,
     add_signal_writer.F2,

--- a/examples/transient_examples/PyFstat_example_short_transient_MCMC_search.py
+++ b/examples/transient_examples/PyFstat_example_short_transient_MCMC_search.py
@@ -59,7 +59,7 @@ theta_prior = {
 ntemps = 2
 log10beta_min = -1
 nwalkers = 100
-nsteps = [100, 100]
+nsteps = [200, 200]
 
 mcmc = pyfstat.MCMCTransientSearch(
     label="transient_search",

--- a/examples/transient_examples/PyFstat_example_short_transient_grid_search.py
+++ b/examples/transient_examples/PyFstat_example_short_transient_grid_search.py
@@ -45,13 +45,10 @@ search1 = pyfstat.GridSearch(
     Alphas=Alphas,
     Deltas=Deltas,
     tref=tref,
-    minStartTime=minStartTime,
-    maxStartTime=maxStartTime,
     BSGL=False,
 )
 search1.run()
 search1.print_max_twoF()
-search1.save_array_to_disk(search1.data)
 
 search1.plot_1D(xkey="F0", xlabel="freq [Hz]", ylabel="$2\\mathcal{F}$")
 
@@ -66,8 +63,6 @@ search2 = pyfstat.TransientGridSearch(
     Alphas=Alphas,
     Deltas=Deltas,
     tref=tref,
-    minStartTime=minStartTime,
-    maxStartTime=maxStartTime,
     transientWindowType="rect",
     t0Band=Tspan - 2 * Tsft,
     tauBand=Tspan,
@@ -77,6 +72,5 @@ search2 = pyfstat.TransientGridSearch(
 )
 search2.run()
 search2.print_max_twoF()
-search2.save_array_to_disk(search2.data)
 
 search2.plot_1D(xkey="F0", xlabel="freq [Hz]", ylabel="$2\\mathcal{F}$")

--- a/pyfstat/grid_based_searches.py
+++ b/pyfstat/grid_based_searches.py
@@ -336,14 +336,23 @@ class GridSearch(BaseSearchClass):
             self.data = data
             self.save_array_to_disk()
 
-    def get_savetxt_fmt(self):
-        fmt = helper_functions.get_doppler_params_output_format(self.output_keys)
-        fmt[self.detstat] = "%.9g"
-        return fmt
+    def get_savetxt_fmt_dict(self):
+        fmt_dict = helper_functions.get_doppler_params_output_format(self.output_keys)
+        fmt_dict[self.detstat] = "%.9g"
+        return fmt_dict
+
+    def get_savetxt_fmt_list(self):
+        """Returns a list of output format specifiers, ordered like the data.
+        This is required because the output of get_savetxt_fmt_dict()
+        will depend on the order in which those entries have been coded up.
+        """
+        fmt_dict = self.get_savetxt_fmt_dict()
+        fmt_list = [fmt_dict[key] for key in self.output_keys]
+        return fmt_list
 
     def _get_tolerance_from_savetxt_fmt(self):
         """ decide appropriate input grid comparison tolerance from fprintf formats """
-        fmt = self.get_savetxt_fmt()
+        fmt = self.get_savetxt_fmt_dict()
         rtol = {}
         atol = {}
         for key, f in fmt.items():
@@ -370,7 +379,7 @@ class GridSearch(BaseSearchClass):
         logging.info("Saving data to {}".format(self.out_file))
         header = "\n".join(self.output_file_header)
         header += "\n" + " ".join(self.output_keys)
-        outfmt = list(self.get_savetxt_fmt().values())
+        outfmt = self.get_savetxt_fmt_list()
         Ncols = len(self.data.dtype)
         if len(outfmt) != Ncols:
             raise RuntimeError(
@@ -379,7 +388,7 @@ class GridSearch(BaseSearchClass):
                 " do not match."
                 " If your search class uses different"
                 " keys than the base GridSearch class,"
-                " override the get_savetxt_fmt"
+                " override the get_savetxt_fmt_dict"
                 " method.".format(Ncols, len(outfmt))
             )
         np.savetxt(
@@ -841,12 +850,12 @@ class TransientGridSearch(GridSearch):
         f = self.tCWfilebase + fmt.format(*vals) + ".dat"
         return f
 
-    def get_savetxt_fmt(self):
-        fmt = helper_functions.get_doppler_params_output_format(self.output_keys)
-        fmt[self.detstat] = "%.9g"
-        fmt["t0"] = "%d"
-        fmt["tau"] = "%d"
-        return fmt
+    def get_savetxt_fmt_dict(self):
+        fmt_dict = helper_functions.get_doppler_params_output_format(self.output_keys)
+        fmt_dict[self.detstat] = "%.9g"
+        fmt_dict["t0"] = "%d"
+        fmt_dict["tau"] = "%d"
+        return fmt_dict
 
     def write_F_mn(self, tCWfile, F_mn, windowRange):
         with open(tCWfile, "w") as tfp:
@@ -964,13 +973,13 @@ class GridGlitchSearch(GridSearch):
         self.set_out_file()
         self.output_file_header = self.get_output_file_header()
 
-    def get_savetxt_fmt(self):
-        fmt = helper_functions.get_doppler_params_output_format(self.output_keys)
-        fmt["delta_F0"] = "%.16g"
-        fmt["delta_F1"] = "%.16g"
-        fmt["tglitch"] = "%d"
-        fmt[self.detstat] = "%.9g"
-        return fmt
+    def get_savetxt_fmt_dict(self):
+        fmt_dict = helper_functions.get_doppler_params_output_format(self.output_keys)
+        fmt_dict["delta_F0"] = "%.16g"
+        fmt_dict["delta_F1"] = "%.16g"
+        fmt_dict["tglitch"] = "%d"
+        fmt_dict[self.detstat] = "%.9g"
+        return fmt_dict
 
 
 class SlidingWindow(DefunctClass):

--- a/pyfstat/grid_based_searches.py
+++ b/pyfstat/grid_based_searches.py
@@ -119,7 +119,7 @@ class GridSearch(BaseSearchClass):
         else:
             return None
 
-    def inititate_search_object(self):
+    def _initiate_search_object(self):
         logging.info("Setting up search object")
         search_ranges = self._get_search_ranges()
         if self.nsegs == 1:
@@ -304,7 +304,7 @@ class GridSearch(BaseSearchClass):
                 return
 
         if hasattr(self, "search") is False:
-            self.inititate_search_object()
+            self._initiate_search_object()
 
         data = []
         logging.info(
@@ -717,7 +717,7 @@ class TransientGridSearch(GridSearch):
                 " results to {}*.dat".format(self.tCWfilebase)
             )
 
-    def inititate_search_object(self):
+    def _initiate_search_object(self):
         logging.info("Setting up search object")
         search_ranges = self._get_search_ranges()
         self.search = ComputeFstat(
@@ -756,7 +756,7 @@ class TransientGridSearch(GridSearch):
             return
 
         if hasattr(self, "search") is False:
-            self.inititate_search_object()
+            self._initiate_search_object()
 
         data = []
         self.timingFstatMap = 0.0
@@ -975,7 +975,6 @@ class FrequencySlidingWindow(DefunctClass):
 
 class EarthTest(DefunctClass):
     last_supported_version = "1.9.0"
-
 
 class DMoff_NO_SPIN(DefunctClass):
     last_supported_version = "1.9.0"

--- a/pyfstat/helper_functions.py
+++ b/pyfstat/helper_functions.py
@@ -464,7 +464,6 @@ def get_version_string():
 def get_doppler_params_output_format(keys):
     # use same format for writing out search parameters
     # as write_FstatCandidate_to_fp() function of lalapps_CFSv2
-    fmt = []
     CFSv2_fmt = "%.16g"
     doppler_keys = [
         "F0",
@@ -478,14 +477,11 @@ def get_doppler_params_output_format(keys):
         "tp",
         "argp",
     ]
-
-    for k in keys:
-        if k in doppler_keys:
-            fmt += [CFSv2_fmt]
+    fmt = {k: CFSv2_fmt for k in keys if k in doppler_keys}
     return fmt
 
 
-def read_txt_file_with_header(f, comments="#"):
+def read_txt_file_with_header(f, names=True, comments="#"):
     # wrapper to np.genfromtxt with smarter header handling
     with open(f, "r") as f_opened:
         Nhead = 0
@@ -493,8 +489,9 @@ def read_txt_file_with_header(f, comments="#"):
             if not line.startswith(comments):
                 break
             Nhead += 1
-    data = np.genfromtxt(f, skip_header=Nhead - 1, names=True, comments=comments)
-
+    data = np.atleast_1d(
+        np.genfromtxt(f, skip_header=Nhead - 1, names=names, comments=comments)
+    )
     return data
 
 

--- a/tests.py
+++ b/tests.py
@@ -663,8 +663,6 @@ class TestComputeFstat(BaseForTestsWithData):
             maxCoverFreq=self.F0 + 0.1,
         )
         FS = search.get_fullycoherent_twoF(
-            tstart=self.tstart,
-            tend=self.tstart + self.duration,
             F0=self.F0,
             F1=self.F1,
             F2=self.F2,
@@ -683,13 +681,11 @@ class TestComputeFstat(BaseForTestsWithData):
             search_ranges=self.search_ranges,
         )
         twoF = search.get_fullycoherent_twoF(
-            self.Writer.tstart,
-            self.Writer.tend(),
-            self.Writer.F0,
-            self.Writer.F1,
-            self.Writer.F2,
-            self.Writer.Alpha,
-            self.Writer.Delta,
+            F0=self.Writer.F0,
+            F1=self.Writer.F1,
+            F2=self.Writer.F2,
+            Alpha=self.Writer.Alpha,
+            Delta=self.Writer.Delta,
         )
         diff = np.abs(twoF - twoF_predicted) / twoF_predicted
         print(
@@ -713,13 +709,11 @@ class TestComputeFstat(BaseForTestsWithData):
             search_ranges=self.search_ranges,
         )
         twoF2 = search.get_fullycoherent_twoF(
-            self.Writer.tstart,
-            self.Writer.tend(),
-            self.Writer.F0,
-            self.Writer.F1,
-            self.Writer.F2,
-            self.Writer.Alpha,
-            self.Writer.Delta,
+            F0=self.Writer.F0,
+            F1=self.Writer.F1,
+            F2=self.Writer.F2,
+            Alpha=self.Writer.Alpha,
+            Delta=self.Writer.Delta,
         )
         diff = np.abs(twoF2 - twoF_predicted) / twoF_predicted
         print(
@@ -749,13 +743,11 @@ class TestComputeFstat(BaseForTestsWithData):
             detectors=self.Writer.detectors,
         )
         FS_from_file = search.get_fullycoherent_twoF(
-            self.Writer.tstart,
-            self.Writer.tend(),
-            self.Writer.F0,
-            self.Writer.F1,
-            self.Writer.F2,
-            self.Writer.Alpha,
-            self.Writer.Delta,
+            F0=self.Writer.F0,
+            F1=self.Writer.F1,
+            F2=self.Writer.F2,
+            Alpha=self.Writer.Alpha,
+            Delta=self.Writer.Delta,
         )
         self.assertTrue(np.abs(predicted_FS - FS_from_file) / FS_from_file < 0.3)
 
@@ -775,13 +767,11 @@ class TestComputeFstat(BaseForTestsWithData):
             detectors=self.Writer.detectors,
         )
         FS_from_dict = search.get_fullycoherent_twoF(
-            self.Writer.tstart,
-            self.Writer.tend(),
-            self.Writer.F0,
-            self.Writer.F1,
-            self.Writer.F2,
-            self.Writer.Alpha,
-            self.Writer.Delta,
+            F0=self.Writer.F0,
+            F1=self.Writer.F1,
+            F2=self.Writer.F2,
+            Alpha=self.Writer.Alpha,
+            Delta=self.Writer.Delta,
         )
         self.assertTrue(FS_from_dict == FS_from_file)
 
@@ -798,8 +788,6 @@ class TestComputeFstat(BaseForTestsWithData):
             BSGL=True,
         )
         lnBSGL = search_H1L1.get_fullycoherent_twoF(
-            tstart=self.tstart,
-            tend=self.tstart + self.duration,
             F0=self.F0,
             F1=self.F1,
             F2=self.F2,
@@ -829,8 +817,6 @@ class TestComputeFstat(BaseForTestsWithData):
             BSGL=True,
         )
         lnBSGL = search_H1L1.get_fullycoherent_twoF(
-            tstart=self.tstart,
-            tend=self.tstart + self.duration,
             F0=self.F0,
             F1=self.F1,
             F2=self.F2,
@@ -861,13 +847,13 @@ class TestComputeFstat(BaseForTestsWithData):
             num_segments=Nsft + 1,
         )
         twoF = search.get_fullycoherent_twoF(
-            self.Writer.tstart,
-            self.Writer.tstart + taus[-1],
-            self.Writer.F0,
-            self.Writer.F1,
-            self.Writer.F2,
-            self.Writer.Alpha,
-            self.Writer.Delta,
+            F0=self.Writer.F0,
+            F1=self.Writer.F1,
+            F2=self.Writer.F2,
+            Alpha=self.Writer.Alpha,
+            Delta=self.Writer.Delta,
+            tstart=self.Writer.tstart,
+            tend=self.Writer.tstart + taus[-1],
         )
         reldiff = np.abs(twoF_cumulative[-1] - twoF) / twoF
         print(
@@ -911,13 +897,11 @@ class TestComputeFstatNoNoise(BaseForTestsWithData):
             search_ranges=self.search_ranges,
         )
         FS = search.get_fullycoherent_twoF(
-            self.Writer.tstart,
-            self.Writer.tend(),
-            self.Writer.F0,
-            self.Writer.F1,
-            self.Writer.F2,
-            self.Writer.Alpha,
-            self.Writer.Delta,
+            F0=self.Writer.F0,
+            F1=self.Writer.F1,
+            F2=self.Writer.F2,
+            Alpha=self.Writer.Alpha,
+            Delta=self.Writer.Delta,
         )
         self.assertTrue(np.abs(predicted_FS - FS) / FS < 0.3)
 
@@ -941,13 +925,11 @@ class TestComputeFstatNoNoise(BaseForTestsWithData):
             search_ranges=self.search_ranges,
         )
         FS = search.get_fullycoherent_twoF(
-            self.Writer.tstart,
-            self.Writer.tend(),
-            self.Writer.F0,
-            self.Writer.F1,
-            self.Writer.F2,
-            self.Writer.Alpha,
-            self.Writer.Delta,
+            F0=self.Writer.F0,
+            F1=self.Writer.F1,
+            F2=self.Writer.F2,
+            Alpha=self.Writer.Alpha,
+            Delta=self.Writer.Delta,
         )
         self.assertTrue(np.abs(predicted_FS - FS) / FS < 0.3)
 
@@ -1571,9 +1553,7 @@ class TestGridSearch(BaseForTestsWithData):
         search.run()
         self.assertTrue(os.path.isfile(search.out_file))
         max2F_point = search.get_max_twoF()
-        self.assertTrue(
-            np.all(max2F_point["twoF"] >= search.data[:, search.keys.index("twoF")])
-        )
+        self.assertTrue(np.all(max2F_point["twoF"] >= search.data["twoF"]))
 
     def test_grid_search_against_CFSv2(self):
         search = pyfstat.GridSearch(
@@ -1690,9 +1670,7 @@ class TestTransientGridSearch(BaseForTestsWithData):
         search.run()
         self.assertTrue(os.path.isfile(search.out_file))
         max2F_point = search.get_max_twoF()
-        self.assertTrue(
-            np.all(max2F_point["twoF"] >= search.data[:, search.keys.index("twoF")])
-        )
+        self.assertTrue(np.all(max2F_point["twoF"] >= search.data["twoF"]))
         tCWfile = search.get_transient_fstat_map_filename(max2F_point)
         tCW_out = pyfstat.helper_functions.read_txt_file_with_header(
             tCWfile, comments="#"

--- a/tests.py
+++ b/tests.py
@@ -1693,16 +1693,7 @@ class TestTransientGridSearch(BaseForTestsWithData):
         self.assertTrue(
             np.all(max2F_point["twoF"] >= search.data[:, search.keys.index("twoF")])
         )
-        tCWfile = (
-            search.tCWfilebase
-            + "{:.16f}_{:.16f}_{:.16f}_{:.16g}_{:.16g}.dat".format(
-                max2F_point["F0"],
-                max2F_point["Alpha"],
-                max2F_point["Delta"],
-                max2F_point["F1"],
-                max2F_point["F2"],
-            )
-        )
+        tCWfile = search.get_transient_fstat_map_filename(max2F_point)
         tCW_out = pyfstat.helper_functions.read_txt_file_with_header(
             tCWfile, comments="#"
         )


### PR DESCRIPTION
This is another case where fixing something small ballooned into reworking a core feature, because working around it was just too messy.

The main change is to make `tstart` and `tend` optional arguments in the core function `get_fullycoherent_twoF()`, falling back to `self.minStartTime` and `self.maxStartTime` if they're `None`, which is sufficient for the basic CW classes `GridSearch` and `MCMCSearch` and only needs to be overridden point-by-point for some of the transient and glitch classes.

- requires lots of tracking changes in grid and mcmc searches
- change grid searches to use named-column ndarrays internally to avoid fragile numeric indexing
- partially clean up keys storage in MCMC searches
- change helper_functions.get_doppler_params_output_format() to return dict
- amend tests and examples
~- WIP: SlidingWindow and FrequencySlidingWindow broken for now~
- closes #167