### PR TITLE
GridSearch.check_old_data_is_okay_to_use(): add length check

### DIFF
--- a/pyfstat/grid_based_searches.py
+++ b/pyfstat/grid_based_searches.py
@@ -233,6 +233,19 @@ class GridSearch(BaseSearchClass):
         # need to convert any "None" entries in input_data array safely to 0s
         # to make np.allclose() work reliably
         new_data = np.nan_to_num(self.input_data.astype(np.float64))
+        if np.shape(old_data)[0] != np.shape(new_data)[1]:
+            # only testing number of points, not number of dimensions, here
+            # because output file can have detstat and post-proc quantities
+            # added and hence have different number of dimensions
+            # (this could in principle be cleverly predicted at this point)
+            logging.info(
+                "Old data found in '{:s}', input parameters grid differs"
+                " in length ({:d} points in file, {:d} points requested);"
+                " continuing with grid search.".format(
+                    self.out_file, np.shape(old_data)[0], np.shape(new_data)[1]
+                )
+            )
+            return False
         rtol, atol = self._get_tolerance_from_savetxt_fmt()
         column_matches = [
             np.allclose(


### PR DESCRIPTION
Another small fix for this function, for cases where differently-dimensioned input arrays are requested than what's stored in the rerefence file. That should normally already trip up the header consistency check, but not if internals have changed between runs.

 - avoid np.allclose() below complaining
 - only testing number of points, not number of dimensions, here
  because output file can have detstat and post-proc quantities
  added and hence have different number of dimensions
  (this could in principle be cleverly predicted at this point,
   but left for future work)