### PR TITLE
remove kwargs from helper_functions.predict_fstat()

### DIFF
--- a/pyfstat/helper_functions.py
+++ b/pyfstat/helper_functions.py
@@ -733,7 +733,6 @@ def predict_fstat(
     transientWindowType="none",
     transientStartTime=None,
     transientTau=None,
-    **kwargs
 ):
     """Wrapper to lalapps_PredictFstat
 


### PR DESCRIPTION
 - none are passed through to the commandline tool
 - which would be very fragile anyway
 - so all this enables is dangerous backwards fake-compatibility
   as exposed in #186