### PR TITLE
Setup dev environment

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,6 +16,14 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Linting with flake8
+      run: |
+        pip install flake8
+        flake8 --count --statistics .
+    - name: Style check with black
+      run: |
+        pip install black
+        black --check --diff .
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -29,14 +37,6 @@ jobs:
         wget $EPHEM_SRC/sun00-40-DE405.dat.gz -P $LALPULSAR_DATADIR
         echo "Successfully downloaded ephemerides:"
         ls -l $LALPULSAR_DATADIR
-    - name: Linting with flake8
-      run: |
-        pip install flake8
-        flake8 --count --statistics .
-    - name: Style check with black
-      run: |
-        pip install black
-        black --check --diff .
     - name: Test with pytest
       run: |
         pip install pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/ambv/black
+    rev: stable
+    hooks:
+      - id: black
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.3
+    hooks:
+    - id: flake8

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ and [citing](#citing-this-work) PyFstat.
 * We also have a number of
 [examples](https://github.com/PyFstat/PyFstat/tree/master/examples),
 demonstrating different use cases.
-* Developers or contributors are encouraged to have a look into
+* New contributors are encouraged to have a look into
 [how to set up a development environment](#contributing-to-pyfstat)
 
 
@@ -281,8 +281,8 @@ Here's what you need to know:
   `black --check --diff .` to show the required style changes, or `black .` to automatically apply them.
 * `bin/setup-dev-tools.sh` gets your virtual environment ready for you. After making sure you are 
 using a virtual environment, it install `pytest`, `black` and `flake8` and uses `pre-commit` to run
-the last two using a pre-commit hoook. In this way, you will be prompted by a warning whenver you 
-forget to run `black` or `flake8` befor commit :wink:.
+the last two using a pre-commit hook. In this way, you will be prompted a warning whenever you 
+forget to run `black` or `flake8` before doing your commit :wink:.
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -243,8 +243,8 @@ echo 'export LALPULSAR_DATADIR=$VIRTUAL_ENV/share/lalpulsar' >> ${VIRTUAL_ENV}/b
 deactivate
 source path/to/venv/bin/activate
 ```
-An executable version of this snippet is readily accessible by **sourcing** `bin/get_and_export_ephemeris.sh`. 
-Mind that this script does **not** include an export command anywhere, so you will have to source it every time
+An executable version of this snippet is readily accessible by **sourcing** `bin/get-and-export-ephemeris.sh`. 
+Mind that this script does **not** include an `export` command anywhere, so you will have to source it every time
 in order to properly set `LALPULSAR_DATADIR` variable.
 
 If instead you have built and installed lalsuite from source,
@@ -284,8 +284,8 @@ Here's what you need to know:
   `black --check --diff .` to show the required style changes, or `black .` to automatically apply them.
 * `bin/setup-dev-tools.sh` gets your virtual environment ready for you. After making sure you are 
 using a virtual environment (venv or conda),
-it installs `pytest`, `black` and `flake8` and uses `pre-commit` to run
-the last two using a pre-commit hook. In this way, you will be prompted a warning whenever you 
+it installs `black`, `flake8`, `pre-commit`, `pytest`, `wheel` via `pip` and uses `pre-commit` to run
+the `black` and `flake8` using a pre-commit hook. In this way, you will be prompted a warning whenever you
 forget to run `black` or `flake8` before doing your commit :wink:.
 
 ## Contributors

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ and [citing](#citing-this-work) PyFstat.
 * We also have a number of
 [examples](https://github.com/PyFstat/PyFstat/tree/master/examples),
 demonstrating different use cases.
+* Developers or contributors are encouraged to have a look into
+[how to set up a development environment](#contributing-to-pyfstat)
+
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3967045.svg)](https://doi.org/10.5281/zenodo.3967045)
 [![PyPI version](https://badge.fury.io/py/PyFstat.svg)](https://badge.fury.io/py/PyFstat)
@@ -261,18 +264,7 @@ Paths set in this way will take precedence over the environment variable.
 Finally, you can manually specify ephemerides files when initialising
 each PyFstat search (as one of the arguments).
 
-## Contributors
-
-Maintainers:
-* Greg Ashton
-* David Keitel
-
-Other contributors:
-* Reinhard Prix
-* Rodrigo Tenorio
-* Karl Wette
-* Sylvia Zhu
-
+## Contributing to PyFstat
 This project is open to development, please feel free to contact us
 for advice or just jump in and submit an
 [issue](https://github.com/PyFstat/PyFstat/issues/new/choose) or
@@ -287,6 +279,23 @@ Here's what you need to know:
   `flake8 --count --statistics .` to find common coding errors and then fix them manually,
   and then
   `black --check --diff .` to show the required style changes, or `black .` to automatically apply them.
+* `bin/setup-dev-tools.sh` gets your virtual environment ready for you. After making sure you are 
+using a virtual environment, it install `pytest`, `black` and `flake8` and uses `pre-commit` to run
+the last two using a pre-commit hoook. In this way, you will be prompted by a warning whenver you 
+forget to run `black` or `flake8` befor commit :wink:.
+
+## Contributors
+
+Maintainers:
+* Greg Ashton
+* David Keitel
+
+Other contributors:
+* Reinhard Prix
+* Rodrigo Tenorio
+* Karl Wette
+* Sylvia Zhu
+
 
 ## Citing this work
 

--- a/README.md
+++ b/README.md
@@ -283,7 +283,8 @@ Here's what you need to know:
   and then
   `black --check --diff .` to show the required style changes, or `black .` to automatically apply them.
 * `bin/setup-dev-tools.sh` gets your virtual environment ready for you. After making sure you are 
-using a virtual environment, it install `pytest`, `black` and `flake8` and uses `pre-commit` to run
+using a virtual environment (venv or conda),
+it installs `pytest`, `black` and `flake8` and uses `pre-commit` to run
 the last two using a pre-commit hook. In this way, you will be prompted a warning whenever you 
 forget to run `black` or `flake8` before doing your commit :wink:.
 

--- a/README.md
+++ b/README.md
@@ -243,6 +243,9 @@ echo 'export LALPULSAR_DATADIR=$VIRTUAL_ENV/share/lalpulsar' >> ${VIRTUAL_ENV}/b
 deactivate
 source path/to/venv/bin/activate
 ```
+An executable version of this snippet is readily accessible by **sourcing** `bin/get_and_export_ephemeris.sh`. 
+Mind that this script does **not** include an export command anywhere, so you will have to source it every time
+in order to properly set `LALPULSAR_DATADIR` variable.
 
 If instead you have built and installed lalsuite from source,
 and set your path up properly through something like

--- a/bin/check_if_virtual_environment.py
+++ b/bin/check_if_virtual_environment.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/bin/check_if_virtual_environment.py
+++ b/bin/check_if_virtual_environment.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+is_virtual_environment = sys.prefix != sys.base_prefix
+is_conda_environment = os.path.exists(os.path.join(sys.prefix, "conda-meta", "history"))
+
+if not (is_virtual_environment or is_conda_environment):
+    sys.exit(
+        "Sorry, you are not using neither a virtual environment"
+        " nor a conda environment; aborting operation."
+    )
+
+for name, state in [
+    ("Python virtual environment {}", is_virtual_environment),
+    ("Conda environment {}", is_conda_environment),
+]:
+    print(name.format("detected." if state else "not detected."))
+print(f"Executable: {sys.executable}")

--- a/bin/get-and-export-ephemeris.sh
+++ b/bin/get-and-export-ephemeris.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Get ephemeris files and export env variable to access them.
 # Output path is accepted as an input; otherwise, falls back
 # to ../.ephemeris.

--- a/bin/get-and-export-ephemeris.sh
+++ b/bin/get-and-export-ephemeris.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 # Get ephemeris files and export env variable to access them.
 # Output path is accepted as an input; otherwise, falls back
 # to ../.ephemeris.

--- a/bin/get_and_export_ephemeris.sh
+++ b/bin/get_and_export_ephemeris.sh
@@ -1,0 +1,20 @@
+# Get ephemeris files and export env variable to access them.
+# Output path is accepted as an input; otherwise, falls back
+# to ../.ephemeris.
+# This script does NOT alter any other bash script.
+
+if [ -z $1 ]
+then
+    this_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    out_dir=${this_dir}/../.ephemeris/
+    echo "No output path was given"
+    echo "Falling back to ${out_dir}"
+else
+    out_dir=$1
+    echo "Output path: ${out_dir}"
+fi
+
+mkdir -p out_dir
+wget -nc https://git.ligo.org/lscsoft/lalsuite/raw/master/lalpulsar/lib/earth00-40-DE405.dat.gz -P ${out_dir} 
+wget -nc https://git.ligo.org/lscsoft/lalsuite/raw/master/lalpulsar/lib/sun00-40-DE405.dat.gz -P ${out_dir}
+export LALPULSAR_DATADIR=${out_dir}

--- a/bin/get_and_export_ephemeris.sh
+++ b/bin/get_and_export_ephemeris.sh
@@ -14,7 +14,7 @@ else
     echo "Output path: ${out_dir}"
 fi
 
-mkdir -p out_dir
+mkdir -p ${out_dir}
 wget -nc https://git.ligo.org/lscsoft/lalsuite/raw/master/lalpulsar/lib/earth00-40-DE405.dat.gz -P ${out_dir} 
 wget -nc https://git.ligo.org/lscsoft/lalsuite/raw/master/lalpulsar/lib/sun00-40-DE405.dat.gz -P ${out_dir}
 export LALPULSAR_DATADIR=${out_dir}

--- a/bin/setup-dev-tools.sh
+++ b/bin/setup-dev-tools.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # This script is intended to set up a proper development
 # environment according to the PyFstat standad. 
 # As explained in the REAMDE, that includes:

--- a/bin/setup-dev-tools.sh
+++ b/bin/setup-dev-tools.sh
@@ -1,0 +1,18 @@
+# This script is intended to set up a proper development
+# environment according to the PyFstat standad. 
+# As explained in the REAMDE, that includes:
+# - Making sure you are running under a python virtual environment.
+# - Installing pytest to enable local testing.
+# - Configuring pre-commit hooks to enforce the use of black and flake8.
+
+# First of all, get this script's path
+this_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Check whether you are running inside a virtual environment (you'd better do so!)
+python ${this_dir}/check_if_virtual_environment.py
+
+# Install development tools
+pip install -r ${this_dir}/../requirements-dev.txt
+
+# Set up pre-commit hooks
+pre-commit install

--- a/bin/setup-dev-tools.sh
+++ b/bin/setup-dev-tools.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 # This script is intended to set up a proper development
 # environment according to the PyFstat standad. 
 # As explained in the REAMDE, that includes:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+black
+flake8
+pre-commit
+pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ black
 flake8
 pre-commit
 pytest
+wheel


### PR DESCRIPTION
Automates the set up of a development environment by just running a bash script.

The script:

- Makes sure one is developing inside a virtual environment.
- Installs `pytest`, `flake8`, `black` and `pre-commit`.
- Sets up pre-commit hooks to run `flake8` and `black`.

Optionally, we could add a script to authomatically download ephemeris (which will be only needed if installed from `pip`).

@dbkeitel Opinions?