### PR TITLE
Deprecate unmaintained grid classes

### DIFF
--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -1742,3 +1742,30 @@ class SemiCoherentGlitchSearch(SearchForSignalWithJumps, ComputeFstat):
         )
 
         return twoFsegA + twoFsegB
+
+
+class DeprecatedClass:
+    def __new__(cls, *args, **kwargs):
+        logging.warning(
+            f"The {cls.__name__} class is no longer maintained"
+            " and will be removed in an upcoming release of PyFstat!"
+            " If you rely on this class and/or are interested in taking over"
+            " maintenance, please report an issue at:"
+            " https://github.com/PyFstat/PyFstat/issues",
+        )
+        return super().__new__(cls, *args, **kwargs)
+
+
+class DefunctClass:
+    last_supported_version = None
+    pr_welcome = True
+
+    def __new__(cls, *args, **kwargs):
+        defunct_message = f"The {cls.__name__} class is no longer included in PyFstat!"
+        if cls.last_supported_version:
+            defunct_message += (
+                f" Last supported version was {cls.last_supported_version}."
+            )
+        if cls.pr_welcome:
+            defunct_message += " Pull requests to reinstate the class are welcome."
+        raise NotImplementedError(defunct_message)

--- a/pyfstat/grid_based_searches.py
+++ b/pyfstat/grid_based_searches.py
@@ -20,6 +20,7 @@ from pyfstat.core import (
     SemiCoherentSearch,
     tqdm,
     args,
+    DeprecatedClass,
 )
 import lalpulsar
 import lal
@@ -853,7 +854,7 @@ class TransientGridSearch(GridSearch):
             self.search.__del__()
 
 
-class SliceGridSearch(GridSearch):
+class SliceGridSearch(GridSearch, DeprecatedClass):
     """ Slice gridded search using ComputeFstat """
 
     @helper_functions.initializer
@@ -1026,7 +1027,7 @@ class SliceGridSearch(GridSearch):
             return fig, axes
 
 
-class GridUniformPriorSearch:
+class GridUniformPriorSearch(DeprecatedClass):
     @helper_functions.initializer
     def __init__(
         self,
@@ -1186,7 +1187,7 @@ class GridGlitchSearch(GridSearch):
         return fmt
 
 
-class SlidingWindow(GridSearch):
+class SlidingWindow(GridSearch, DeprecatedClass):
     @helper_functions.initializer
     def __init__(
         self,
@@ -1324,7 +1325,7 @@ class SlidingWindow(GridSearch):
             return ax
 
 
-class FrequencySlidingWindow(GridSearch):
+class FrequencySlidingWindow(GridSearch, DeprecatedClass):
     """ A sliding-window search over the Frequency """
 
     @helper_functions.initializer
@@ -1485,7 +1486,7 @@ class FrequencySlidingWindow(GridSearch):
             return ax
 
 
-class EarthTest(GridSearch):
+class EarthTest(GridSearch, DeprecatedClass):
     """ """
 
     tex_labels = {
@@ -1738,7 +1739,7 @@ class EarthTest(GridSearch):
         plt.close(fig)
 
 
-class DMoff_NO_SPIN(GridSearch):
+class DMoff_NO_SPIN(GridSearch, DeprecatedClass):
     """ DMoff test using SSBPREC_NO_SPIN """
 
     @helper_functions.initializer


### PR DESCRIPTION
@Rodrigo-Tenorio This is the discussed implementation for the first step of #213.

cc @GregoryAshton @ReinhardPrix 

For future reference, step2, the usage of `DefunctClass` would look like:
```
class FrequencySlidingWindow(DefunctClass):
    last_supported_version="1.8.0"
```