### PR TITLE
Make tests faster

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -42,7 +42,7 @@ jobs:
         pip install pytest
         # make sure to test *installed* version of pyFstat
         pip install -e $GITHUB_WORKSPACE
-        (cd .. && pytest $GITHUB_WORKSPACE/tests.py --log-file=$GITHUB_WORKSPACE/tests.log)
+        (cd .. && pytest --durations=0 $GITHUB_WORKSPACE/tests.py --log-file=$GITHUB_WORKSPACE/tests.log)
     - name: Build package
       run: |
         pip install wheel check-wheel-contents

--- a/tests.py
+++ b/tests.py
@@ -1224,8 +1224,8 @@ class TestMCMCSearch(BaseForMCMCSearchTests):
                 theta_prior=thetas[prior_choice],
                 tref=self.tref,
                 sftfilepattern=self.Writer.sftfilepath,
-                nsteps=[100, 100],
-                nwalkers=100,
+                nsteps=[20, 20],
+                nwalkers=20,
                 ntemps=2,
                 log10beta_min=-1,
             )


### PR DESCRIPTION
Address #193 .

It won't go faster than this, as the rest of the time seems to be spent in set up commands. 
We should gain 30s and a `--durations=0` flag to keep an eye on what we do.