### PR TITLE
fix logging of Writer.make_cff()

### DIFF
--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -386,15 +386,11 @@ class Writer(BaseSearchClass):
         content = self.get_single_config_line(0)
 
         if verbose:
-            logging.info(
-                "Writing the following injection parameters"
-                " to config file {:s}:".format(self.config_file_name)
-            )
-            logging.info(content)
-        else:
-            logging.info("Writing config file {:s}...".format(self.config_file_name))
+            logging.info("Injection parameters:")
+            logging.info(content.rstrip("\n"))
 
         if self.check_if_cff_file_needs_rewriting(content):
+            logging.info("Writing config file: {:s}".format(self.config_file_name))
             config_file = open(self.config_file_name, "w+")
             config_file.write(content)
             config_file.close()
@@ -937,13 +933,11 @@ transientTau = {:10.0f}\n"""
             content += line
 
         if verbose:
-            logging.info(
-                "Writing the following injection parameters"
-                " to config file {:s}:".format(self.config_file_name)
-            )
-            logging.info(content)
+            logging.info("Injection parameters:")
+            logging.info(content.rstrip("\n"))
 
         if self.check_if_cff_file_needs_rewriting(content):
+            logging.info("Writing config file: {:s}".format(self.config_file_name))
             config_file = open(self.config_file_name, "w+")
             config_file.write(content)
             config_file.close()


### PR DESCRIPTION
 - only say "Writing" after check for whether to do it
 - and improve formatting

The output previously was confusing, like this:
```
16:17 INFO    : Writing the following injection parameters to config file TestData/test.cff:
16:17 INFO    : [TS0]
Alpha = 5.000000000000000104e-03
Delta = 1.199999999999999956e+00
h0 = 1.000000000000000000e+02
cosi = 0.000000000000000000e+00
psi = 0.000000000000000000e+00
transientWindowType = none
refTime = 700000000.000000000
Freq = 3.000000000000000000e+01
f1dot = -1.000000000000000036e-10
f2dot = 0.000000000000000000e+00
phi0 = 0.000000000000000000e+00

16:17 INFO    : Checking if we can re-use injection config file...
16:17 INFO    : ...no config file TestData/test.cff found.
```