### PR TITLE
Fix expected SFT file names when duration is not multiple of Tsft

### DIFF
--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -154,16 +154,20 @@ class Writer(BaseSearchClass):
         self.duration = int(self.duration)
 
         IFOs = self.detectors.split(",")
-        numSFTs = len(IFOs) * [int(float(self.duration) / self.Tsft)]
+        # when duration is not a multiple of Tsft, to match MFDv5
+        # we need to round the number *up*
+        # and also include the overlapping bit at the end in the duration
+        numSFTs = int(np.ceil(float(self.duration) / self.Tsft))  # per IFO
+        effective_duration = numSFTs * self.Tsft
 
         self.sftfilenames = [
             lalpulsar.OfficialSFTFilename(
                 dets[0],
                 dets[1],
-                numSFTs[ind],
+                numSFTs,
                 self.Tsft,
                 self.tstart,
-                self.duration,
+                effective_duration,
                 self.label,
             )
             for ind, dets in enumerate(IFOs)

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -526,8 +526,8 @@ class Writer(BaseSearchClass):
         except OSError:
             pass
 
-        cl_mfd = []
-        cl_mfd.append("lalapps_Makefakedata_v5")
+        mfd = "lalapps_Makefakedata_v5"
+        cl_mfd = [mfd]
         cl_mfd.append("--outSingleSFT=TRUE")
         cl_mfd.append('--outSFTdir="{}"'.format(self.outdir))
         cl_mfd.append('--outLabel="{}"'.format(self.label))
@@ -584,7 +584,13 @@ class Writer(BaseSearchClass):
         check_ok = self.check_cached_data_okay_to_use(cl_mfd)
         if check_ok is False:
             helper_functions.run_commandline(cl_mfd)
-            logging.info("Successfully wrote SFTs to: {}".format(self.sftfilepath))
+            if os.path.isfile(self.sftfilepath):
+                logging.info(f"Successfully wrote SFTs to: {self.sftfilepath}")
+            else:
+                logging.warning(
+                    f"It seems we successfully ran {mfd},"
+                    f" but the expected path does not exist: {self.sftfilepath}."
+                )
 
     def predict_fstat(self, assumeSqrtSX=None):
         """ Wrapper to lalapps_PredictFstat """

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -589,12 +589,12 @@ class Writer(BaseSearchClass):
         check_ok = self.check_cached_data_okay_to_use(cl_mfd)
         if check_ok is False:
             helper_functions.run_commandline(cl_mfd)
-            if os.path.isfile(self.sftfilepath):
+            if np.all([os.path.isfile(f) for f in self.sftfilepath.split(";")]):
                 logging.info(f"Successfully wrote SFTs to: {self.sftfilepath}")
             else:
-                logging.warning(
+                raise RuntimeError(
                     f"It seems we successfully ran {mfd},"
-                    f" but the expected path does not exist: {self.sftfilepath}."
+                    f" but did not get the expected SFT file path(s): {self.sftfilepath}."
                 )
 
     def predict_fstat(self, assumeSqrtSX=None):

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -97,9 +97,10 @@ class Writer(BaseSearchClass):
             frequency evolution and amplitude parameters for injection
             if h0==None or h0==0, these are all ignored
             if h0>0, then Alpha, Delta, cosi need to be set explicitly
-        Tsft: float
-            the sft duration
-        noiseSFTs: str
+        Tsft: int
+            The SFT duration in seconds.
+            Will be ignored if noiseSFTs are given.
+        noiseSFTs: str or None
             SFT on top of which signals will be injected.
             If not None, additional constraints can be applied using the arguments
             tstart and duration.
@@ -227,13 +228,13 @@ class Writer(BaseSearchClass):
         # Get the "overall" values of the search
         Tsft = np.unique(Tsft)
         if len(Tsft) != 1:
-            raise ValueError("SFTs contain different basetimes: {}".format(Tsft))
-        elif Tsft[0] != self.Tsft:
-            raise ValueError(
-                "SFT basetime {} differs from input base time {}".format(
-                    Tsft[0], self.Tsft
-                )
+            raise ValueError(f"SFTs contain different basetimes: {Tsft}")
+        if Tsft[0] != self.Tsft:
+            logging.warning(
+                f"Overwriting self.Tsft={self.Tsft}"
+                f" with value {Tsft[0]} read from noiseSFTs."
             )
+        self.Tsft = Tsft[0]
         self.tstart = min(tstart)
         self.duration = max(tend) - self.tstart
         self.detectors = ",".join(IFOs)

--- a/tests.py
+++ b/tests.py
@@ -126,16 +126,17 @@ class TestWriter(BaseForTestsWithData):
 
     def test_run_makefakedata(self):
         self.Writer.make_data(verbose=True)
+        numSFTs = int(np.ceil(self.duration / self.Tsft))
         expected_outfile = os.path.join(
             self.Writer.outdir,
             "{:1s}-{:d}_{:2s}_{:d}SFT_{:s}-{:d}-{:d}.sft".format(
                 self.detectors[0],
-                int(self.duration / self.Tsft),
+                numSFTs,
                 self.detectors,
                 self.Tsft,
                 self.Writer.label,
                 self.Writer.tstart,
-                self.Writer.duration,
+                numSFTs * self.Tsft,
             ),
         )
         self.assertTrue(os.path.isfile(expected_outfile))
@@ -191,7 +192,7 @@ class TestWriter(BaseForTestsWithData):
         )
         max_values_noise_and_signal = np.max(data, axis=0)
         max_freqs_noise_and_signal = freqs[np.argmax(data, axis=0)]
-        self.assertTrue(len(times) == self.duration / self.Tsft)
+        self.assertTrue(len(times) == int(np.ceil(self.duration / self.Tsft)))
         # with signal: all SFTs should peak at same freq
         self.assertTrue(len(np.unique(max_freqs_noise_and_signal)) == 1)
 
@@ -352,6 +353,12 @@ class TestWriter(BaseForTestsWithData):
             ),
         )
         self.assertTrue(os.path.isfile(expected_SFT_filepath))
+
+
+class TestWriterOtherTsft(TestWriter):
+    label = "TestWriterOtherTsft"
+    writer_class_to_test = pyfstat.Writer
+    Tsft = 1024
 
 
 class TestBinaryModulatedWriter(TestWriter):


### PR DESCRIPTION
I think this is sufficient to fix #202. The alternative `_get_setup_from_noiseSFTs()` case should be fine already, since there we are just taking the SFT file names as we've been given them, but I haven't dug explicitly into it.

- [ ] TODO: check MFDv5 code/documentation to confirm we now actually _always_ match its behaviour, and I haven't left out weird corner cases.
- [x] TODO: add a test case