### PR TITLE
core.py/Add more sigmas to predict Fstat plot

### DIFF
--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -1209,18 +1209,18 @@ class ComputeFstat(BaseSearchClass):
                 "CFS and PFS starting time differs: This shouldn't be the case. "
                 "Did you change conventions?"
             )
-
-            ax.fill_between(
-                taus_PFS_days,
-                pfs - pfs_sigma,
-                pfs + pfs_sigma,
-                color="cyan",
-                label=(
-                    "Predicted $\\langle 2\\mathcal{F} \\rangle \\pm 1\\sigma$ band"
-                ),
-                zorder=-10,
-                alpha=0.2,
-            )
+            for i in range(1, 4):
+                ax.fill_between(
+                    taus_PFS_days,
+                    pfs - i * pfs_sigma,
+                    pfs + i * pfs_sigma,
+                    color="cyan",
+                    label=(
+                        f"Predicted $\\langle 2\\mathcal{{F}} \\rangle \\pm {i}\\sigma$ band"
+                    ),
+                    zorder=-10,
+                    alpha=2.0 / (1 + 2.0 * i),
+                )
 
         ax.legend(loc="best")
         if savefig:


### PR DESCRIPTION
Could it be the case that we are simply using `predict_fstat` in a very conservative way?
![PyFstat_example_twoF_cumulative_L1_twoFcumulative](https://user-images.githubusercontent.com/49152330/94715331-9d382680-034d-11eb-8907-a50a3da8bc2b.png)
![PyFstat_example_twoF_cumulative_H1_twoFcumulative](https://user-images.githubusercontent.com/49152330/94715363-a88b5200-034d-11eb-9ccd-7a9b18fb8a5a.png)
![PyFstat_example_twoF_cumulative_H1L1_twoFcumulative](https://user-images.githubusercontent.com/49152330/94715335-9e695380-034d-11eb-987b-61f43e84e5b4.png)

