### PR TITLE
Implement injection parameter generator

### DIFF
--- a/pyfstat/__init__.py
+++ b/pyfstat/__init__.py
@@ -7,6 +7,7 @@ from .core import (
 )
 from .make_sfts import (
     InjectionParametersGenerator,
+    AllSkyInjectionParametersGenerator,
     Writer,
     BinaryModulatedWriter,
     GlitchWriter,

--- a/pyfstat/__init__.py
+++ b/pyfstat/__init__.py
@@ -6,6 +6,7 @@ from .core import (
     SemiCoherentGlitchSearch,
 )
 from .make_sfts import (
+    InjectionParametersGenerator,
     Writer,
     BinaryModulatedWriter,
     GlitchWriter,

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -44,9 +44,9 @@ class InjectionParametersGenerator:
         seed:
             `seed` argument to be feed to numpy.random.default_rng.
         """
-        self._rng = np.random.default_rng(seed)
-        if priors is not None:
-            self.priors = priors
+        self.seed = seed
+        self._rng = np.random.default_rng(self.seed)
+        self.priors = priors or {}
 
     @property
     def seed(self):

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -72,7 +72,7 @@ class InjectionParametersGenerator:
         return injection_parameters
 
     def __call__(self):
-        self.return_injection_parameters()
+        return self.return_injection_parameters()
 
 
 class Writer(BaseSearchClass):

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -40,45 +40,77 @@ class InjectionParametersGenerator:
             while each value must contain a dictionary with its key as one of the available random
             number generators of numpy and its values as kwargs.
         """
-        self.set_outdir(outdir)
-        self.set_label(label)
-        self.set_parameter_priors(parameter_priors)
+        self.outdir = outdir
+        self.label = label
+        self.parameter_priors = parameter_priors
 
         self._rng = np.random.default_rng()
 
         self.injection_parameters = None
 
-    def set_outdir(self, outdir):
-        """Create output folder"""
-        self.outdir = outdir + ("/" if outdir[-1] != "/" else "")
-        os.makedirs(outdir, exist_ok=True)
+    @property
+    def outdir(self):
+        return self._outdir
 
-    def set_label(self, label):
+    @property
+    def label(self):
+        return self._label
+
+    @property
+    def parameter_priors(self):
+        return self._parameter_priors
+
+    def check_out_files(self):
+        """
+        Check if output files already exist to prevent
+        accidental overwritting
+        """
+        pass
+
+    @outdir.setter
+    def outdir(self, new_outdir):
+        """Set output dir name.
+
+        Output dir(s) will not be created until needed.
+
+        Parameters
+        ----------
+        new_outdir: str
+            Output directory name. Trailing slash is irrelevant, as
+            os.path.join will be used to construct the actual filenames.
+        """
+        self._outdir = new_outdir
+
+    @label.setter
+    def label(self, new_label):
         """Set injection set's label
 
         A warning wil be raised if there exists a file in the same folder with
         the same name.
         """
-        self.label = label + ".mdfparameters"
+        self._label = new_label
         if os.path.isfile(self.outdir + self.label):
             raise FileExistsError(
                 "Injection file {} already exists in {}".format(self.label, self.outdir)
             )
 
-    def set_parameter_priors(self, parameter_priors):
-        """Check parameter_priors' format"""
-        for parameter in parameter_priors.keys():
-            if len(parameter_priors[parameter].keys()) != 1:
+    @parameter_priors.setter
+    def parameter_priors(self, new_parameter_priors):
+        """Set priors to drawn parameter space points from """
+
+        # Check parameter_priors' format
+        for parameter in new_parameter_priors.keys():
+            if len(new_parameter_priors[parameter].keys()) != 1:
                 raise ValueError(
                     "Some paramer ranges contain more than one"
                     "random number generator per parameter."
                     "Please, check your parameter ranges dict."
                 )
 
-        self.parameter_priors = parameter_priors
+        self._parameter_priors = new_parameter_priors
         logging.info(
             "Updating parameters: "
-            + " ".join(["{}".format(key) for key in parameter_priors.keys()])
+            + " ".join(["{}".format(key) for key in new_parameter_priors.keys()])
         )
 
     def generate_injection_parameters(self, number_of_injections):

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -38,8 +38,17 @@ class InjectionParametersGenerator:
         self.parameter_priors = parameter_priors
 
     @property
+    def seed(self):
+        return self._seed
+
+    @property
     def parameter_priors(self):
         return self._parameter_priors
+
+    @seed.setter
+    def seed(self, new_seed):
+        self._seed = new_seed
+        self._rng = np.random.default_rng(self._seed)
 
     @parameter_priors.setter
     def parameter_priors(self, new_parameter_priors):

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -105,13 +105,16 @@ class AllSkyInjectionParametersGenerator(InjectionParametersGenerator):
 
     def __init__(self, priors=None, seed=None):
 
-        self.restricted_priors_set = False
-        super().__init__(None, seed)
         self.restricted_priors = {
             "Alpha": lambda: self._rng.uniform(low=0.0, high=2 * np.pi),
             "Delta": lambda: 2 * np.arcsin(self._rng.uniform(low=-1.0, high=1.0)),
         }
-        InjectionParametersGenerator.priors.fset(self, self.restricted_priors)
+        self.restricted_priors_set = False
+
+        super().__init__(None, seed)
+        self.priors = (priors or {}).copy()
+        self.priors.update(self.restricted_priors)
+        self.restricted_priors_set = True
 
     def _check_if_updating_sky_priors(self, new_priors):
         if self.restricted_priors_set and any(

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -2,6 +2,7 @@
 
 
 import numpy as np
+import functools
 import logging
 import os
 import glob
@@ -52,7 +53,7 @@ class InjectionParametersGenerator:
 
     @parameter_priors.setter
     def parameter_priors(self, new_parameter_priors):
-        """Set priors to drawn parameter space points from """
+        """Set priors to draw parameter space points from """
 
         current_priors = getattr(self, "parameter_priors", {})
         for parameter_name, parameter_prior in new_parameter_priors.items():
@@ -63,7 +64,7 @@ class InjectionParametersGenerator:
                 rng_function = getattr(self._rng, rng_function_name)
                 rng_kwargs = parameter_prior[rng_function_name]
                 current_priors.update(
-                    {parameter_name: (lambda: rng_function(**rng_kwargs))}
+                    {parameter_name: functools.partial(rng_function, **rng_kwargs)}
                 )
 
         self._parameter_priors = current_priors
@@ -76,7 +77,7 @@ class InjectionParametersGenerator:
     def return_injection_parameters(self):
         injection_parameters = {
             parameter_name: parameter_prior()
-            for parameter_name, parameter_prior in self.parameter_priors.items()
+            for parameter_name, parameter_prior in self._parameter_priors.items()
         }
         return injection_parameters
 

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -75,7 +75,7 @@ class InjectionParametersGenerator:
     def draw(self):
         injection_parameters = {
             parameter_name: parameter_prior()
-            for parameter_name, parameter_prior in self._priors.items()
+            for parameter_name, parameter_prior in self.priors.items()
         }
         return injection_parameters
 

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -60,12 +60,16 @@ class InjectionParametersGenerator:
         for parameter_name, parameter_prior in new_parameter_priors.items():
             if callable(parameter_prior):
                 current_priors.update({parameter_name: parameter_prior})
-            else:
+            elif isinstance(parameter_prior, dict):
                 rng_function_name = next(iter(parameter_prior))
                 rng_function = getattr(self._rng, rng_function_name)
                 rng_kwargs = parameter_prior[rng_function_name]
                 current_priors.update(
                     {parameter_name: functools.partial(rng_function, **rng_kwargs)}
+                )
+            else:  # Assume it is something to be returned as is
+                current_priors.update(
+                    {parameter_name: functools.partial(lambda x: x, parameter_prior)}
                 )
 
         self._parameter_priors = current_priors

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -88,7 +88,7 @@ class InjectionParametersGenerator:
             + " ".join(["{}".format(key) for key in new_priors.keys()])
         )
 
-    def return_injection_parameters(self):
+    def draw(self):
         injection_parameters = {
             parameter_name: parameter_prior()
             for parameter_name, parameter_prior in self._priors.items()
@@ -96,7 +96,7 @@ class InjectionParametersGenerator:
         return injection_parameters
 
     def __call__(self):
-        return self.return_injection_parameters()
+        return self.draw()
 
 
 class AllSkyInjectionParametersGenerator(InjectionParametersGenerator):

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -103,7 +103,7 @@ class AllSkyInjectionParametersGenerator(InjectionParametersGenerator):
         self.restricted_priors = {
             # This is required because numpy has no arcsin distro
             "Alpha": lambda: self._rng.uniform(low=0.0, high=2 * np.pi),
-            "Delta": lambda: 2 * np.arcsin(self._rng.uniform(low=-1.0, high=1.0)),
+            "Delta": lambda: np.arcsin(self._rng.uniform(low=-1.0, high=1.0)),
         }
 
     def _check_if_updating_sky_priors(self, new_priors):

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -45,7 +45,7 @@ class InjectionParametersGenerator:
             `seed` argument to be feed to numpy.random.default_rng.
         """
         self.set_seed(seed)
-        self.priors = priors or {}
+        self.set_priors(priors or {})
 
     def set_seed(self, seed):
         self.seed = seed

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -68,17 +68,17 @@ class InjectionParametersGenerator:
         current_priors = getattr(self, "priors", {})
         for parameter_name, parameter_prior in new_priors.items():
             if callable(parameter_prior):
-                current_priors.update({parameter_name: parameter_prior})
+                current_priors[parameter_name] = parameter_prior
             elif isinstance(parameter_prior, dict):
                 rng_function_name = next(iter(parameter_prior))
                 rng_function = getattr(self._rng, rng_function_name)
                 rng_kwargs = parameter_prior[rng_function_name]
-                current_priors.update(
-                    {parameter_name: functools.partial(rng_function, **rng_kwargs)}
+                current_priors[parameter_name] = functools.partial(
+                    rng_function, **rng_kwargs
                 )
             else:  # Assume it is something to be returned as is
-                current_priors.update(
-                    {parameter_name: functools.partial(lambda x: x, parameter_prior)}
+                current_priors[parameter_name] = functools.partial(
+                    lambda x: x, parameter_prior
                 )
 
         self._priors = current_priors

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -93,7 +93,7 @@ class AllSkyInjectionParametersGenerator(InjectionParametersGenerator):
         self._update_priors(self.restricted_priors)
 
     def set_seed(self, seed):
-        super().set_seed
+        super().set_seed(seed)
         self.restricted_priors = {
             # This whole shenanigan is required because numpy has no arcsin distro
             "Alpha": lambda: self._rng.uniform(low=0.0, high=2 * np.pi),
@@ -113,7 +113,7 @@ class AllSkyInjectionParametersGenerator(InjectionParametersGenerator):
 
     def set_priors(self, new_priors):
         self._check_if_updating_sky_priors(new_priors)
-        super().set_priors(self, {**new_priors, **self.restricted_priors})
+        super().set_priors({**new_priors, **self.restricted_priors})
 
 
 class Writer(BaseSearchClass):

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -34,8 +34,8 @@ class InjectionParametersGenerator:
         parameter_priors: dict
             Each key refers to one of the signal's parameters (following the PyFstat convetion).
         """
-        self.parameter_priors = parameter_priors
         self._rng = np.random.default_rng(seed)
+        self.parameter_priors = parameter_priors
 
     @property
     def parameter_priors(self):

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -111,7 +111,7 @@ class InjectionParametersGenerator:
                 rng_function = getattr(self._rng, rng_function_name)
                 rng_kwargs = parameter_prior[rng_function_name]
                 current_priors.update(
-                    {parameter_name, lambda: rng_function(**rng_kwargs)}
+                    {parameter_name: (lambda: rng_function(**rng_kwargs))}
                 )
 
             prior_keys.extend(parameter_name)

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -71,6 +71,9 @@ class InjectionParametersGenerator:
         }
         return injection_parameters
 
+    def __call__(self):
+        self.return_injection_parameters()
+
 
 class Writer(BaseSearchClass):
     """ Instance object for generating SFTs """

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -49,6 +49,13 @@ class InjectionParametersGenerator:
 
     def set_priors(self, new_priors):
         """Set priors to draw parameter space points from """
+        if type(new_priors) is not dict:
+            raise ValueError(
+                "new_priors is not a dict type.\nPlease, check "
+                "this class' docstring to learn about the expected format: "
+                f"{self.__init__.__doc__}"
+            )
+
         self.priors = {}
         self._update_priors(new_priors)
 

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -103,17 +103,18 @@ class AllSkyInjectionParametersGenerator(InjectionParametersGenerator):
     """Like InjectionParametersGenerator, but with hardcoded priors to perform
     all sky searches. It assumes 1) PyFstat notation and 2) Equatorial coordinates"""
 
-    restricted_priors = {
-        "Alpha": lambda: np.random.uniform(low=0.0, high=2 * np.pi),
-        "Delta": lambda: 2 * np.arcsin(np.random.uniform(low=-1.0, high=1.0)),
-    }
-
     def __init__(self, priors=None, seed=None):
+
+        self.restricted_priors_set = False
+        super().__init__(None, seed)
+        self.restricted_priors = {
+            "Alpha": lambda: self._rng.uniform(low=0.0, high=2 * np.pi),
+            "Delta": lambda: 2 * np.arcsin(self._rng.uniform(low=-1.0, high=1.0)),
+        }
         InjectionParametersGenerator.priors.fset(self, self.restricted_priors)
-        super().__init__(priors, seed)
 
     def _check_if_updating_sky_priors(self, new_priors):
-        if any(
+        if self.restricted_priors_set and any(
             restricted_key in new_priors
             for restricted_key in self.restricted_priors.keys()
         ):

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -101,7 +101,7 @@ class InjectionParametersGenerator:
 
 class AllSkyInjectionParametersGenerator(InjectionParametersGenerator):
     """Like InjectionParametersGenerator, but with hardcoded priors to perform
-    all sky searches. It assumes 1) PyFstat notation and 2) Ecuatorial coordinates"""
+    all sky searches. It assumes 1) PyFstat notation and 2) Equatorial coordinates"""
 
     restricted_priors = {
         "Alpha": lambda: np.random.uniform(low=0.0, high=2 * np.pi),
@@ -119,7 +119,7 @@ class AllSkyInjectionParametersGenerator(InjectionParametersGenerator):
         ):
             raise ValueError(
                 "New parameter priors would overwrite sky priors (Alpha, Delta)."
-                "This class is explicitiely coded to prevent that from happening. Please, restore "
+                "This class is explicitly coded to prevent that from happening. Please, restore "
                 "to InjectionParametersGenerator if that's really what you want to do"
             )
 

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -29,16 +29,13 @@ class InjectionParametersGenerator:
     them in the proper format.
     """
 
-    def __init__(self, parameter_priors=None):
+    def __init__(self, parameter_priors=None, seed=None):
         """
         parameter_priors: dict
             Each key refers to one of the signal's parameters (following the PyFstat convetion).
         """
         self.parameter_priors = parameter_priors
-
-        self._rng = np.random.default_rng()
-
-        self.injection_parameters = None
+        self._rng = np.random.default_rng(seed)
 
     @property
     def parameter_priors(self):
@@ -68,8 +65,11 @@ class InjectionParametersGenerator:
         )
 
     def return_injection_parameters(self):
-        for parameter_name in self.parameter_priors:
-            pass
+        injection_parameters = {
+            parameter_name: parameter_prior()
+            for parameter_name, parameter_prior in self.parameter_priors.items()
+        }
+        return injection_parameters
 
 
 class Writer(BaseSearchClass):

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -98,11 +98,7 @@ class InjectionParametersGenerator:
         """Set priors to drawn parameter space points from """
 
         current_priors = getattr(self, "parameter_priors", {})
-
-        logging.info(
-            "Updating parameters: "
-            + " ".join(["{}".format(key) for key in new_parameter_priors.keys()])
-        )
+        prior_keys = []
 
         for parameter_name, parameter_prior in new_parameter_priors.items():
             # Currenlty two input formats are supported
@@ -118,20 +114,26 @@ class InjectionParametersGenerator:
                     {parameter_name, lambda: rng_function(**rng_kwargs)}
                 )
 
+            prior_keys.extend(parameter_name)
+
         self._parameter_priors = current_priors
+        self._prior_keys = prior_keys
+
+        logging.info(
+            "Updated parameters: "
+            + " ".join(["{}".format(key) for key in new_parameter_priors.keys()])
+        )
 
     def generate_injection_parameters(self, number_of_injections):
         """The important thing"""
-        injection_parameters = {}
 
-        for parameters_name, parameters_info in self.parameter_priors.items():
-            rng_name = next(iter(parameters_info))
-            rng_function = getattr(self._rng, rng_name)
-            rng_kwargs = parameters_info[rng_name]
+        injection_parameters = []
+        for injection_index in number_of_injections:
 
-            injection_parameters[parameters_name] = rng_function(
-                **rng_kwargs, size=number_of_injections
-            )
+            this_parameters = {key: prior() for key, prior in self._parameter_priors}
+
+        injection_parameters.append(this_parameters)
+
         self.injection_parameters = injection_parameters
 
 

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -65,7 +65,11 @@ class InjectionParametersGenerator:
         Check if output files already exist to prevent
         accidental overwritting
         """
-        pass
+        # Provisional
+        if os.path.isfile(self.outdir + self.label):
+            raise FileExistsError(
+                "Injection file {} already exists in {}".format(self.label, self.outdir)
+            )
 
     @outdir.setter
     def outdir(self, new_outdir):
@@ -89,10 +93,6 @@ class InjectionParametersGenerator:
         the same name.
         """
         self._label = new_label
-        if os.path.isfile(self.outdir + self.label):
-            raise FileExistsError(
-                "Injection file {} already exists in {}".format(self.label, self.outdir)
-            )
 
     @parameter_priors.setter
     def parameter_priors(self, new_parameter_priors):

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -38,7 +38,7 @@ class InjectionParametersGenerator:
                 1) Callable without required arguments
                     {"ParameterA": np.random.uniform}
                 2) Dict containing numpy.random distribution as key and kwargs in a dict as value
-                    {"ParameterA": {"uniform": {low: 0, high:1}}}
+                    {"ParameterA": {"uniform": {"low": 0, "high":1}}}
                 3) Constant value to be returned as is
                     {"ParameterA": 1.0}
         seed:

--- a/tests.py
+++ b/tests.py
@@ -126,7 +126,6 @@ class TestInjectionParametersGenerator(BaseForTestsWithOutdir):
         InjectionGenerator = self.class_to_test(numpy_priors)
 
         parameters = InjectionGenerator.draw()
-        print(parameters)
         self.assertTrue(parameters["ParameterA"] == 0.0)
         self.assertTrue(parameters["ParameterB"] == 1.0)
 

--- a/tests.py
+++ b/tests.py
@@ -147,7 +147,7 @@ class TestInjectionParametersGenerator(BaseForTestsWithOutdir):
 
     def test_rng_generation(self):
         self.InjectionGenerator = pyfstat.InjectionParametersGenerator(
-            parameter_priors={"ParameterA": {"normal": {"loc": 0, "scale": 0.01}}}
+            priors={"ParameterA": {"normal": {"loc": 0, "scale": 0.01}}}
         )
         samples = [
             self.InjectionGenerator.return_injection_parameters()["ParameterA"]

--- a/tests.py
+++ b/tests.py
@@ -171,6 +171,16 @@ class TestAllSkyInjectionParametersGenerator(TestInjectionParametersGenerator):
 
     class_to_test = pyfstat.AllSkyInjectionParametersGenerator
 
+    def test_rng_seed(self):
+        a_seed = 420
+
+        samples = []
+        for i in range(2):
+            self.InjectionGenerator = self.class_to_test(seed=a_seed)
+            samples.append(self.InjectionGenerator.draw())
+        self.assertTrue(samples[0]["Alpha"] == samples[1]["Alpha"])
+        self.assertTrue(samples[0]["Delta"] == samples[1]["Delta"])
+
     def test_rng_generation(self):
         self.InjectionGenerator = self.class_to_test()
         ra_samples = [

--- a/tests.py
+++ b/tests.py
@@ -118,16 +118,35 @@ class TestInjectionParametersGenerator(BaseForTestsWithOutdir):
     label = "TestInjectionParametersGenerator"
 
     def test_numpy_priors(self):
-        pass
+        numpy_priors = {
+            "ParameterA": {"uniform": {"low": 0.0, "high": 0.0}},
+            "ParameterB": {"uniform": {"low": 1.0, "high": 1.0}},
+        }
+        self.InjectionGenerator = pyfstat.InjectionParametersGenerator(numpy_priors)
+
+        parameters = self.InjectionGenerator.return_injection_parameters()
+        print(parameters)
+        self.assertTrue(parameters["ParameterA"] == 0.0)
+        self.assertTrue(parameters["ParameterB"] == 1.0)
 
     def test_callable_priors(self):
-        pass
+        callable_priors = {"ParameterA": lambda: 0.0, "ParameterB": lambda: 1.0}
+        self.InjectionGenerator = pyfstat.InjectionParametersGenerator(callable_priors)
 
-    def test_multiple_output_priors(self):
-        pass
+        parameters = self.InjectionGenerator.return_injection_parameters()
+        self.assertTrue(parameters["ParameterA"] == 0.0)
+        self.assertTrue(parameters["ParameterB"] == 1.0)
 
-    def test_output(self):
-        pass
+    def test_rng_generation(self):
+        self.InjectionGenerator = pyfstat.InjectionParametersGenerator(
+            parameter_priors={"ParameterA": {"normal": {"loc": 0, "scale": 0.01}}}
+        )
+        samples = [
+            self.InjectionGenerator.return_injection_parameters()["ParameterA"]
+            for i in range(100)
+        ]
+        mean = np.mean(samples)
+        self.assertTrue(np.abs(mean) < 0.1)
 
 
 class TestWriter(BaseForTestsWithData):

--- a/tests.py
+++ b/tests.py
@@ -124,7 +124,7 @@ class TestInjectionParametersGenerator(BaseForTestsWithOutdir):
         }
         self.InjectionGenerator = pyfstat.InjectionParametersGenerator(numpy_priors)
 
-        parameters = self.InjectionGenerator.return_injection_parameters()
+        parameters = self.InjectionGenerator.draw()
         print(parameters)
         self.assertTrue(parameters["ParameterA"] == 0.0)
         self.assertTrue(parameters["ParameterB"] == 1.0)
@@ -133,7 +133,7 @@ class TestInjectionParametersGenerator(BaseForTestsWithOutdir):
         callable_priors = {"ParameterA": lambda: 0.0, "ParameterB": lambda: 1.0}
         self.InjectionGenerator = pyfstat.InjectionParametersGenerator(callable_priors)
 
-        parameters = self.InjectionGenerator.return_injection_parameters()
+        parameters = self.InjectionGenerator.draw()
         self.assertTrue(parameters["ParameterA"] == 0.0)
         self.assertTrue(parameters["ParameterB"] == 1.0)
 
@@ -141,18 +141,23 @@ class TestInjectionParametersGenerator(BaseForTestsWithOutdir):
         constant_priors = {"ParameterA": 0.0, "ParameterB": 1.0}
         self.InjectionGenerator = pyfstat.InjectionParametersGenerator(constant_priors)
 
-        parameters = self.InjectionGenerator.return_injection_parameters()
+        parameters = self.InjectionGenerator.draw()
         self.assertTrue(parameters["ParameterA"] == 0.0)
         self.assertTrue(parameters["ParameterB"] == 1.0)
+
+    def test_rng_key(self):
+        self.InjectionGenerator = pyfstat.InjectionParametersGenerator(
+            priors={"ParameterA": {"normal": {"loc": 0, "scale": 0.01}}},
+        )
+        samples = [self.InjectionGenerator.draw()["ParameterA"] for i in range(100)]
+        mean = np.mean(samples)
+        self.assertTrue(np.abs(mean) < 0.1)
 
     def test_rng_generation(self):
         self.InjectionGenerator = pyfstat.InjectionParametersGenerator(
             priors={"ParameterA": {"normal": {"loc": 0, "scale": 0.01}}}
         )
-        samples = [
-            self.InjectionGenerator.return_injection_parameters()["ParameterA"]
-            for i in range(100)
-        ]
+        samples = [self.InjectionGenerator.draw()["ParameterA"] for i in range(100)]
         mean = np.mean(samples)
         self.assertTrue(np.abs(mean) < 0.1)
 
@@ -163,12 +168,10 @@ class TestAllSkyInjectionParametersGenerator(BaseForTestsWithOutdir):
     def test_rng_generation(self):
         self.InjectionGenerator = pyfstat.AllSkyInjectionParametersGenerator()
         ra_samples = [
-            self.InjectionGenerator.return_injection_parameters()["Alpha"] / np.pi - 1.0
-            for i in range(500)
+            self.InjectionGenerator.draw()["Alpha"] / np.pi - 1.0 for i in range(500)
         ]
         dec_samples = [
-            self.InjectionGenerator.return_injection_parameters()["Delta"] * 2.0 / np.pi
-            for i in range(500)
+            self.InjectionGenerator.draw()["Delta"] * 2.0 / np.pi for i in range(500)
         ]
         self.assertTrue(np.abs(np.mean(ra_samples)) < 0.1)
         self.assertTrue(np.abs(np.mean(dec_samples)) < 0.1)

--- a/tests.py
+++ b/tests.py
@@ -123,26 +123,26 @@ class TestInjectionParametersGenerator(BaseForTestsWithOutdir):
             "ParameterA": {"uniform": {"low": 0.0, "high": 0.0}},
             "ParameterB": {"uniform": {"low": 1.0, "high": 1.0}},
         }
-        self.InjectionGenerator = self.class_to_test(numpy_priors)
+        InjectionGenerator = self.class_to_test(numpy_priors)
 
-        parameters = self.InjectionGenerator.draw()
+        parameters = InjectionGenerator.draw()
         print(parameters)
         self.assertTrue(parameters["ParameterA"] == 0.0)
         self.assertTrue(parameters["ParameterB"] == 1.0)
 
     def test_callable_priors(self):
         callable_priors = {"ParameterA": lambda: 0.0, "ParameterB": lambda: 1.0}
-        self.InjectionGenerator = self.class_to_test(callable_priors)
+        InjectionGenerator = self.class_to_test(callable_priors)
 
-        parameters = self.InjectionGenerator.draw()
+        parameters = InjectionGenerator.draw()
         self.assertTrue(parameters["ParameterA"] == 0.0)
         self.assertTrue(parameters["ParameterB"] == 1.0)
 
     def test_constant_priors(self):
         constant_priors = {"ParameterA": 0.0, "ParameterB": 1.0}
-        self.InjectionGenerator = self.class_to_test(constant_priors)
+        InjectionGenerator = self.class_to_test(constant_priors)
 
-        parameters = self.InjectionGenerator.draw()
+        parameters = InjectionGenerator.draw()
         self.assertTrue(parameters["ParameterA"] == 0.0)
         self.assertTrue(parameters["ParameterB"] == 1.0)
 
@@ -151,17 +151,17 @@ class TestInjectionParametersGenerator(BaseForTestsWithOutdir):
 
         samples = []
         for i in range(2):
-            self.InjectionGenerator = self.class_to_test(
+            InjectionGenerator = self.class_to_test(
                 priors={"ParameterA": {"normal": {"loc": 0, "scale": 1}}}, seed=a_seed
             )
-            samples.append(self.InjectionGenerator.draw())
+            samples.append(InjectionGenerator.draw())
         self.assertTrue(samples[0]["ParameterA"] == samples[1]["ParameterA"])
 
     def test_rng_generation(self):
-        self.InjectionGenerator = self.class_to_test(
+        InjectionGenerator = self.class_to_test(
             priors={"ParameterA": {"normal": {"loc": 0, "scale": 0.01}}}
         )
-        samples = [self.InjectionGenerator.draw()["ParameterA"] for i in range(100)]
+        samples = [InjectionGenerator.draw()["ParameterA"] for i in range(100)]
         mean = np.mean(samples)
         self.assertTrue(np.abs(mean) < 0.1)
 
@@ -176,18 +176,18 @@ class TestAllSkyInjectionParametersGenerator(TestInjectionParametersGenerator):
 
         samples = []
         for i in range(2):
-            self.InjectionGenerator = self.class_to_test(seed=a_seed)
-            samples.append(self.InjectionGenerator.draw())
+            InjectionGenerator = self.class_to_test(seed=a_seed)
+            samples.append(InjectionGenerator.draw())
         self.assertTrue(samples[0]["Alpha"] == samples[1]["Alpha"])
         self.assertTrue(samples[0]["Delta"] == samples[1]["Delta"])
 
     def test_rng_generation(self):
-        self.InjectionGenerator = self.class_to_test()
+        InjectionGenerator = self.class_to_test()
         ra_samples = [
-            self.InjectionGenerator.draw()["Alpha"] / np.pi - 1.0 for i in range(500)
+            InjectionGenerator.draw()["Alpha"] / np.pi - 1.0 for i in range(500)
         ]
         dec_samples = [
-            self.InjectionGenerator.draw()["Delta"] * 2.0 / np.pi for i in range(500)
+            InjectionGenerator.draw()["Delta"] * 2.0 / np.pi for i in range(500)
         ]
         self.assertTrue(np.abs(np.mean(ra_samples)) < 0.1)
         self.assertTrue(np.abs(np.mean(dec_samples)) < 0.1)

--- a/tests.py
+++ b/tests.py
@@ -116,13 +116,14 @@ class BaseForTestsWithData(BaseForTestsWithOutdir):
 
 class TestInjectionParametersGenerator(BaseForTestsWithOutdir):
     label = "TestInjectionParametersGenerator"
+    class_to_test = pyfstat.InjectionParametersGenerator
 
     def test_numpy_priors(self):
         numpy_priors = {
             "ParameterA": {"uniform": {"low": 0.0, "high": 0.0}},
             "ParameterB": {"uniform": {"low": 1.0, "high": 1.0}},
         }
-        self.InjectionGenerator = pyfstat.InjectionParametersGenerator(numpy_priors)
+        self.InjectionGenerator = self.class_to_test(numpy_priors)
 
         parameters = self.InjectionGenerator.draw()
         print(parameters)
@@ -131,7 +132,7 @@ class TestInjectionParametersGenerator(BaseForTestsWithOutdir):
 
     def test_callable_priors(self):
         callable_priors = {"ParameterA": lambda: 0.0, "ParameterB": lambda: 1.0}
-        self.InjectionGenerator = pyfstat.InjectionParametersGenerator(callable_priors)
+        self.InjectionGenerator = self.class_to_test(callable_priors)
 
         parameters = self.InjectionGenerator.draw()
         self.assertTrue(parameters["ParameterA"] == 0.0)
@@ -139,7 +140,7 @@ class TestInjectionParametersGenerator(BaseForTestsWithOutdir):
 
     def test_constant_priors(self):
         constant_priors = {"ParameterA": 0.0, "ParameterB": 1.0}
-        self.InjectionGenerator = pyfstat.InjectionParametersGenerator(constant_priors)
+        self.InjectionGenerator = self.class_to_test(constant_priors)
 
         parameters = self.InjectionGenerator.draw()
         self.assertTrue(parameters["ParameterA"] == 0.0)
@@ -150,14 +151,14 @@ class TestInjectionParametersGenerator(BaseForTestsWithOutdir):
 
         samples = []
         for i in range(2):
-            self.InjectionGenerator = pyfstat.InjectionParametersGenerator(
+            self.InjectionGenerator = self.class_to_test(
                 priors={"ParameterA": {"normal": {"loc": 0, "scale": 1}}}, seed=a_seed
             )
             samples.append(self.InjectionGenerator.draw())
         self.assertTrue(samples[0]["ParameterA"] == samples[1]["ParameterA"])
 
     def test_rng_generation(self):
-        self.InjectionGenerator = pyfstat.InjectionParametersGenerator(
+        self.InjectionGenerator = self.class_to_test(
             priors={"ParameterA": {"normal": {"loc": 0, "scale": 0.01}}}
         )
         samples = [self.InjectionGenerator.draw()["ParameterA"] for i in range(100)]
@@ -165,11 +166,13 @@ class TestInjectionParametersGenerator(BaseForTestsWithOutdir):
         self.assertTrue(np.abs(mean) < 0.1)
 
 
-class TestAllSkyInjectionParametersGenerator(BaseForTestsWithOutdir):
+class TestAllSkyInjectionParametersGenerator(TestInjectionParametersGenerator):
     label = "TestAllInjectionParametersGenerator"
 
+    class_to_test = pyfstat.AllSkyInjectionParametersGenerator
+
     def test_rng_generation(self):
-        self.InjectionGenerator = pyfstat.AllSkyInjectionParametersGenerator()
+        self.InjectionGenerator = self.class_to_test()
         ra_samples = [
             self.InjectionGenerator.draw()["Alpha"] / np.pi - 1.0 for i in range(500)
         ]

--- a/tests.py
+++ b/tests.py
@@ -145,13 +145,16 @@ class TestInjectionParametersGenerator(BaseForTestsWithOutdir):
         self.assertTrue(parameters["ParameterA"] == 0.0)
         self.assertTrue(parameters["ParameterB"] == 1.0)
 
-    def test_rng_key(self):
-        self.InjectionGenerator = pyfstat.InjectionParametersGenerator(
-            priors={"ParameterA": {"normal": {"loc": 0, "scale": 0.01}}},
-        )
-        samples = [self.InjectionGenerator.draw()["ParameterA"] for i in range(100)]
-        mean = np.mean(samples)
-        self.assertTrue(np.abs(mean) < 0.1)
+    def test_rng_seed(self):
+        a_seed = 420
+
+        samples = []
+        for i in range(2):
+            self.InjectionGenerator = pyfstat.InjectionParametersGenerator(
+                priors={"ParameterA": {"normal": {"loc": 0, "scale": 1}}}, seed=a_seed
+            )
+            samples.append(self.InjectionGenerator.draw())
+        self.assertTrue(samples[0]["ParameterA"] == samples[1]["ParameterA"])
 
     def test_rng_generation(self):
         self.InjectionGenerator = pyfstat.InjectionParametersGenerator(

--- a/tests.py
+++ b/tests.py
@@ -114,6 +114,22 @@ class BaseForTestsWithData(BaseForTestsWithOutdir):
         self.search_ranges = {key: [getattr(self, key)] for key in self.search_keys}
 
 
+class TestInjectionParametersGenerator(BaseForTestsWithOutdir):
+    label = "TestInjectionParametersGenerator"
+
+    def test_numpy_priors(self):
+        pass
+
+    def test_callable_priors(self):
+        pass
+
+    def test_multiple_output_priors(self):
+        pass
+
+    def test_output(self):
+        pass
+
+
 class TestWriter(BaseForTestsWithData):
     label = "TestWriter"
     writer_class_to_test = pyfstat.Writer

--- a/tests.py
+++ b/tests.py
@@ -137,6 +137,14 @@ class TestInjectionParametersGenerator(BaseForTestsWithOutdir):
         self.assertTrue(parameters["ParameterA"] == 0.0)
         self.assertTrue(parameters["ParameterB"] == 1.0)
 
+    def test_constant_priors(self):
+        constant_priors = {"ParameterA": 0.0, "ParameterB": 1.0}
+        self.InjectionGenerator = pyfstat.InjectionParametersGenerator(constant_priors)
+
+        parameters = self.InjectionGenerator.return_injection_parameters()
+        self.assertTrue(parameters["ParameterA"] == 0.0)
+        self.assertTrue(parameters["ParameterB"] == 1.0)
+
     def test_rng_generation(self):
         self.InjectionGenerator = pyfstat.InjectionParametersGenerator(
             parameter_priors={"ParameterA": {"normal": {"loc": 0, "scale": 0.01}}}

--- a/tests.py
+++ b/tests.py
@@ -149,6 +149,23 @@ class TestInjectionParametersGenerator(BaseForTestsWithOutdir):
         self.assertTrue(np.abs(mean) < 0.1)
 
 
+class TestAllSkyInjectionParametersGenerator(BaseForTestsWithOutdir):
+    label = "TestAllInjectionParametersGenerator"
+
+    def test_rng_generation(self):
+        self.InjectionGenerator = pyfstat.AllSkyInjectionParametersGenerator()
+        ra_samples = [
+            self.InjectionGenerator.return_injection_parameters()["Alpha"] / np.pi - 1.0
+            for i in range(500)
+        ]
+        dec_samples = [
+            self.InjectionGenerator.return_injection_parameters()["Delta"] * 2.0 / np.pi
+            for i in range(500)
+        ]
+        self.assertTrue(np.abs(np.mean(ra_samples)) < 0.1)
+        self.assertTrue(np.abs(np.mean(dec_samples)) < 0.1)
+
+
 class TestWriter(BaseForTestsWithData):
     label = "TestWriter"
     writer_class_to_test = pyfstat.Writer


### PR DESCRIPTION
Implement a class to generate injection parameters. 

The idea would be the same one one has been doing so far: Pick a rng and draw injection parameters from it. But, instead
of re-inventing the wheel every time, now we could just pass those arguments to this new class an query injection parameters on demand.

- [x] Finish up the implementation.
- [x] Deal with "constant parameters" (just make sure you don't have to code them too explicitly).
- [x] Fill up tests cases.

More desirable things:
- ~[ ] Make this class an iterable?~ Somehow I feel a callable makes more sense.
- [x] Add a subclass which already includes all sky sampling.