### PR TITLE
Fix cumulative twoF

### DIFF
--- a/examples/glitch_examples/PyFstat_example_glitch_robust_directed_MCMC_search_on_1_glitch.py
+++ b/examples/glitch_examples/PyFstat_example_glitch_robust_directed_MCMC_search_on_1_glitch.py
@@ -77,6 +77,8 @@ mcmc.transform_dictionary["tglitch"][
 t1 = time.time()
 mcmc.run(save_loudest=False)  # uses CFSv2 which doesn't support glitch parameters
 dT = time.time() - t1
+mcmc.print_summary()
+
 fig_and_axes = gridcorner._get_fig_and_axes(4, 2, 0.05)
 mcmc.plot_corner(
     label_offset=0.25,
@@ -87,7 +89,7 @@ mcmc.plot_corner(
     truth_color="C3",
 )
 
-mcmc.print_summary()
+mcmc.plot_cumulative_max()
 
 print(("Prior widths =", F0_width, F1_width))
 print(("Actual run time = {}".format(dT)))

--- a/examples/glitch_examples/PyFstat_example_standard_directed_MCMC_search_on_1_glitch.py
+++ b/examples/glitch_examples/PyFstat_example_standard_directed_MCMC_search_on_1_glitch.py
@@ -52,6 +52,6 @@ mcmc.transform_dictionary["F1"] = dict(
 )
 
 mcmc.run()
+mcmc.print_summary()
 mcmc.plot_corner()
 mcmc.plot_cumulative_max()
-mcmc.print_summary()

--- a/examples/glitch_examples/PyFstat_example_standard_directed_MCMC_search_on_1_glitch.py
+++ b/examples/glitch_examples/PyFstat_example_standard_directed_MCMC_search_on_1_glitch.py
@@ -53,4 +53,5 @@ mcmc.transform_dictionary["F1"] = dict(
 
 mcmc.run()
 mcmc.plot_corner()
+mcmc.plot_cumulative_max()
 mcmc.print_summary()

--- a/examples/mcmc_examples/PyFstat_example_semi_coherent_MCMC_search.py
+++ b/examples/mcmc_examples/PyFstat_example_semi_coherent_MCMC_search.py
@@ -91,5 +91,6 @@ mcmc.plot_corner(add_prior=True, truths=signal_parameters)
 mcmc.plot_prior_posterior(injection_parameters=signal_parameters)
 mcmc.plot_chainconsumer(truth=signal_parameters)
 mcmc.plot_cumulative_max(
-        savefig=True, custom_ax_kwargs={"title": "Cumulative 2F for the best MCMC candidate"},
+    savefig=True,
+    custom_ax_kwargs={"title": "Cumulative 2F for the best MCMC candidate"},
 )

--- a/examples/mcmc_examples/PyFstat_example_semi_coherent_MCMC_search.py
+++ b/examples/mcmc_examples/PyFstat_example_semi_coherent_MCMC_search.py
@@ -90,3 +90,6 @@ mcmc.print_summary()
 mcmc.plot_corner(add_prior=True, truths=signal_parameters)
 mcmc.plot_prior_posterior(injection_parameters=signal_parameters)
 mcmc.plot_chainconsumer(truth=signal_parameters)
+mcmc.plot_cumulative_max(
+    plt_label="MCMC Example", title="Cumulative 2F for the best MCMC candidate"
+)

--- a/examples/mcmc_examples/PyFstat_example_semi_coherent_MCMC_search.py
+++ b/examples/mcmc_examples/PyFstat_example_semi_coherent_MCMC_search.py
@@ -91,5 +91,7 @@ mcmc.plot_corner(add_prior=True, truths=signal_parameters)
 mcmc.plot_prior_posterior(injection_parameters=signal_parameters)
 mcmc.plot_chainconsumer(truth=signal_parameters)
 mcmc.plot_cumulative_max(
-    plt_label="MCMC Example", title="Cumulative 2F for the best MCMC candidate"
+    plot_label="MCMC Example",
+    # title="Cumulative 2F for the best MCMC candidate",
+    custom_axis_kwargs={"title": "Cumulative 2F for the best MCMC candidate"},
 )

--- a/examples/mcmc_examples/PyFstat_example_semi_coherent_MCMC_search.py
+++ b/examples/mcmc_examples/PyFstat_example_semi_coherent_MCMC_search.py
@@ -91,7 +91,5 @@ mcmc.plot_corner(add_prior=True, truths=signal_parameters)
 mcmc.plot_prior_posterior(injection_parameters=signal_parameters)
 mcmc.plot_chainconsumer(truth=signal_parameters)
 mcmc.plot_cumulative_max(
-    plot_label="MCMC Example",
-    # title="Cumulative 2F for the best MCMC candidate",
-    custom_axis_kwargs={"title": "Cumulative 2F for the best MCMC candidate"},
+        savefig=True, custom_ax_kwargs={"title": "Cumulative 2F for the best MCMC candidate"},
 )

--- a/examples/other_examples/PyFstat_example_twoF_cumulative.py
+++ b/examples/other_examples/PyFstat_example_twoF_cumulative.py
@@ -26,9 +26,14 @@ signal_parameters = {
     "tref": gw_data["tstart"],
     "cosi": 1,
     "h0": gw_data["sqrtSX"] / depth,
+    "asini": 10,
+    "period": 10 * 3600 * 24,
+    "tp": gw_data["tstart"] + gw_data["duration"] / 2.0,
+    "ecc": 0,
+    "argp": 0,
 }
 
-data = pyfstat.Writer(
+data = pyfstat.BinaryModulatedWriter(
     label=label,
     outdir=outdir,
     **gw_data,

--- a/examples/other_examples/PyFstat_example_twoF_cumulative.py
+++ b/examples/other_examples/PyFstat_example_twoF_cumulative.py
@@ -43,12 +43,14 @@ print("Predicted twoF value: {}\n".format(twoF))
 ifo_constraints = ["L1", "H1", None]
 compute_fstat_per_ifo = [
     pyfstat.ComputeFstat(
-        sftfilepattern=data.sftfilepath,
+        sftfilepattern=os.path.join(
+            data.outdir,
+            (f"{ifo_constraint[0]}*.sft" if ifo_constraint is not None else "*.sft"),
+        ),
         tref=signal_parameters["tref"],
         binary=signal_parameters.get("asini", 0),
         minCoverFreq=-0.5,
         maxCoverFreq=-0.5,
-        detectors=ifo_constraint,
     )
     for ifo_constraint in ifo_constraints
 ]

--- a/examples/other_examples/PyFstat_example_twoF_cumulative.py
+++ b/examples/other_examples/PyFstat_example_twoF_cumulative.py
@@ -81,8 +81,10 @@ for ind, compute_f_stat in enumerate(compute_fstat_per_ifo):
         label=label + (f"_{ifo_constraints[ind]}" if ind < 2 else "_H1L1"),
         outdir=outdir,
         signal_parameters=predict_f_stat_params,
-        custom_axis_kwargs={"title": "How does 2F accumulate over time?"},
-        plot_label="Cumulative 2F"
-        + (f" {ifo_constraints[ind]}" if ind < 2 else " H1 + L1"),
+        custom_ax_kwargs={
+            "title": "How does 2F accumulate over time?",
+            "label": "Cumulative 2F"
+            + (f" {ifo_constraints[ind]}" if ind < 2 else " H1 + L1"),
+        },
         **cumulative_f_stat_params,
     )

--- a/examples/other_examples/PyFstat_example_twoF_cumulative.py
+++ b/examples/other_examples/PyFstat_example_twoF_cumulative.py
@@ -76,13 +76,13 @@ predict_f_stat_params = {
 }
 
 for ind, compute_f_stat in enumerate(compute_fstat_per_ifo):
-    taus, twoF = compute_f_stat.calculate_twoF_cumulative(**cumulative_f_stat_params)
+    # taus, twoF = compute_f_stat.calculate_twoF_cumulative(**cumulative_f_stat_params)
     compute_f_stat.plot_twoF_cumulative(
-        **cumulative_f_stat_params,
         label=label + (f"_{ifo_constraints[ind]}" if ind < 2 else "_H1L1"),
         outdir=outdir,
-        injection_parameters=predict_f_stat_params,
+        signal_parameters=predict_f_stat_params,
+        custom_axis_kwargs={"title": "How does 2F accumulate over time?"},
         plot_label="Cumulative 2F"
         + (f" {ifo_constraints[ind]}" if ind < 2 else " H1 + L1"),
-        custom_axis_kwargs={"title": "This is a custom title"},
+        **cumulative_f_stat_params,
     )

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -1079,8 +1079,7 @@ class ComputeFstat(BaseSearchClass):
         outdir,
         signal_parameters=None,
         predict_fstat_segments=15,
-        custom_axis_kwargs=None,
-        plot_label=None,
+        custom_ax_kwargs=None,
         savefig=True,
         **calculate_twoF_cumulative_kwargs,
     ):
@@ -1099,7 +1098,7 @@ class ComputeFstat(BaseSearchClass):
             see _calculate_predict_fstat_cumulative() for details.
         predict_fstat_segments : int
             Number of points to use for PredictFStat.
-        custom_axis_kwargs : dict
+        custom_ax_kwargs : dict
             Optional axis formatting options.
         plot_label : str
             Legend label for the cumulative 2F values computed from data.
@@ -1124,6 +1123,15 @@ class ComputeFstat(BaseSearchClass):
         taus_days = taus / 86400.0
 
         tstart = calculate_twoF_cumulative_kwargs.get("tstart", self.minStartTime)
+
+        plot_label = custom_ax_kwargs.pop(
+            "label",
+            (
+                f"Cumulative 2F {taus.shape[0]:d} segments"
+                f" ({(taus_days[1] - taus_days[0]):.2g} days per segment)"
+            ),
+        )
+
         axis_kwargs = {
             "xlabel": r"Days from $t_{{\rm start}}={:.0f}$".format(tstart),
             "ylabel": r"$\log_{10}(\mathrm{BSGL})_{\rm cumulative}$"
@@ -1131,19 +1139,14 @@ class ComputeFstat(BaseSearchClass):
             else r"$\widetilde{2\mathcal{F}}_{\rm cumulative}$",
             "xlim": (0, taus_days[-1]),
         }
-        if custom_axis_kwargs is not None:
+        if custom_ax_kwargs is not None:
             for kwarg in "xlabel", "ylabel":
-                if kwarg in custom_axis_kwargs:
+                if kwarg in custom_ax_kwargs:
                     logging.warning(
                         f"Be careful, overwriting {kwarg} {axis_kwargs[kwarg]}"
-                        " with {custom_axis_kwargs[kwarg]}: Check out the units!"
+                        " with {custom_ax_kwargs[kwarg]}: Check out the units!"
                     )
-            axis_kwargs.update(custom_axis_kwargs or {})
-
-        plot_label = plot_label or (
-            f"Cumulative 2F {taus.shape[0]:d} segments"
-            f" ({(taus_days[1] - taus_days[0]):.2g} days per segment)"
-        )
+            axis_kwargs.update(custom_ax_kwargs or {})
 
         fig, ax = plt.subplots()
         ax.grid()

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -1058,7 +1058,7 @@ class ComputeFstat(BaseSearchClass):
         """Calculate expected 2F, with uncertainty, over subsets of the observation span.
 
         This yields the expected behaviour that calculate_twoF_cumulative() can
-        be compared again: 2F for CW signals increases with duration
+        be compared against: 2F for CW signals increases with duration
         as we take longer and longer subsets of the total observation span.
 
         Parameters

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -955,7 +955,7 @@ class ComputeFstat(BaseSearchClass):
         argp=None,
         tstart=None,
         tend=None,
-        cumulative_fstat_segments=1000,
+        num_segments=1000,
     ):
         """Calculate the cumulative twoF over subsets of the observation span.
 
@@ -974,14 +974,14 @@ class ComputeFstat(BaseSearchClass):
             GPS times to restrict the range of data used;
             if None: falls back to self.minStartTime and self.maxStartTime;
             if outside those: auto-truncated
-        cumulative_fstat_segments: int
+        num_segments: int
             Number of segments to split [tstart,tend] into
 
         Returns
         -------
-        taus : ndarray of shape (cumulative_fstat_segments,)
+        taus : ndarray of shape (num_segments,)
             Offsets of each segment's tend from the overall tstart.
-        twoFs : ndarray of shape (cumulative_fstat_segments,)
+        twoFs : ndarray of shape (num_segments,)
             Values of twoF computed over [[tstart,tstart+tau] for tau in taus].
 
         """
@@ -989,7 +989,7 @@ class ComputeFstat(BaseSearchClass):
         tend = min(tend, self.maxStartTime) if tend else self.maxStartTime
         min_tau = 2 * self.Tsft
         max_tau = tend - tstart
-        taus = np.linspace(min_tau, max_tau, cumulative_fstat_segments)
+        taus = np.linspace(min_tau, max_tau, num_segments)
         twoFs = []
 
         if not self.transientWindowType:

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -1045,7 +1045,7 @@ class ComputeFstat(BaseSearchClass):
         out = [
             helper_functions.predict_fstat(
                 minStartTime=self.minStartTime,
-                maxStartTime=t,
+                duration=t - self.minStartTime,
                 sftfilepattern=self.sftfilepattern,
                 IFO=IFO,
                 **pfs_input,

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -1040,7 +1040,7 @@ class ComputeFstat(BaseSearchClass):
             for duration in cumulative_durations
         ]
 
-        return cumulative_durations, np.array(twoFs)
+        return tstart, cumulative_durations, np.array(twoFs)
 
     def predict_twoF_cumulative(
         self,
@@ -1103,7 +1103,7 @@ class ComputeFstat(BaseSearchClass):
             for duration in cumulative_durations
         ]
         pfs, pfs_sigma = np.array(out).T
-        return cumulative_durations, pfs, pfs_sigma
+        return tstart, cumulative_durations, pfs, pfs_sigma
 
     def plot_twoF_cumulative(
         self,

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -1125,8 +1125,11 @@ class ComputeFstat(BaseSearchClass):
         ----------
         CFS_input: dict
             self.calculate_twoF_cumulative input arguments.
+            (besides [tstart, tend, num_segments]).
         PFS_input: dict
-            self.predict_twoF_cumulative input arguments.
+            self.predict_twoF_cumulative input arguments
+            (besides [tstart, tend, num_segments]).
+            if None: do not calculate predicted 2F
         tstart, tend: int or None
             GPS times to restrict the range of data used;
             if None: falls back to self.minStartTime and self.maxStartTime;
@@ -1136,8 +1139,7 @@ class ComputeFstat(BaseSearchClass):
         custom_ax_kwargs : dict
             Optional axis formatting options.
         savefig : bool
-            If true, save the figure in outdir and return taus, twoFs.
-            If false, return axes object.
+            If true, save the figure in outdir.
         label: str
             Output filename (ignored unless savefig is True).
         outdir: str
@@ -1158,7 +1160,7 @@ class ComputeFstat(BaseSearchClass):
         )
         taus_CFS_days = taus_CFS / 86400.0
 
-        # Set up plot-realted objects
+        # Set up plot-related objects
         axis_kwargs = {
             "xlabel": f"Days from $t_\\mathrm{{start}}={actual_tstart_CFS:.0f}$",
             "ylabel": "$\\log_{10}(\\mathrm{BSGL})_{\\mathrm{cumulative}$"

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -1160,10 +1160,10 @@ class ComputeFstat(BaseSearchClass):
 
         # Set up plot-realted objects
         axis_kwargs = {
-            "xlabel": r"Days from $t_{{\rm start}}={:.0f}$".format(actual_tstart_CFS),
-            "ylabel": r"$\log_{10}(\mathrm{BSGL})_{\rm cumulative}$"
+            "xlabel": f"Days from $t_\\mathrm{{start}}={actual_tstart_CFS:.0f}$",
+            "ylabel": "$\\log_{10}(\\mathrm{BSGL})_{\\mathrm{cumulative}$"
             if self.BSGL
-            else r"$\widetilde{2\mathcal{F}}_{\rm cumulative}$",
+            else "$\\widetilde{2\\mathcal{F}}_{\\mathrm{cumulative}}$",
             "xlim": (0, taus_CFS_days[-1]),
         }
         plot_label = (
@@ -1208,7 +1208,7 @@ class ComputeFstat(BaseSearchClass):
                 pfs + pfs_sigma,
                 color="cyan",
                 label=(
-                    r"Predicted $\langle 2\mathcal{F} " r"\rangle\pm $ 1-$\sigma$ band"
+                    "Predicted $\\langle 2\\mathcal{F} \\rangle \\pm 1\\sigma$ band"
                 ),
                 zorder=-10,
                 alpha=0.2,

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -1013,8 +1013,10 @@ class ComputeFstat(BaseSearchClass):
             [[tstart,tstart+duration] for duration in cumulative_durations].
 
         """
+
+        reset_old_window = None
         if not self.transientWindowType:
-            # FIXME: Can we move this elsewhere?
+            reset_old_window = self.transientWindowType
             self.transientWindowType = "rect"
             self.init_computefstatistic()
 
@@ -1039,6 +1041,10 @@ class ComputeFstat(BaseSearchClass):
             )
             for duration in cumulative_durations
         ]
+
+        if reset_old_window is not None:
+            self.transientWindowType = reset_old_window
+            self.init_computefstatistic()
 
         return tstart, cumulative_durations, np.array(twoFs)
 

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -941,6 +941,33 @@ class ComputeFstat(BaseSearchClass):
 
         return log10_BSGL / np.log10(np.exp(1))
 
+    def _set_up_cumulative_times(self, tstart, tend, num_segments):
+        """Construct time arrays to be used in cumulative twoF computations.
+
+        This allows calculate_twoF_cumulative and predict_twoF_cumulative to use
+        the same convention (although the number of segments on use is generally
+        different due to the computing time required by predict_twoF_cumulative).
+
+        First segment is hardcoded to spann 2 * self.Tsft. Last segment embraces
+        the whole data stream.
+
+        Parameters
+        ----------
+        tstart, tend: int or None
+            GPS times to restrict the range of data used;
+            if None: falls back to self.minStartTime and self.maxStartTime;
+            if outside those: auto-truncated
+        num_segments: int
+            Number of segments to split [tstart,tend] into
+        """
+        tstart = max(tstart, self.minStartTime) if tstart else self.minStartTime
+        tend = min(tend, self.maxStartTime) if tend else self.maxStartTime
+        min_duration = 2 * self.Tsft
+        max_duration = tend - tstart
+        cumulative_durations = np.linspace(min_duration, max_duration, num_segments)
+
+        return tstart, tend, cumulative_durations
+
     def calculate_twoF_cumulative(
         self,
         F0,

--- a/pyfstat/helper_functions.py
+++ b/pyfstat/helper_functions.py
@@ -713,6 +713,29 @@ def get_dictionary_from_lines(lines, comments, raise_error):
                 pass
     return d
 
+def get_predict_fstat_parameters_from_dict(signal_parameters,  return_lal_keys=False):
+    """
+    Given a dictionary with arbitrary signal parameters,
+    return only those ones required by helper_functions.predict_fstat
+    (Freq, Alpha, Delta, h0, cosi, psi)
+
+    Parameters
+    ----------
+    signal_parameters: dict
+        Dictionary containing at least the signal parameters required by 
+        helper_functions.predict_fstat. This dictionary's keys must follow 
+        the PyFstat convention (F0 instead of Freq).
+    return_lal_keys: bool
+        If True, the returned dictionary will contain keys according to the
+        lal convention (Freq instead of F0).
+    """
+    predict_fstat_params = {
+            key: signal_parameters[key] for key in ["F0", "Alpha", "Delta", "h0", "cosi", "psi"]
+            }
+    if return_lal_keys:
+        # FIXME Use the actual function to do this
+        predict_fstat_params["Freq"] = predict_fstat_params["F0"]
+    return predict_fstat_params
 
 def predict_fstat(
     h0=None,

--- a/pyfstat/helper_functions.py
+++ b/pyfstat/helper_functions.py
@@ -713,7 +713,8 @@ def get_dictionary_from_lines(lines, comments, raise_error):
                 pass
     return d
 
-def get_predict_fstat_parameters_from_dict(signal_parameters,  return_lal_keys=False):
+
+def get_predict_fstat_parameters_from_dict(signal_parameters, return_lal_keys=False):
     """
     Given a dictionary with arbitrary signal parameters,
     return only those ones required by helper_functions.predict_fstat
@@ -722,20 +723,22 @@ def get_predict_fstat_parameters_from_dict(signal_parameters,  return_lal_keys=F
     Parameters
     ----------
     signal_parameters: dict
-        Dictionary containing at least the signal parameters required by 
-        helper_functions.predict_fstat. This dictionary's keys must follow 
+        Dictionary containing at least the signal parameters required by
+        helper_functions.predict_fstat. This dictionary's keys must follow
         the PyFstat convention (F0 instead of Freq).
     return_lal_keys: bool
         If True, the returned dictionary will contain keys according to the
         lal convention (Freq instead of F0).
     """
     predict_fstat_params = {
-            key: signal_parameters[key] for key in ["F0", "Alpha", "Delta", "h0", "cosi", "psi"]
-            }
+        key: signal_parameters[key]
+        for key in ["F0", "Alpha", "Delta", "h0", "cosi", "psi"]
+    }
     if return_lal_keys:
         # FIXME Use the actual function to do this
         predict_fstat_params["Freq"] = predict_fstat_params["F0"]
     return predict_fstat_params
+
 
 def predict_fstat(
     h0=None,

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -1218,9 +1218,9 @@ class MCMCSearch(BaseSearchClass):
             return fig, axes
 
     def plot_cumulative_max(self, **kwargs):
-        """Plot the cumulative twoF for the maximum posterior estimate
+        """Plot the cumulative twoF for the maximum posterior estimate.
 
-        See the pyfstat.core.plot_twoF_cumulative function for further details
+        See the pyfstat.core.plot_twoF_cumulative function for further details.
         """
         logging.info("Getting cumulative 2F")
         d, maxtwoF = self.get_max_twoF()
@@ -1233,6 +1233,10 @@ class MCMCSearch(BaseSearchClass):
 
         if hasattr(self, "search") is False:
             self._initiate_search_object()
+        # Predicted 2F values will be calculated for the parameter space point
+        # in the ".loudest" file generated above,
+        # while the parameters that are explicitly passed here are for the
+        # cumulative 2F calculation on the actual data.
         if self.binary is False:
             self.search.plot_twoF_cumulative(
                 self.label,

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -1228,9 +1228,6 @@ class MCMCSearch(BaseSearchClass):
             if key not in d:
                 d[key] = val
 
-        if "add_pfs" in kwargs and not hasattr(self, "search"):
-            self.generate_loudest()
-
         if hasattr(self, "search") is False:
             self._initiate_search_object()
 

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -1234,7 +1234,7 @@ class MCMCSearch(BaseSearchClass):
         if hasattr(self, "search") is False:
             self._initiate_search_object()
 
-        self.search.plot_twoF_cumulative(self.label, self.outdir, **d, **kwargs)
+        self.search.plot_twoF_cumulative(CFS_input=d, label=self.label, outdir=self.outdir, **kwargs)
 
     def _generic_lnprior(self, **kwargs):
         """Return a lambda function of the pdf

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -1233,37 +1233,8 @@ class MCMCSearch(BaseSearchClass):
 
         if hasattr(self, "search") is False:
             self._initiate_search_object()
-        # Predicted 2F values will be calculated for the parameter space point
-        # in the ".loudest" file generated above,
-        # while the parameters that are explicitly passed here are for the
-        # cumulative 2F calculation on the actual data.
-        if self.binary is False:
-            self.search.plot_twoF_cumulative(
-                self.label,
-                self.outdir,
-                F0=d["F0"],
-                F1=d["F1"],
-                F2=d["F2"],
-                Alpha=d["Alpha"],
-                Delta=d["Delta"],
-                **kwargs,
-            )
-        else:
-            self.search.plot_twoF_cumulative(
-                self.label,
-                self.outdir,
-                F0=d["F0"],
-                F1=d["F1"],
-                F2=d["F2"],
-                Alpha=d["Alpha"],
-                Delta=d["Delta"],
-                asini=d["asini"],
-                period=d["period"],
-                ecc=d["ecc"],
-                argp=d["argp"],
-                tp=d["argp"],
-                **kwargs,
-            )
+
+        self.search.plot_twoF_cumulative(self.label, self.outdir, **d, **kwargs)
 
     def _generic_lnprior(self, **kwargs):
         """Return a lambda function of the pdf

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -2451,7 +2451,7 @@ class MCMCGlitchSearch(MCMCSearch):
             if j < self.theta0_idx:
                 summed_deltaF0 = np.sum(delta_F0s[j : self.theta0_idx])
                 F0_j = d["F0"] - summed_deltaF0
-                taus, twoFs = self.search.calculate_twoF_cumulative(
+                actual_ts, taus, twoFs = self.search.calculate_twoF_cumulative(
                     F0_j,
                     F1=d["F1"],
                     F2=d["F2"],
@@ -2464,7 +2464,7 @@ class MCMCGlitchSearch(MCMCSearch):
             elif j >= self.theta0_idx:
                 summed_deltaF0 = np.sum(delta_F0s[self.theta0_idx : j + 1])
                 F0_j = d["F0"] + summed_deltaF0
-                taus, twoFs = self.search.calculate_twoF_cumulative(
+                actual_ts, taus, twoFs = self.search.calculate_twoF_cumulative(
                     F0_j,
                     F1=d["F1"],
                     F2=d["F2"],
@@ -2473,7 +2473,7 @@ class MCMCGlitchSearch(MCMCSearch):
                     tstart=ts,
                     tend=te,
                 )
-            ax.plot(ts + taus, twoFs)
+            ax.plot(actual_ts + taus, twoFs)
 
         ax.set_xlabel("GPS time")
         fig.savefig(os.path.join(self.outdir, self.label + "_twoFcumulative.png"))

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -1246,8 +1246,6 @@ class MCMCSearch(BaseSearchClass):
                 F2=d["F2"],
                 Alpha=d["Alpha"],
                 Delta=d["Delta"],
-                tstart=self.minStartTime,
-                tend=self.maxStartTime,
                 **kwargs,
             )
         else:
@@ -1264,8 +1262,6 @@ class MCMCSearch(BaseSearchClass):
                 ecc=d["ecc"],
                 argp=d["argp"],
                 tp=d["argp"],
-                tstart=self.minStartTime,
-                tend=self.maxStartTime,
                 **kwargs,
             )
 

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -1234,7 +1234,9 @@ class MCMCSearch(BaseSearchClass):
         if hasattr(self, "search") is False:
             self._initiate_search_object()
 
-        self.search.plot_twoF_cumulative(CFS_input=d, label=self.label, outdir=self.outdir, **kwargs)
+        self.search.plot_twoF_cumulative(
+            CFS_input=d, label=self.label, outdir=self.outdir, **kwargs
+        )
 
     def _generic_lnprior(self, **kwargs):
         """Return a lambda function of the pdf

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -1220,7 +1220,20 @@ class MCMCSearch(BaseSearchClass):
     def plot_cumulative_max(self, **kwargs):
         """Plot the cumulative twoF for the maximum posterior estimate.
 
-        See the pyfstat.core.plot_twoF_cumulative function for further details.
+        This method accepts the same arguments as `pyfstat.core.ComputeFstat.plot_twoF_cumulative`,
+        except for `CFS_input`, which is taken from the loudest candidate; and `label` and `outdir`,
+        which are taken from the instance of this class.
+
+        For example, one can pass signal arguments to predic_twoF_cumulative through `PFS_kwargs`, or
+        set the number of segments using `num_segments_(CFS|PFS)`. The same applies for other options
+        such as `tstart`, `tend` or `savefig`. Every single of these arguments will be passed to
+        `pyfstat.core.ComputeFstat.plot_twoF_cumulative` as they are, using their default argument
+        otherwise.
+
+        Keep in mind that one has to explicitely set `savefig=True` to output the figure!
+
+        See `pyfstat.core.ComputeFstat.plot_twoF_cumulative` for a comprehensive list of accepted
+        arguments and their default values.
         """
         logging.info("Getting cumulative 2F")
         d, maxtwoF = self.get_max_twoF()

--- a/tests.py
+++ b/tests.py
@@ -752,7 +752,7 @@ class TestComputeFstat(BaseForTestsWithData):
 
     def test_cumulative_twoF(self):
         Nsft = 100
-        # FIXME: Do this in a consistent way using 
+        # FIXME: Do this in a consistent way using
         # BaseSearchClass's method
         lal_signal_params = default_signal_params.copy()
         lal_signal_params["phi0"] = lal_signal_params.pop("phi")

--- a/tests.py
+++ b/tests.py
@@ -762,7 +762,7 @@ class TestComputeFstat(BaseForTestsWithData):
             self.Writer.Alpha,
             self.Writer.Delta,
             tstart=self.Writer.tstart,
-            tend=self.Writer.tend(),
+            # tend=self.Writer.tend(),
         )
         twoF_cumulative = twoF_cumulative[-1]
 

--- a/tests.py
+++ b/tests.py
@@ -767,13 +767,13 @@ class TestComputeFstat(BaseForTestsWithData):
             minCoverFreq=self.F0 - 0.1,
             maxCoverFreq=self.F0 + 0.1,
         )
-        taus, twoF_cumulative = search.calculate_twoF_cumulative(
+        start_time, taus, twoF_cumulative = search.calculate_twoF_cumulative(
             self.Writer.F0,
             self.Writer.F1,
             self.Writer.F2,
             self.Writer.Alpha,
             self.Writer.Delta,
-            cumulative_fstat_segments=Nsft + 1,
+            num_segments=Nsft + 1,
         )
         twoF = search.get_fullycoherent_twoF(
             self.Writer.tstart,

--- a/tests.py
+++ b/tests.py
@@ -748,6 +748,44 @@ class TestComputeFstat(BaseForTestsWithData):
         )
         self.assertTrue(lnBSGL > 0)
 
+    def test_cumulative_twoF(self):
+
+        search = pyfstat.ComputeFstat(
+            tref=self.Writer.tref,
+            sftfilepattern=self.Writer.sftfilepath,
+            search_ranges=self.search_ranges,
+        )
+        taus, twoF_cumulative = search.calculate_twoF_cumulative(
+            self.Writer.F0,
+            self.Writer.F1,
+            self.Writer.F2,
+            self.Writer.Alpha,
+            self.Writer.Delta,
+            tstart=self.Writer.tstart,
+            tend=self.Writer.tend(),
+        )
+        twoF_cumulative = twoF_cumulative[-1]
+
+        twoF = search.get_fullycoherent_twoF(
+            self.Writer.tstart,
+            self.Writer.tstart + taus[-1],
+            self.Writer.F0,
+            self.Writer.F1,
+            self.Writer.F2,
+            self.Writer.Alpha,
+            self.Writer.Delta,
+        )
+
+        diff = np.abs(twoF_cumulative - twoF) / twoF
+        print(
+            (
+                "Computed twoF is {}"
+                " while recovered value using the cumulative method is {},"
+                " relative difference: {}".format(twoF, twoF_cumulative, diff)
+            )
+        )
+        self.assertTrue(diff < 0.01)
+
 
 class TestComputeFstatNoNoise(BaseForTestsWithData):
     # FIXME: should be possible to merge into TestComputeFstat with smart

--- a/tests.py
+++ b/tests.py
@@ -752,6 +752,10 @@ class TestComputeFstat(BaseForTestsWithData):
 
     def test_cumulative_twoF(self):
         Nsft = 100
+        # FIXME: Do this in a consistent way using 
+        # BaseSearchClass's method
+        lal_signal_params = default_signal_params.copy()
+        lal_signal_params["phi0"] = lal_signal_params.pop("phi")
         # not using any SFTs on disk
         search = pyfstat.ComputeFstat(
             tref=self.tref,
@@ -759,7 +763,7 @@ class TestComputeFstat(BaseForTestsWithData):
             maxStartTime=self.tstart + Nsft * self.Tsft,
             detectors=self.detectors,
             injectSqrtSX=self.sqrtSX,
-            injectSources=default_signal_params,
+            injectSources=lal_signal_params,
             minCoverFreq=self.F0 - 0.1,
             maxCoverFreq=self.F0 + 0.1,
         )

--- a/tests.py
+++ b/tests.py
@@ -38,7 +38,7 @@ default_signal_params = {
     "h0": 5,
     "cosi": 0,
     "psi": 0,
-    "phi0": 0,
+    "phi": 0,
     "Alpha": 5e-3,
     "Delta": 1.2,
 }
@@ -369,7 +369,7 @@ class TestBinaryModulatedWriter(TestWriter):
         theta_prior = {
             key: value
             for key, value in default_signal_params.items()
-            if key not in ["h0", "cosi"]
+            if key not in ["h0", "cosi", "psi", "phi"]
         }
         theta_prior.update({key: value for key, value in default_binary_params.items()})
         theta_prior["tp"] = {


### PR DESCRIPTION
Make #170 work again

- [x] Fix cumulative 2F computation.
- [x] Fix basic plotting options of `ComputeFStatistic`
- [x] Fix options dealing with PFS.
- [x] Fix options dealing with injection parameters.
- [x] Fix MCMC wrapper (it applies this function to the maximum candidate).
- [x] Check behaviour of PFS when using single IFO: Check #189 , as this only affects to PFS and not the actual cumulative 2F.

And I guess @dbkeitel would like
- [x] Add corresponding tests. Proposal: Compute `2F` using the coherent method and the cumulative method; the last value of the cumulative method should match that of the coherent method.

More issues to deal with:
- [x] ~Fix~ Remove single IFO support (~choose your preferred fix method amongst `dd` or a longer key combination :wink:~ which means you have to manually give the input SFT you want to compute your cumulative twoF on.)