### PR TITLE
GridSearch.get_array_from_tuple(): change from np.arange() to np.linspace()

### DIFF
--- a/pyfstat/grid_based_searches.py
+++ b/pyfstat/grid_based_searches.py
@@ -167,9 +167,18 @@ class GridSearch(BaseSearchClass):
         if len(x) == 1:
             return np.array(x)
         elif len(x) == 3 and self.input_arrays is False:
-            return np.arange(x[0], x[1], x[2])
+            # This used to be
+            # return np.arange(x[0], x[1], x[2])
+            # but according to the numpy docs:
+            # "When using a non-integer step, such as 0.1,
+            # the results will often not be consistent.
+            # It is better to use numpy.linspace for these cases."
+            # and indeed it sometimes included the end point, sometimes didn't
+            return np.linspace(
+                x[0], x[1], num=int((x[1] - x[0]) / x[2]) + 1, endpoint=True
+            )
         else:
-            logging.info("Using tuple as is")
+            logging.info("Using tuple of length {:d} as is.".format(len(x)))
             return np.array(x)
 
     def get_input_data_array(self):

--- a/tests.py
+++ b/tests.py
@@ -1404,9 +1404,12 @@ class TestMCMCTransientSearch(BaseForMCMCSearchTests):
 
 class TestGridSearch(BaseForTestsWithData):
     label = "TestGridSearch"
-    F0s = [29, 31, 0.1]
+    # Need to hand-pick values F0s here for the CFSv2 comparison:
+    # that code sometimes includes endpoints, sometimes not.
+    # For the F0s here, it happens to match our convention (include endpoint).
+    F0s = [29.999, 30.001, 1e-4]
     F1s = [-1e-10, 0, 1e-11]
-    Band = 2.5
+    Band = 0.5
 
     def test_grid_search(self):
         search = pyfstat.GridSearch(


### PR DESCRIPTION
For further discussion. This is to be more consistent in handling endpoint inclusion in grid arrays, but doesn't really solve 1:1 comparisons with CFSv2.

 - previous `np.arange()` usage led to seemingly random inclusion or exclusion of the end point requested through the `[start,end,step]` format
 - following numpy docs recommendation for non-integer stepsizes:
> "When using a non-integer step, such as 0.1, the results will often not be consistent. It is better to use numpy.linspace for these cases."
 - now this should always consistently include end point
 - CFSv2 isn't a reliable target to match before or after, so change test case to a set of F0s that happens to match the new convention

@ReinhardPrix as a CFSv2 authority, I'm wondering if you have any opinion/advice on this?
My impression is that that code cannot be relied on for consistent grid points, e.g. at least on my machine (no idea if it may be machine-dependent) `--Freq 29.999 --FreqBand 0.002 --dFreq 1e-4` will include the endpoint (30.001), but `--Freq 29.99 --FreqBand 0.02 --dFreq 1e-3` will return 30.009 as the last point in its output file. I tried digging through the code a bit but with all the deeply nested functions for various fancier grid cases, it was hard to find the logic for those simple input arguments. I think my experience from years ago was also that +-1 bins were just something we arranged to live with...?
Either way, it seems best to me to have PyFstat have its own self-consistent convention, and just construct comparison cases carefully by hand where needed. Would you agree?

PS: Technically, the CFSv2 endpoint in the test case after this change is `30.00099999999999` not `30.001` but my test accepts that level of roundoff.