### PR TITLE
improve sqrtSX handling

### DIFF
--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -286,12 +286,19 @@ class ComputeFstat(BaseSearchClass):
         injectSources : dict or str
             Either a dictionary of the values to inject, or a string pointing
             to the .cff file to inject
-        injectSqrtSX :
-            Per-IFO single-sided PSD values for generating fake Gaussian noise on the fly
-        assumeSqrtSX : float
-            Don't estimate noise-floors but assume (stationary) per-IFO
-            sqrt{SX} (if single value: use for all IFOs). If signal only,
-            set sqrtSX=1
+        injectSqrtSX : float or list or str
+            Single-sided PSD values for generating fake Gaussian noise on the fly.
+            Single float or str value: use same for all IFOs.
+            List or comma-separated string: must match len(detectors)
+            and/or the data in sftfilepattern.
+            Detectors will be paired to list elements following alphabetical order.
+        assumeSqrtSX : float or list or str
+            Don't estimate noise-floors but assume this (stationary) single-sided PSD.
+            Single float or str value: use same for all IFOs.
+            List or comma-separated string: must match len(detectors)
+            and/or the data in sftfilepattern.
+            Detectors will be paired to list elements following alphabetical order.
+            If working with signal-only data, please set assumeSqrtSX=1 .
         SSBprec : int
             Flag to set the SSB calculation: 0=Newtonian, 1=relativistic,
             2=relativisitic optimised, 3=DMoff, 4=NO_SPIN
@@ -466,7 +473,7 @@ class ComputeFstat(BaseSearchClass):
             FstatOAs.assumeSqrtSX = lalpulsar.FstatOptionalArgsDefaults.assumeSqrtSX
         else:
             mnf = lalpulsar.MultiNoiseFloor()
-            assumeSqrtSX = np.atleast_1d(self.assumeSqrtSX)
+            assumeSqrtSX = helper_functions.parse_list_of_numbers(self.assumeSqrtSX)
             mnf.sqrtSn[: len(assumeSqrtSX)] = assumeSqrtSX
             mnf.length = len(assumeSqrtSX)
             FstatOAs.assumeSqrtSX = mnf
@@ -511,7 +518,9 @@ class ComputeFstat(BaseSearchClass):
         else:
             FstatOAs.injectSources = lalpulsar.FstatOptionalArgsDefaults.injectSources
         if hasattr(self, "injectSqrtSX") and self.injectSqrtSX is not None:
-            self.injectSqrtSX = np.atleast_1d(self.injectSqrtSX)
+            self.injectSqrtSX = helper_functions.parse_list_of_numbers(
+                self.injectSqrtSX
+            )
             if len(self.injectSqrtSX) != len(self.detector_names):
                 raise ValueError(
                     "injectSqrtSX must be of same length as detector_names ({}!={})".format(

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -539,7 +539,9 @@ class Writer(BaseSearchClass):
                 "to produce noiseSFTs."
             )
         elif self.noiseSFTs is not None:
-            if self.sqrtSX and self.sqrtSX > 0.0:
+            if self.sqrtSX and np.any(
+                [s > 0 for s in helper_functions.parse_list_of_numbers(self.sqrtSX)]
+            ):
                 logging.warning(
                     "In addition to using noiseSFTs, you are adding "
                     "Gaussian noise with sqrtSX={} "

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -76,8 +76,9 @@ class MCMCSearch(BaseSearchClass):
     injectSources: dict, optional
         If given, inject these properties into the SFT files before running
         the search
-    assumeSqrtSX: float, optional
-        Don't estimate noise-floors, but assume (stationary) per-IFO sqrt{SX}
+    assumeSqrtSX: float or list or str
+        Don't estimate noise-floors, but assume (stationary) per-IFO sqrt{SX}.
+        See `core.ComputeFstat`.
     transientWindowType: str
         If 'rect' or 'exp',
         compute atoms so that a transient (t0,tau) map can later be computed.
@@ -2555,8 +2556,9 @@ class MCMCSemiCoherentSearch(MCMCSearch):
     injectSources: dict, optional
         If given, inject these properties into the SFT files before running
         the search
-    assumeSqrtSX: float, optional
-        Don't estimate noise-floors, but assume (stationary) per-IFO sqrt{SX}
+    assumeSqrtSX: float or list or str, optional
+        Don't estimate noise-floors, but assume (stationary) per-IFO sqrt{SX}.
+        See `core.ComputeFstat`.
     nsegs: int
         The number of segments
 


### PR DESCRIPTION
Several classes/functions take sqrtSX-type inputs which can be single values or per-IFO lists, and their type can in principle be either a float, list of floats, list of strings or comma-separated string. These are then variously passed to lalapps commandlines (requiring simple floats or strings), passed to swig-wrapped lal functions (requiring lists) or checked PyFstat-internally for being > or < 0 (currently failing if a list or string).

We could somehow curb this chaos at the highest-level user-facing input stage by only accepting one format, but here's a semi-elegant attempt to be robust in parsing this.

One uncovered failure mode is if the user input is a list and a command-line gets constructed from it with plain `format`, but at least the error message from lalapps should be clear in that case.