### PR TITLE
MCMC plots: properly rescale injection parameters

### DIFF
--- a/examples/followup_examples/PyFstat_example_semi_coherent_directed_follow_up.py
+++ b/examples/followup_examples/PyFstat_example_semi_coherent_directed_follow_up.py
@@ -79,18 +79,22 @@ mcmc = pyfstat.MCMCFollowUpSearch(
 
 NstarMax = 1000
 Nsegs0 = 100
-fig, axes = plt.subplots(nrows=2, figsize=(3.4, 3.5))
+walkers_fig, walkers_axes = plt.subplots(nrows=2, figsize=(3.4, 3.5))
 mcmc.run(
     NstarMax=NstarMax,
     Nsegs0=Nsegs0,
+    plot_walkers=True,
     walker_plot_args={
         "labelpad": 0.01,
         "plot_det_stat": False,
-        "fig": fig,
-        "axes": axes,
+        "fig": walkers_fig,
+        "axes": walkers_axes,
+        "injection_parameters": signal_parameters,
     },
 )
+walkers_fig.savefig(os.path.join(outdir, label + "_walkers.png"))
+plt.close(walkers_fig)
 
-mcmc.plot_corner(add_prior=True)
-mcmc.plot_prior_posterior()
 mcmc.print_summary()
+mcmc.plot_corner(add_prior=True, truths=signal_parameters)
+mcmc.plot_prior_posterior(injection_parameters=signal_parameters)

--- a/examples/mcmc_examples/PyFstat_example_MCMC_search_using_initialisation.py
+++ b/examples/mcmc_examples/PyFstat_example_MCMC_search_using_initialisation.py
@@ -77,7 +77,9 @@ mcmc = pyfstat.MCMCSearch(
     log10beta_min=log10beta_min,
 )
 mcmc.setup_initialisation(100, scatter_val=1e-10)
-mcmc.run()
-mcmc.plot_corner(add_prior=True)
-mcmc.plot_prior_posterior()
+mcmc.run(
+    walker_plot_args={"plot_det_stat": True, "injection_parameters": signal_parameters}
+)
 mcmc.print_summary()
+mcmc.plot_corner(add_prior=True, truths=signal_parameters)
+mcmc.plot_prior_posterior(injection_parameters=signal_parameters)

--- a/examples/mcmc_examples/PyFstat_example_fully_coherent_MCMC_search.py
+++ b/examples/mcmc_examples/PyFstat_example_fully_coherent_MCMC_search.py
@@ -82,7 +82,9 @@ mcmc.transform_dictionary = dict(
         subtractor=signal_parameters["F1"], symbol="$\\dot{f}-\\dot{f}^\\mathrm{s}$"
     ),
 )
-mcmc.run()
-mcmc.plot_corner(add_prior=True)
-mcmc.plot_prior_posterior()
+mcmc.run(
+    walker_plot_args={"plot_det_stat": True, "injection_parameters": signal_parameters}
+)
 mcmc.print_summary()
+mcmc.plot_corner(add_prior=True, truths=signal_parameters)
+mcmc.plot_prior_posterior(injection_parameters=signal_parameters)

--- a/examples/mcmc_examples/PyFstat_example_semi_coherent_MCMC_search.py
+++ b/examples/mcmc_examples/PyFstat_example_semi_coherent_MCMC_search.py
@@ -83,7 +83,9 @@ mcmc.transform_dictionary = dict(
         subtractor=signal_parameters["F1"], symbol="$\\dot{f}-\\dot{f}^\\mathrm{s}$"
     ),
 )
-mcmc.run()
-mcmc.plot_corner(add_prior=True)
-mcmc.plot_prior_posterior()
+mcmc.run(
+    walker_plot_args={"plot_det_stat": True, "injection_parameters": signal_parameters}
+)
 mcmc.print_summary()
+mcmc.plot_corner(add_prior=True, truths=signal_parameters)
+mcmc.plot_prior_posterior(injection_parameters=signal_parameters)

--- a/examples/transient_examples/PyFstat_example_long_transient_MCMC_search.py
+++ b/examples/transient_examples/PyFstat_example_long_transient_MCMC_search.py
@@ -12,17 +12,19 @@ if not os.path.isdir(outdir) or not np.any(
         "Please first run PyFstat_example_make_data_for_long_transient_search.py !"
     )
 
-F0 = 30.0
-F1 = -1e-10
-F2 = 0
-Alpha = 0.5
-Delta = 1
-
-minStartTime = 1000000000
+tstart = 1000000000
 duration = 200 * 86400
-maxStartTime = minStartTime + duration
-Tspan = maxStartTime - minStartTime
-tref = minStartTime
+
+inj = {
+    "tref": tstart,
+    "F0": 30.0,
+    "F1": -1e-10,
+    "F2": 0,
+    "Alpha": 0.5,
+    "Delta": 1,
+    "transient_tstart": tstart + 0.25 * duration,
+    "transient_duration": 0.5 * duration,
+}
 
 DeltaF0 = 6e-7
 DeltaF1 = 1e-13
@@ -30,16 +32,24 @@ DeltaF1 = 1e-13
 # to make the search cheaper, we exactly target the transientStartTime
 # to the injected value and only search over TransientTau
 theta_prior = {
-    "F0": {"type": "unif", "lower": F0 - DeltaF0 / 2.0, "upper": F0 + DeltaF0 / 2.0},
-    "F1": {"type": "unif", "lower": F1 - DeltaF1 / 2.0, "upper": F1 + DeltaF1 / 2.0},
-    "F2": F2,
-    "Alpha": Alpha,
-    "Delta": Delta,
-    "transient_tstart": minStartTime + 0.25 * duration,
+    "F0": {
+        "type": "unif",
+        "lower": inj["F0"] - DeltaF0 / 2.0,
+        "upper": inj["F0"] + DeltaF0 / 2.0,
+    },
+    "F1": {
+        "type": "unif",
+        "lower": inj["F1"] - DeltaF1 / 2.0,
+        "upper": inj["F1"] + DeltaF1 / 2.0,
+    },
+    "F2": inj["F2"],
+    "Alpha": inj["Alpha"],
+    "Delta": inj["Delta"],
+    "transient_tstart": tstart + 0.25 * duration,
     "transient_duration": {
         "type": "halfnorm",
-        "loc": 0.001 * Tspan,
-        "scale": 0.5 * Tspan,
+        "loc": 0.001 * duration,
+        "scale": 0.5 * duration,
     },
 }
 
@@ -53,16 +63,14 @@ mcmc = pyfstat.MCMCTransientSearch(
     outdir=outdir,
     sftfilepattern=os.path.join(outdir, "*simulated_transient_signal*sft"),
     theta_prior=theta_prior,
-    tref=tref,
-    minStartTime=minStartTime,
-    maxStartTime=maxStartTime,
+    tref=inj["tref"],
     nsteps=nsteps,
     nwalkers=nwalkers,
     ntemps=ntemps,
     log10beta_min=log10beta_min,
     transientWindowType="rect",
 )
-mcmc.run()
-mcmc.plot_corner(add_prior=True)
-mcmc.plot_prior_posterior()
+mcmc.run(walker_plot_args={"plot_det_stat": True, "injection_parameters": inj})
 mcmc.print_summary()
+mcmc.plot_corner(add_prior=True, truths=inj)
+mcmc.plot_prior_posterior(injection_parameters=inj)

--- a/examples/transient_examples/PyFstat_example_short_transient_MCMC_search.py
+++ b/examples/transient_examples/PyFstat_example_short_transient_MCMC_search.py
@@ -12,37 +12,47 @@ if not os.path.isdir(outdir) or not np.any(
         "Please first run PyFstat_example_make_data_for_short_transient_search.py !"
     )
 
-F0 = 30.0
-F1 = -1e-10
-F2 = 0
-Alpha = 0.5
-Delta = 1
-
-minStartTime = 1000000000
-maxStartTime = minStartTime + 2 * 86400
-Tspan = maxStartTime - minStartTime
-tref = minStartTime
-
+tstart = 1000000000
+duration = 2 * 86400
 Tsft = 1800
+
+inj = {
+    "tref": tstart,
+    "F0": 30.0,
+    "F1": -1e-10,
+    "F2": 0,
+    "Alpha": 0.5,
+    "Delta": 1,
+    "transient_tstart": tstart + 0.25 * duration,
+    "transient_duration": 0.5 * duration,
+}
 
 DeltaF0 = 1e-2
 DeltaF1 = 1e-9
 
 theta_prior = {
-    "F0": {"type": "unif", "lower": F0 - DeltaF0 / 2.0, "upper": F0 + DeltaF0 / 2.0},
-    "F1": {"type": "unif", "lower": F1 - DeltaF1 / 2.0, "upper": F1 + DeltaF1 / 2.0},
-    "F2": F2,
-    "Alpha": Alpha,
-    "Delta": Delta,
+    "F0": {
+        "type": "unif",
+        "lower": inj["F0"] - DeltaF0 / 2.0,
+        "upper": inj["F0"] + DeltaF0 / 2.0,
+    },
+    "F1": {
+        "type": "unif",
+        "lower": inj["F1"] - DeltaF1 / 2.0,
+        "upper": inj["F1"] + DeltaF1 / 2.0,
+    },
+    "F2": inj["F2"],
+    "Alpha": inj["Alpha"],
+    "Delta": inj["Delta"],
     "transient_tstart": {
         "type": "unif",
-        "lower": minStartTime,
-        "upper": maxStartTime - 2 * Tsft,
+        "lower": tstart,
+        "upper": tstart + duration - 2 * Tsft,
     },
     "transient_duration": {
         "type": "unif",
         "lower": 2 * Tsft,
-        "upper": Tspan - 2 * Tsft,
+        "upper": duration - 2 * Tsft,
     },
 }
 
@@ -56,18 +66,14 @@ mcmc = pyfstat.MCMCTransientSearch(
     outdir=outdir,
     sftfilepattern=os.path.join(outdir, "*simulated_transient_signal*sft"),
     theta_prior=theta_prior,
-    tref=tref,
-    minStartTime=minStartTime,
-    maxStartTime=maxStartTime,
+    tref=inj["tref"],
     nsteps=nsteps,
     nwalkers=nwalkers,
     ntemps=ntemps,
     log10beta_min=log10beta_min,
     transientWindowType="rect",
-    # minCoverFreq=-0.04,
-    # maxCoverFreq=-0.04,
 )
-mcmc.run()
-mcmc.plot_corner(add_prior=True)
-mcmc.plot_prior_posterior()
+mcmc.run(walker_plot_args={"plot_det_stat": True, "injection_parameters": inj})
 mcmc.print_summary()
+mcmc.plot_corner(add_prior=True, truths=inj)
+mcmc.plot_prior_posterior(injection_parameters=inj)

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -1352,10 +1352,18 @@ class MCMCSearch(BaseSearchClass):
         labelpad=5,
     ):
         """ Plot all the chains from a sampler """
-        if injection_parameters is not None and not isinstance(
-            injection_parameters, dict
-        ):
-            raise ValueError("injection_parameters is not a dictionary")
+        if injection_parameters is not None:
+            if not isinstance(injection_parameters, dict):
+                raise ValueError("injection_parameters is not a dictionary")
+            else:
+                scaled_injection_parameters = {
+                    key: (
+                        injection_parameters[key]
+                        - self._get_rescale_subtractor_for_key(key)
+                    )
+                    * self._get_rescale_multiplier_for_key(key)
+                    for key in injection_parameters.keys()
+                }
 
         if symbols is None:
             symbols = self._get_labels()
@@ -1428,7 +1436,7 @@ class MCMCSearch(BaseSearchClass):
                     )
                     if injection_parameters is not None:
                         axes[i].axhline(
-                            injection_parameters[self.theta_keys[i]],
+                            scaled_injection_parameters[self.theta_keys[i]],
                             ls="--",
                             lw=2.0,
                             color="orange",
@@ -1452,7 +1460,7 @@ class MCMCSearch(BaseSearchClass):
                 )
                 if injection_parameters is not None:
                     axes[0].axhline(
-                        injection_parameters[self.theta_keys[0]],
+                        scaled_injection_parameters[self.theta_keys[0]],
                         ls="--",
                         lw=5.0,
                         color="orange",


### PR DESCRIPTION
Let's use this as a starting point to fix #166. So far only amends one example to expose the issue in the walker plot:

![PyFstat_example_fully_coherent_MCMC_search_walkers](https://user-images.githubusercontent.com/28396587/93223344-412baa80-f770-11ea-9877-6ecd79cfc9d5.png)

Not actually sure right now if corner plots are also affected, this one looks fine but I'd need to double-check other examples without my messy cahnges from #171.