### PR TITLE
fix plot_corner(truths) in glitch example

### DIFF
--- a/examples/glitch_examples/PyFstat_example_glitch_robust_directed_MCMC_search_on_1_glitch.py
+++ b/examples/glitch_examples/PyFstat_example_glitch_robust_directed_MCMC_search_on_1_glitch.py
@@ -80,7 +80,7 @@ dT = time.time() - t1
 fig_and_axes = gridcorner._get_fig_and_axes(4, 2, 0.05)
 mcmc.plot_corner(
     label_offset=0.25,
-    truths=[0, 0, 0, 0],
+    truths={"F0": F0, "F1": F1, "delta_F0": delta_F0, "tglitch": tstart + dtglitch},
     fig_and_axes=fig_and_axes,
     quantiles=(0.16, 0.84),
     hist_kwargs=dict(lw=1.5, zorder=-1),


### PR DESCRIPTION
Overly hacky manual choice exposed by #185.

Fixed version:

![semicoherent_glitch_robust_directed_MCMC_search_on_1_glitch_corner](https://user-images.githubusercontent.com/28396587/93782072-674ac200-fc2a-11ea-8f3f-3e20716e79bf.png)
