### PR TITLE
Include examples in sphinx html documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,13 +178,11 @@ For a general introduction to installing modules, see
   and [black](https://black.readthedocs.io) style checker
   locally,
   as these checks are required to pass by the online integration pipeline.
-* Some optional plotting methods depend on two additional packages,
-  and some of the [examples](./examples) require these to run:
- [gridcorner](https://gitlab.aei.uni-hannover.de/GregAshton/gridcorner) 
-  and [chainconsumer](https://github.com/Samreay/ChainConsumer);
-for `pip` users this is most conveniently installed by
+* Some optional plotting methods depend on the additional package
+  [chainconsumer](https://github.com/Samreay/ChainConsumer)
+  and some of the [examples](./examples) require this to run.
+  Gor `pip` users, this is most conveniently installed by
 ```
-pip install git+https://gitlab.aei.uni-hannover.de/GregAshton/gridcorner
 pip install chainconsumer
 ```
 * If you prefer to make your own LALSuite installation

--- a/docs/source/PyFstat_example_make_data_for_short_transient_search.rst
+++ b/docs/source/PyFstat_example_make_data_for_short_transient_search.rst
@@ -1,0 +1,10 @@
+PyFstat\_example\_make\_data\_for\_short\_transient\_search.py
+==============================================================
+
+.. automodule:: PyFstat_example_make_data_for_short_transient_search
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. literalinclude:: ../../examples/transient_examples/PyFstat_example_make_data_for_short_transient_search.py
+   :linenos:

--- a/docs/source/PyFstat_example_short_transient_MCMC_search.rst
+++ b/docs/source/PyFstat_example_short_transient_MCMC_search.rst
@@ -1,0 +1,10 @@
+PyFstat\_example_short\_transient\_MCMC\_search.py
+==============================================================
+
+.. automodule:: PyFstat_example_short_transient_MCMC_search
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. literalinclude:: ../../examples/transient_examples/PyFstat_example_short_transient_MCMC_search.py
+   :linenos:

--- a/docs/source/PyFstat_example_short_transient_grid_search.rst
+++ b/docs/source/PyFstat_example_short_transient_grid_search.rst
@@ -1,0 +1,10 @@
+PyFstat\_example\_short\_transient\_grid\_search.py
+==============================================================
+
+.. automodule:: PyFstat_example_short_transient_grid_search
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. literalinclude:: ../../examples/transient_examples/PyFstat_example_short_transient_grid_search.py
+   :linenos:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,6 +15,11 @@ import sys
 
 sys.path.insert(0, os.path.abspath("../../"))
 sys.path.insert(0, os.path.abspath("../../pyfstat/"))
+examples_basedir = "../../examples/"
+for case in os.listdir(examples_basedir):
+    exdir = os.path.abspath(os.path.join(examples_basedir, case))
+    if os.path.isdir(exdir):
+        sys.path.insert(0, exdir)
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -1,0 +1,32 @@
+examples
+============
+
+Simple stand-alone examples intended to teach basic usage of the library.
+
+NOTE this part of the documentation is work in progress and very incomplete.
+
+PyFstat\_example\_simple\_mcmc\_vs\_grid\_comparison.py
+-------------------------------------------------------
+
+This is an example of how running "automodule" on one of the executable example
+scripts looks like. "[source]" links only show up if there are any members.
+
+.. automodule:: PyFstat_example_simple_mcmc_vs_grid_comparison
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+transient\_examples
+-------------------
+
+Alternatively, this is how some hand-crafted solution with just links to
+literal includes will look like. This seems more useful.
+
+A set of examples for data generation and searches
+of limited-duration transient-CW signals.
+
+.. toctree::
+
+   PyFstat_example_make_data_for_short_transient_search
+   PyFstat_example_short_transient_grid_search
+   PyFstat_example_short_transient_MCMC_search

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -9,4 +9,5 @@ PyFstat
    :maxdepth: 4
 
    pyfstat
+   examples
    tests

--- a/docs/source/pyfstat.rst
+++ b/docs/source/pyfstat.rst
@@ -20,6 +20,14 @@ pyfstat.grid\_based\_searches module
    :undoc-members:
    :show-inheritance:
 
+pyfstat.gridcorner module
+-------------------------
+
+.. automodule:: pyfstat.gridcorner
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 pyfstat.helper\_functions module
 --------------------------------
 

--- a/examples/glitch_examples/PyFstat_example_glitch_robust_directed_MCMC_search_on_1_glitch.py
+++ b/examples/glitch_examples/PyFstat_example_glitch_robust_directed_MCMC_search_on_1_glitch.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pyfstat
-import gridcorner
 import time
 from PyFstat_example_make_data_for_search_on_1_glitch import (
     tstart,
@@ -79,11 +78,10 @@ mcmc.run(save_loudest=False)  # uses CFSv2 which doesn't support glitch paramete
 dT = time.time() - t1
 mcmc.print_summary()
 
-fig_and_axes = gridcorner._get_fig_and_axes(4, 2, 0.05)
+print("Making corner plot...")
 mcmc.plot_corner(
     label_offset=0.25,
     truths={"F0": F0, "F1": F1, "delta_F0": delta_F0, "tglitch": tstart + dtglitch},
-    fig_and_axes=fig_and_axes,
     quantiles=(0.16, 0.84),
     hist_kwargs=dict(lw=1.5, zorder=-1),
     truth_color="C3",

--- a/examples/glitch_examples/PyFstat_example_glitch_robust_directed_grid_search_on_1_glitch.py
+++ b/examples/glitch_examples/PyFstat_example_glitch_robust_directed_grid_search_on_1_glitch.py
@@ -16,14 +16,6 @@ from PyFstat_example_make_data_for_search_on_1_glitch import (
 import time
 import os
 
-try:
-    from gridcorner import gridcorner
-except ImportError:
-    raise ImportError(
-        "Python module 'gridcorner' not found, please install from "
-        "https://gitlab.aei.uni-hannover.de/GregAshton/gridcorner"
-    )
-
 label = "semicoherent_glitch_robust_directed_grid_search_on_1_glitch"
 
 Nstar = 1000
@@ -68,6 +60,7 @@ delta_F0s_vals = np.unique(search.data[:, 5]) - delta_F0
 tglitch_vals = np.unique(search.data[:, 7])
 tglitch_vals_days = (tglitch_vals - tstart) / 86400.0 - dtglitch / 86400.0
 
+print("Making gridcorner plot...")
 twoF = search.data[:, -1].reshape(
     (len(F0_vals), len(F1_vals), len(delta_F0s_vals), len(tglitch_vals))
 )
@@ -80,7 +73,7 @@ labels = [
     "$t^\\mathrm{g} - t^\\mathrm{g}_\\mathrm{s}$\n[d]",
     "$\\widehat{2\\mathcal{F}}$",
 ]
-fig, axes = gridcorner(
+fig, axes = pyfstat.gridcorner(
     twoF,
     xyz,
     projection="log_mean",

--- a/examples/grid_examples/PyFstat_example_grid_search_F0F1.py
+++ b/examples/grid_examples/PyFstat_example_grid_search_F0F1.py
@@ -2,14 +2,6 @@ import pyfstat
 import numpy as np
 import os
 
-try:
-    from gridcorner import gridcorner
-except ImportError:
-    raise ImportError(
-        "Python module 'gridcorner' not found, please install from "
-        "https://gitlab.aei.uni-hannover.de/GregAshton/gridcorner"
-    )
-
 label = os.path.splitext(os.path.basename(__file__))[0]
 outdir = os.path.join("PyFstat_example_data", label)
 
@@ -81,6 +73,7 @@ search.plot_1D(xkey="F0", xlabel="freq [Hz]", ylabel="$2\\mathcal{F}$")
 search.plot_1D(xkey="F1")
 search.plot_2D(xkey="F0", ykey="F1", colorbar=True)
 
+print("Making gridcorner plot...")
 F0_vals = np.unique(search.data[:, 2]) - F0
 F1_vals = np.unique(search.data[:, 3]) - F1
 twoF = search.data[:, -1].reshape((len(F0_vals), len(F1_vals)))
@@ -90,7 +83,7 @@ labels = [
     "$\\dot{f} - \\dot{f}_0$",
     "$\\widetilde{2\\mathcal{F}}$",
 ]
-fig, axes = gridcorner(
+fig, axes = pyfstat.gridcorner(
     twoF, xyz, projection="log_mean", labels=labels, whspace=0.1, factor=1.8
 )
 fig.savefig(os.path.join(outdir, label + "_projection_matrix.png"))

--- a/examples/grid_examples/PyFstat_example_grid_search_F0F1F2.py
+++ b/examples/grid_examples/PyFstat_example_grid_search_F0F1F2.py
@@ -2,14 +2,6 @@ import pyfstat
 import numpy as np
 import os
 
-try:
-    from gridcorner import gridcorner
-except ImportError:
-    raise ImportError(
-        "Python module 'gridcorner' not found, please install from "
-        "https://gitlab.aei.uni-hannover.de/GregAshton/gridcorner"
-    )
-
 label = os.path.splitext(os.path.basename(__file__))[0]
 outdir = os.path.join("PyFstat_example_data", label)
 
@@ -93,6 +85,7 @@ search.plot_1D(xkey="Delta", agg_chunksize=agg_chunksize)
 # search.plot_2D(xkey="F0",ykey="F2",colorbar=True)
 # search.plot_2D(xkey="F1",ykey="F2",colorbar=True)
 
+print("Making gridcorner plot...")
 F0_vals = np.unique(search.data[:, 2]) - F0
 F1_vals = np.unique(search.data[:, 3]) - F1
 F2_vals = np.unique(search.data[:, 4]) - F2
@@ -104,7 +97,7 @@ labels = [
     "$\\ddot{f} - \\ddot{f}_0$",
     "$\\widetilde{2\\mathcal{F}}$",
 ]
-fig, axes = gridcorner(
+fig, axes = pyfstat.gridcorner(
     twoF, xyz, projection="log_mean", labels=labels, whspace=0.1, factor=1.8
 )
 fig.savefig(os.path.join(outdir, label + "_projection_matrix.png"))

--- a/examples/mcmc_vs_grid_simple_example/PyFstat_example_simple_mcmc_vs_grid_comparison.py
+++ b/examples/mcmc_vs_grid_simple_example/PyFstat_example_simple_mcmc_vs_grid_comparison.py
@@ -5,14 +5,6 @@ import os
 import numpy as np
 import matplotlib.pyplot as plt
 
-try:
-    from gridcorner import gridcorner
-except ImportError:
-    raise ImportError(
-        "Python module 'gridcorner' not found, please install from "
-        "https://gitlab.aei.uni-hannover.de/GregAshton/gridcorner"
-    )
-
 # flip this switch for a more expensive 4D (F0,F1,Alpha,Delta) run
 # instead of just (F0,F1)
 # (still only a few minutes on current laptops)
@@ -132,7 +124,7 @@ if sky:
     corner_labels.append("$\\alpha - \\alpha_0$")
     corner_labels.append("$\\delta - \\delta_0$")
 corner_labels.append(labels["2F"])
-gridcorner_fig, gridcorner_axes = gridcorner(
+gridcorner_fig, gridcorner_axes = pyfstat.gridcorner(
     twoF, vals, projection="log_mean", labels=corner_labels, whspace=0.1, factor=1.8
 )
 gridcorner_fig.savefig(os.path.join(outdir, gridsearch.label + "_corner.png"))

--- a/examples/mcmc_vs_grid_simple_example/PyFstat_example_simple_mcmc_vs_grid_comparison.py
+++ b/examples/mcmc_vs_grid_simple_example/PyFstat_example_simple_mcmc_vs_grid_comparison.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+""" An example to compare MCMCSearch and GridSearch on the same data. """
+
 import pyfstat
 import os
 import numpy as np
@@ -45,260 +47,9 @@ labels = {
 }
 labels["max2F"] = "$\\max\\,$" + labels["2F"]
 
-print("Generating SFTs with injected signal...")
-writer = pyfstat.Writer(
-    label="simulated_signal",
-    outdir=outdir,
-    tstart=tstart,
-    duration=duration,
-    detectors=detectors,
-    sqrtSX=sqrtSX,
-    Tsft=Tsft,
-    **inj,
-    Band=1,  # default band estimation would be too narrow for a wide grid/prior
-)
-writer.make_data()
-print("")
-
-
-# set up square search grid with fixed (F0,F1) mismatch
-# and (optionally) some ad-hoc sky coverage
-m = 0.001
-dF0 = np.sqrt(12 * m) / (np.pi * duration)
-dF1 = np.sqrt(180 * m) / (np.pi * duration ** 2)
-DeltaF0 = 500 * dF0
-DeltaF1 = 200 * dF1
-if sky:
-    # cover less range to keep runtime down
-    DeltaF0 /= 10
-    DeltaF1 /= 10
-F0s = [inj["F0"] - DeltaF0 / 2.0, inj["F0"] + DeltaF0 / 2.0, dF0]
-F1s = [inj["F1"] - DeltaF1 / 2.0, inj["F1"] + DeltaF1 / 2.0, dF1]
-F2s = [inj["F2"]]
-search_keys = ["F0", "F1"]  # only the ones that aren't 0-width
-if sky:
-    dSky = 0.01  # rather coarse to keep runtime down
-    DeltaSky = 10 * dSky
-    Alphas = [inj["Alpha"] - DeltaSky / 2.0, inj["Alpha"] + DeltaSky / 2.0, dSky]
-    Deltas = [inj["Delta"] - DeltaSky / 2.0, inj["Delta"] + DeltaSky / 2.0, dSky]
-    search_keys += ["Alpha", "Delta"]
-else:
-    Alphas = [inj["Alpha"]]
-    Deltas = [inj["Delta"]]
-search_keys_label = "".join(search_keys)
-
-print("Performing GridSearch...")
-gridsearch = pyfstat.GridSearch(
-    label="grid_search_" + search_keys_label,
-    outdir=outdir,
-    sftfilepattern=os.path.join(outdir, "*simulated_signal*sft"),
-    F0s=F0s,
-    F1s=F1s,
-    F2s=F2s,
-    Alphas=Alphas,
-    Deltas=Deltas,
-    tref=inj["tref"],
-    BSGL=False,
-)
-gridsearch.run()
-gridsearch.print_max_twoF()
-gridsearch.save_array_to_disk(gridsearch.data)
-
-# do some plots of the GridSearch results
-if not sky:  # this plotter can't currently deal with too large result arrays
-    print("Plotting 1D 2F distributions...")
-    for key in search_keys:
-        gridsearch.plot_1D(xkey=key, xlabel=labels[key], ylabel=labels["2F"])
-
-print("Making GridSearch {:s} corner plot...".format("-".join(search_keys)))
-vals = [
-    np.unique(gridsearch.data[:, gridsearch.keys.index(key)]) - inj[key]
-    for key in search_keys
-]
-twoF = gridsearch.data[:, -1].reshape([len(kval) for kval in vals])
-corner_labels = [
-    "$f - f_0$ [Hz]",
-    "$\\dot{f} - \\dot{f}_0$ [Hz/s]",
-]
-if sky:
-    corner_labels.append("$\\alpha - \\alpha_0$")
-    corner_labels.append("$\\delta - \\delta_0$")
-corner_labels.append(labels["2F"])
-gridcorner_fig, gridcorner_axes = pyfstat.gridcorner(
-    twoF, vals, projection="log_mean", labels=corner_labels, whspace=0.1, factor=1.8
-)
-gridcorner_fig.savefig(os.path.join(outdir, gridsearch.label + "_corner.png"))
-plt.close(gridcorner_fig)
-print("")
-
-
-print("Performing MCMCSearch...")
-# set up priors in F0 and F1 (over)covering the grid ranges
-if sky:  # MCMC will still be fast in 4D with wider range than grid
-    DeltaF0 *= 50
-    DeltaF1 *= 50
-theta_prior = {
-    "F0": {
-        "type": "unif",
-        "lower": inj["F0"] - DeltaF0 / 2.0,
-        "upper": inj["F0"] + DeltaF0 / 2.0,
-    },
-    "F1": {
-        "type": "unif",
-        "lower": inj["F1"] - DeltaF1 / 2.0,
-        "upper": inj["F1"] + DeltaF1 / 2.0,
-    },
-    "F2": inj["F2"],
-}
-if sky:
-    # also implicitly covering twice the grid range here
-    theta_prior["Alpha"] = {
-        "type": "unif",
-        "lower": inj["Alpha"] - DeltaSky,
-        "upper": inj["Alpha"] + DeltaSky,
-    }
-    theta_prior["Delta"] = {
-        "type": "unif",
-        "lower": inj["Delta"] - DeltaSky,
-        "upper": inj["Delta"] + DeltaSky,
-    }
-else:
-    theta_prior["Alpha"] = inj["Alpha"]
-    theta_prior["Delta"] = inj["Delta"]
-# ptemcee sampler settings - in a real application we might want higher values
-ntemps = 2
-log10beta_min = -1
-nwalkers = 100
-nsteps = [200, 200]  # [burnin,production]
-
-mcmcsearch = pyfstat.MCMCSearch(
-    label="mcmc_search_" + search_keys_label,
-    outdir=outdir,
-    sftfilepattern=os.path.join(outdir, "*simulated_signal*sft"),
-    theta_prior=theta_prior,
-    tref=inj["tref"],
-    nsteps=nsteps,
-    nwalkers=nwalkers,
-    ntemps=ntemps,
-    log10beta_min=log10beta_min,
-)
-# walker plot is generated during main run of the search class
-mcmcsearch.run(walker_plot_args={"plot_det_stat": True, "injection_parameters": inj})
-mcmcsearch.print_summary()
-
-# call some built-in plotting methods
-# these can all highlight the injection parameters, too
-print("Making MCMCSearch {:s} corner plot...".format("-".join(search_keys)))
-mcmcsearch.plot_corner(truths=inj)
-print("Making MCMCSearch prior-posterior comparison plot...")
-mcmcsearch.plot_prior_posterior(injection_parameters=inj)
-print("")
-
-
-# NOTE: everything below here is just custom commandline output and plotting
-# for this particular example, which uses the PyFstat outputs,
-# but isn't very instructive if you just want to learn the main usage of the package.
-
-
-# some informative command-line output comparing search results and injection
-# get max of GridSearch, contains twoF and all Doppler parameters in the dict
-max_dict_grid = gridsearch.get_max_twoF()
-# same for MCMCSearch, here twoF is separate, and non-sampled parameters are not included either
-max_dict_mcmc, max_2F_mcmc = mcmcsearch.get_max_twoF()
-print(
-    "max2F={:.4f} from GridSearch, offsets from injection: {:s}.".format(
-        max_dict_grid["twoF"],
-        ", ".join(
-            [
-                "{:.4e} in {:s}".format(max_dict_grid[key] - inj[key], key)
-                for key in search_keys
-            ]
-        ),
-    )
-)
-print(
-    "max2F={:.4f} from MCMCSearch, offsets from injection: {:s}.".format(
-        max_2F_mcmc,
-        ", ".join(
-            [
-                "{:.4e} in {:s}".format(max_dict_mcmc[key] - inj[key], key)
-                for key in search_keys
-            ]
-        ),
-    )
-)
-# get additional point and interval estimators
-stats_dict_mcmc = mcmcsearch.get_summary_stats()
-print(
-    "mean   from MCMCSearch: offset from injection by      {:s},"
-    " or in fractions of 2sigma intervals: {:s}.".format(
-        ", ".join(
-            [
-                "{:.4e} in {:s}".format(stats_dict_mcmc[key]["mean"] - inj[key], key)
-                for key in search_keys
-            ]
-        ),
-        ", ".join(
-            [
-                "{:.2f}% in {:s}".format(
-                    100
-                    * np.abs(stats_dict_mcmc[key]["mean"] - inj[key])
-                    / (2 * stats_dict_mcmc[key]["std"]),
-                    key,
-                )
-                for key in search_keys
-            ]
-        ),
-    )
-)
-print(
-    "median from MCMCSearch: offset from injection by      {:s},"
-    " or in fractions of 90% confidence intervals: {:s}.".format(
-        ", ".join(
-            [
-                "{:.4e} in {:s}".format(stats_dict_mcmc[key]["median"] - inj[key], key)
-                for key in search_keys
-            ]
-        ),
-        ", ".join(
-            [
-                "{:.2f}% in {:s}".format(
-                    100
-                    * np.abs(stats_dict_mcmc[key]["median"] - inj[key])
-                    / (
-                        stats_dict_mcmc[key]["upper90"]
-                        - stats_dict_mcmc[key]["lower90"]
-                    ),
-                    key,
-                )
-                for key in search_keys
-            ]
-        ),
-    )
-)
-print()
-
-# do additional custom plotting
-print("Loading grid and MCMC search results for custom comparison plots...")
-gridfile = os.path.join(outdir, gridsearch.label + "_NA_GridSearch.txt")
-if not os.path.isfile(gridfile):
-    raise RuntimeError("Please first run PyFstat_example_simple_grid_search.py !")
-grid_res = pyfstat.helper_functions.read_txt_file_with_header(gridfile)
-mcmc_file = os.path.join(outdir, mcmcsearch.label + "_samples.dat")
-if not os.path.isfile(mcmc_file):
-    raise RuntimeError("Please first run PyFstat_example_simple_mcmc_search.py !")
-mcmc_res = pyfstat.helper_functions.read_txt_file_with_header(mcmc_file)
-
-zoom = {
-    "F0": [inj["F0"] - 10 * dF0, inj["F0"] + 10 * dF0],
-    "F1": [inj["F1"] - 5 * dF1, inj["F1"] + 5 * dF1],
-}
-
-# we'll use two local plotting functions to avoid code duplication in the sky case
-print("Creating MCMC-grid comparison plots...")
-
 
 def plot_grid_vs_samples(grid_res, mcmc_res, xkey, ykey):
+    """ local plotting function to avoid code duplication in the 4D case """
     plt.plot(grid_res[xkey], grid_res[ykey], ".", label="grid")
     plt.plot(mcmc_res[xkey], mcmc_res[ykey], ".", label="mcmc")
     plt.plot(inj[xkey], inj[ykey], "*k", label="injection")
@@ -329,6 +80,7 @@ def plot_grid_vs_samples(grid_res, mcmc_res, xkey, ykey):
 
 
 def plot_2F_scatter(res, label, xkey, ykey):
+    """ local plotting function to avoid code duplication in the 4D case """
     markersize = 3 if label == "grid" else 1
     sc = plt.scatter(res[xkey], res[ykey], c=res["twoF"], s=markersize)
     cb = plt.colorbar(sc)
@@ -354,11 +106,264 @@ def plot_2F_scatter(res, label, xkey, ykey):
     plt.close()
 
 
-# do the actual comparison plots
-plot_grid_vs_samples(grid_res, mcmc_res, "F0", "F1")
-plot_2F_scatter(grid_res, "grid", "F0", "F1")
-plot_2F_scatter(mcmc_res, "mcmc", "F0", "F1")
-if sky:
-    plot_grid_vs_samples(grid_res, mcmc_res, "Alpha", "Delta")
-    plot_2F_scatter(grid_res, "grid", "Alpha", "Delta")
-    plot_2F_scatter(mcmc_res, "mcmc", "Alpha", "Delta")
+if __name__ == "__main__":
+
+    print("Generating SFTs with injected signal...")
+    writer = pyfstat.Writer(
+        label="simulated_signal",
+        outdir=outdir,
+        tstart=tstart,
+        duration=duration,
+        detectors=detectors,
+        sqrtSX=sqrtSX,
+        Tsft=Tsft,
+        **inj,
+        Band=1,  # default band estimation would be too narrow for a wide grid/prior
+    )
+    writer.make_data()
+    print("")
+
+    # set up square search grid with fixed (F0,F1) mismatch
+    # and (optionally) some ad-hoc sky coverage
+    m = 0.001
+    dF0 = np.sqrt(12 * m) / (np.pi * duration)
+    dF1 = np.sqrt(180 * m) / (np.pi * duration ** 2)
+    DeltaF0 = 500 * dF0
+    DeltaF1 = 200 * dF1
+    if sky:
+        # cover less range to keep runtime down
+        DeltaF0 /= 10
+        DeltaF1 /= 10
+    F0s = [inj["F0"] - DeltaF0 / 2.0, inj["F0"] + DeltaF0 / 2.0, dF0]
+    F1s = [inj["F1"] - DeltaF1 / 2.0, inj["F1"] + DeltaF1 / 2.0, dF1]
+    F2s = [inj["F2"]]
+    search_keys = ["F0", "F1"]  # only the ones that aren't 0-width
+    if sky:
+        dSky = 0.01  # rather coarse to keep runtime down
+        DeltaSky = 10 * dSky
+        Alphas = [inj["Alpha"] - DeltaSky / 2.0, inj["Alpha"] + DeltaSky / 2.0, dSky]
+        Deltas = [inj["Delta"] - DeltaSky / 2.0, inj["Delta"] + DeltaSky / 2.0, dSky]
+        search_keys += ["Alpha", "Delta"]
+    else:
+        Alphas = [inj["Alpha"]]
+        Deltas = [inj["Delta"]]
+    search_keys_label = "".join(search_keys)
+
+    print("Performing GridSearch...")
+    gridsearch = pyfstat.GridSearch(
+        label="grid_search_" + search_keys_label,
+        outdir=outdir,
+        sftfilepattern=os.path.join(outdir, "*simulated_signal*sft"),
+        F0s=F0s,
+        F1s=F1s,
+        F2s=F2s,
+        Alphas=Alphas,
+        Deltas=Deltas,
+        tref=inj["tref"],
+        BSGL=False,
+    )
+    gridsearch.run()
+    gridsearch.print_max_twoF()
+    gridsearch.save_array_to_disk(gridsearch.data)
+
+    # do some plots of the GridSearch results
+    if not sky:  # this plotter can't currently deal with too large result arrays
+        print("Plotting 1D 2F distributions...")
+        for key in search_keys:
+            gridsearch.plot_1D(xkey=key, xlabel=labels[key], ylabel=labels["2F"])
+
+    print("Making GridSearch {:s} corner plot...".format("-".join(search_keys)))
+    vals = [
+        np.unique(gridsearch.data[:, gridsearch.keys.index(key)]) - inj[key]
+        for key in search_keys
+    ]
+    twoF = gridsearch.data[:, -1].reshape([len(kval) for kval in vals])
+    corner_labels = [
+        "$f - f_0$ [Hz]",
+        "$\\dot{f} - \\dot{f}_0$ [Hz/s]",
+    ]
+    if sky:
+        corner_labels.append("$\\alpha - \\alpha_0$")
+        corner_labels.append("$\\delta - \\delta_0$")
+    corner_labels.append(labels["2F"])
+    gridcorner_fig, gridcorner_axes = pyfstat.gridcorner(
+        twoF, vals, projection="log_mean", labels=corner_labels, whspace=0.1, factor=1.8
+    )
+    gridcorner_fig.savefig(os.path.join(outdir, gridsearch.label + "_corner.png"))
+    plt.close(gridcorner_fig)
+    print("")
+
+    print("Performing MCMCSearch...")
+    # set up priors in F0 and F1 (over)covering the grid ranges
+    if sky:  # MCMC will still be fast in 4D with wider range than grid
+        DeltaF0 *= 50
+        DeltaF1 *= 50
+    theta_prior = {
+        "F0": {
+            "type": "unif",
+            "lower": inj["F0"] - DeltaF0 / 2.0,
+            "upper": inj["F0"] + DeltaF0 / 2.0,
+        },
+        "F1": {
+            "type": "unif",
+            "lower": inj["F1"] - DeltaF1 / 2.0,
+            "upper": inj["F1"] + DeltaF1 / 2.0,
+        },
+        "F2": inj["F2"],
+    }
+    if sky:
+        # also implicitly covering twice the grid range here
+        theta_prior["Alpha"] = {
+            "type": "unif",
+            "lower": inj["Alpha"] - DeltaSky,
+            "upper": inj["Alpha"] + DeltaSky,
+        }
+        theta_prior["Delta"] = {
+            "type": "unif",
+            "lower": inj["Delta"] - DeltaSky,
+            "upper": inj["Delta"] + DeltaSky,
+        }
+    else:
+        theta_prior["Alpha"] = inj["Alpha"]
+        theta_prior["Delta"] = inj["Delta"]
+    # ptemcee sampler settings - in a real application we might want higher values
+    ntemps = 2
+    log10beta_min = -1
+    nwalkers = 100
+    nsteps = [200, 200]  # [burnin,production]
+
+    mcmcsearch = pyfstat.MCMCSearch(
+        label="mcmc_search_" + search_keys_label,
+        outdir=outdir,
+        sftfilepattern=os.path.join(outdir, "*simulated_signal*sft"),
+        theta_prior=theta_prior,
+        tref=inj["tref"],
+        nsteps=nsteps,
+        nwalkers=nwalkers,
+        ntemps=ntemps,
+        log10beta_min=log10beta_min,
+    )
+    # walker plot is generated during main run of the search class
+    mcmcsearch.run(
+        walker_plot_args={"plot_det_stat": True, "injection_parameters": inj}
+    )
+    mcmcsearch.print_summary()
+
+    # call some built-in plotting methods
+    # these can all highlight the injection parameters, too
+    print("Making MCMCSearch {:s} corner plot...".format("-".join(search_keys)))
+    mcmcsearch.plot_corner(truths=inj)
+    print("Making MCMCSearch prior-posterior comparison plot...")
+    mcmcsearch.plot_prior_posterior(injection_parameters=inj)
+    print("")
+
+    # NOTE: everything below here is just custom commandline output and plotting
+    # for this particular example, which uses the PyFstat outputs,
+    # but isn't very instructive if you just want to learn the main usage of the package.
+
+    # some informative command-line output comparing search results and injection
+    # get max of GridSearch, contains twoF and all Doppler parameters in the dict
+    max_dict_grid = gridsearch.get_max_twoF()
+    # same for MCMCSearch, here twoF is separate, and non-sampled parameters are not included either
+    max_dict_mcmc, max_2F_mcmc = mcmcsearch.get_max_twoF()
+    print(
+        "max2F={:.4f} from GridSearch, offsets from injection: {:s}.".format(
+            max_dict_grid["twoF"],
+            ", ".join(
+                [
+                    "{:.4e} in {:s}".format(max_dict_grid[key] - inj[key], key)
+                    for key in search_keys
+                ]
+            ),
+        )
+    )
+    print(
+        "max2F={:.4f} from MCMCSearch, offsets from injection: {:s}.".format(
+            max_2F_mcmc,
+            ", ".join(
+                [
+                    "{:.4e} in {:s}".format(max_dict_mcmc[key] - inj[key], key)
+                    for key in search_keys
+                ]
+            ),
+        )
+    )
+    # get additional point and interval estimators
+    stats_dict_mcmc = mcmcsearch.get_summary_stats()
+    print(
+        "mean   from MCMCSearch: offset from injection by      {:s},"
+        " or in fractions of 2sigma intervals: {:s}.".format(
+            ", ".join(
+                [
+                    "{:.4e} in {:s}".format(
+                        stats_dict_mcmc[key]["mean"] - inj[key], key
+                    )
+                    for key in search_keys
+                ]
+            ),
+            ", ".join(
+                [
+                    "{:.2f}% in {:s}".format(
+                        100
+                        * np.abs(stats_dict_mcmc[key]["mean"] - inj[key])
+                        / (2 * stats_dict_mcmc[key]["std"]),
+                        key,
+                    )
+                    for key in search_keys
+                ]
+            ),
+        )
+    )
+    print(
+        "median from MCMCSearch: offset from injection by      {:s},"
+        " or in fractions of 90% confidence intervals: {:s}.".format(
+            ", ".join(
+                [
+                    "{:.4e} in {:s}".format(
+                        stats_dict_mcmc[key]["median"] - inj[key], key
+                    )
+                    for key in search_keys
+                ]
+            ),
+            ", ".join(
+                [
+                    "{:.2f}% in {:s}".format(
+                        100
+                        * np.abs(stats_dict_mcmc[key]["median"] - inj[key])
+                        / (
+                            stats_dict_mcmc[key]["upper90"]
+                            - stats_dict_mcmc[key]["lower90"]
+                        ),
+                        key,
+                    )
+                    for key in search_keys
+                ]
+            ),
+        )
+    )
+    print()
+
+    # do additional custom plotting
+    print("Loading grid and MCMC search results for custom comparison plots...")
+    gridfile = os.path.join(outdir, gridsearch.label + "_NA_GridSearch.txt")
+    if not os.path.isfile(gridfile):
+        raise RuntimeError("Please first run PyFstat_example_simple_grid_search.py !")
+    grid_res = pyfstat.helper_functions.read_txt_file_with_header(gridfile)
+    mcmc_file = os.path.join(outdir, mcmcsearch.label + "_samples.dat")
+    if not os.path.isfile(mcmc_file):
+        raise RuntimeError("Please first run PyFstat_example_simple_mcmc_search.py !")
+    mcmc_res = pyfstat.helper_functions.read_txt_file_with_header(mcmc_file)
+
+    zoom = {
+        "F0": [inj["F0"] - 10 * dF0, inj["F0"] + 10 * dF0],
+        "F1": [inj["F1"] - 5 * dF1, inj["F1"] + 5 * dF1],
+    }
+
+    print("Creating MCMC-grid comparison plots...")
+    plot_grid_vs_samples(grid_res, mcmc_res, "F0", "F1")
+    plot_2F_scatter(grid_res, "grid", "F0", "F1")
+    plot_2F_scatter(mcmc_res, "mcmc", "F0", "F1")
+    if sky:
+        plot_grid_vs_samples(grid_res, mcmc_res, "Alpha", "Delta")
+        plot_2F_scatter(grid_res, "grid", "Alpha", "Delta")
+        plot_2F_scatter(mcmc_res, "mcmc", "Alpha", "Delta")

--- a/examples/transient_examples/PyFstat_example_make_data_for_short_transient_search.py
+++ b/examples/transient_examples/PyFstat_example_make_data_for_short_transient_search.py
@@ -1,5 +1,14 @@
 #!/usr/bin/env python
 
+""" An example to generate data with a short transient signal.
+
+This can be run either stand-alone (will just generate SFT files and nothing else);
+or it is also being imported from
+PyFstat_example_short_transient_grid_search.py
+and
+PyFstat_example_short_transient_MCMC_search.py
+"""
+
 import pyfstat
 import os
 
@@ -25,25 +34,27 @@ detectors = "H1,L1"
 
 Tsft = 1800
 
-transient = pyfstat.Writer(
-    label="simulated_transient_signal",
-    outdir=outdir,
-    tref=tref,
-    tstart=tstart,
-    duration=duration,
-    F0=F0,
-    F1=F1,
-    F2=F2,
-    Alpha=Alpha,
-    Delta=Delta,
-    h0=h0,
-    cosi=cosi,
-    detectors=detectors,
-    sqrtSX=sqrtSX,
-    transientStartTime=transient_tstart,
-    transientTau=transient_duration,
-    transientWindowType="rect",
-    Tsft=Tsft,
-    Band=0.1,
-)
-transient.make_data()
+if __name__ == "__main__":
+
+    transient = pyfstat.Writer(
+        label="simulated_transient_signal",
+        outdir=outdir,
+        tref=tref,
+        tstart=tstart,
+        duration=duration,
+        F0=F0,
+        F1=F1,
+        F2=F2,
+        Alpha=Alpha,
+        Delta=Delta,
+        h0=h0,
+        cosi=cosi,
+        detectors=detectors,
+        sqrtSX=sqrtSX,
+        transientStartTime=transient_tstart,
+        transientTau=transient_duration,
+        transientWindowType="rect",
+        Tsft=Tsft,
+        Band=0.1,
+    )
+    transient.make_data()

--- a/examples/transient_examples/PyFstat_example_short_transient_MCMC_search.py
+++ b/examples/transient_examples/PyFstat_example_short_transient_MCMC_search.py
@@ -1,79 +1,79 @@
 #!/usr/bin/env python
 
+""" An example MCMC-based search for a short transient signal. """
+
 import pyfstat
 import os
 import numpy as np
+import PyFstat_example_make_data_for_short_transient_search as data
 
-outdir = os.path.join("PyFstat_example_data", "PyFstat_example_short_transient_search")
-if not os.path.isdir(outdir) or not np.any(
-    [f.endswith(".sft") for f in os.listdir(outdir)]
-):
-    raise RuntimeError(
-        "Please first run PyFstat_example_make_data_for_short_transient_search.py !"
+if __name__ == "__main__":
+
+    if not os.path.isdir(data.outdir) or not np.any(
+        [f.endswith(".sft") for f in os.listdir(data.outdir)]
+    ):
+        raise RuntimeError(
+            "Please first run PyFstat_example_make_data_for_short_transient_search.py !"
+        )
+
+    inj = {
+        "tref": data.tstart,
+        "F0": data.F0,
+        "F1": data.F1,
+        "F2": data.F2,
+        "Alpha": data.Alpha,
+        "Delta": data.Delta,
+        "transient_tstart": data.transient_tstart,
+        "transient_duration": data.transient_duration,
+    }
+
+    DeltaF0 = 1e-2
+    DeltaF1 = 1e-9
+
+    theta_prior = {
+        "F0": {
+            "type": "unif",
+            "lower": inj["F0"] - DeltaF0 / 2.0,
+            "upper": inj["F0"] + DeltaF0 / 2.0,
+        },
+        "F1": {
+            "type": "unif",
+            "lower": inj["F1"] - DeltaF1 / 2.0,
+            "upper": inj["F1"] + DeltaF1 / 2.0,
+        },
+        "F2": inj["F2"],
+        "Alpha": inj["Alpha"],
+        "Delta": inj["Delta"],
+        "transient_tstart": {
+            "type": "unif",
+            "lower": data.tstart,
+            "upper": data.tstart + data.duration - 2 * data.Tsft,
+        },
+        "transient_duration": {
+            "type": "unif",
+            "lower": 2 * data.Tsft,
+            "upper": data.duration - 2 * data.Tsft,
+        },
+    }
+
+    ntemps = 2
+    log10beta_min = -1
+    nwalkers = 100
+    nsteps = [100, 100]
+
+    mcmc = pyfstat.MCMCTransientSearch(
+        label="transient_search",
+        outdir=data.outdir,
+        sftfilepattern=os.path.join(data.outdir, "*simulated_transient_signal*sft"),
+        theta_prior=theta_prior,
+        tref=inj["tref"],
+        nsteps=nsteps,
+        nwalkers=nwalkers,
+        ntemps=ntemps,
+        log10beta_min=log10beta_min,
+        transientWindowType="rect",
     )
-
-tstart = 1000000000
-duration = 2 * 86400
-Tsft = 1800
-
-inj = {
-    "tref": tstart,
-    "F0": 30.0,
-    "F1": -1e-10,
-    "F2": 0,
-    "Alpha": 0.5,
-    "Delta": 1,
-    "transient_tstart": tstart + 0.25 * duration,
-    "transient_duration": 0.5 * duration,
-}
-
-DeltaF0 = 1e-2
-DeltaF1 = 1e-9
-
-theta_prior = {
-    "F0": {
-        "type": "unif",
-        "lower": inj["F0"] - DeltaF0 / 2.0,
-        "upper": inj["F0"] + DeltaF0 / 2.0,
-    },
-    "F1": {
-        "type": "unif",
-        "lower": inj["F1"] - DeltaF1 / 2.0,
-        "upper": inj["F1"] + DeltaF1 / 2.0,
-    },
-    "F2": inj["F2"],
-    "Alpha": inj["Alpha"],
-    "Delta": inj["Delta"],
-    "transient_tstart": {
-        "type": "unif",
-        "lower": tstart,
-        "upper": tstart + duration - 2 * Tsft,
-    },
-    "transient_duration": {
-        "type": "unif",
-        "lower": 2 * Tsft,
-        "upper": duration - 2 * Tsft,
-    },
-}
-
-ntemps = 2
-log10beta_min = -1
-nwalkers = 100
-nsteps = [100, 100]
-
-mcmc = pyfstat.MCMCTransientSearch(
-    label="transient_search",
-    outdir=outdir,
-    sftfilepattern=os.path.join(outdir, "*simulated_transient_signal*sft"),
-    theta_prior=theta_prior,
-    tref=inj["tref"],
-    nsteps=nsteps,
-    nwalkers=nwalkers,
-    ntemps=ntemps,
-    log10beta_min=log10beta_min,
-    transientWindowType="rect",
-)
-mcmc.run(walker_plot_args={"plot_det_stat": True, "injection_parameters": inj})
-mcmc.print_summary()
-mcmc.plot_corner(add_prior=True, truths=inj)
-mcmc.plot_prior_posterior(injection_parameters=inj)
+    mcmc.run(walker_plot_args={"plot_det_stat": True, "injection_parameters": inj})
+    mcmc.print_summary()
+    mcmc.plot_corner(add_prior=True, truths=inj)
+    mcmc.plot_prior_posterior(injection_parameters=inj)

--- a/examples/transient_examples/PyFstat_example_short_transient_grid_search.py
+++ b/examples/transient_examples/PyFstat_example_short_transient_grid_search.py
@@ -1,82 +1,75 @@
 #!/usr/bin/env python
 
+""" An example grid-based search for a short transient signal. """
+
 import pyfstat
 import os
 import numpy as np
+import PyFstat_example_make_data_for_short_transient_search as data
 
-outdir = os.path.join("PyFstat_example_data", "PyFstat_example_short_transient_search")
-if not os.path.isdir(outdir) or not np.any(
-    [f.endswith(".sft") for f in os.listdir(outdir)]
-):
-    raise RuntimeError(
-        "Please first run PyFstat_example_make_data_for_short_transient_search.py !"
+if __name__ == "__main__":
+
+    if not os.path.isdir(data.outdir) or not np.any(
+        [f.endswith(".sft") for f in os.listdir(data.outdir)]
+    ):
+        raise RuntimeError(
+            "Please first run PyFstat_example_make_data_for_short_transient_search.py !"
+        )
+
+    maxStartTime = data.tstart + data.duration
+
+    m = 0.001
+    dF0 = np.sqrt(12 * m) / (np.pi * data.duration)
+    DeltaF0 = 100 * dF0
+    F0s = [data.F0 - DeltaF0 / 2.0, data.F0 + DeltaF0 / 2.0, dF0]
+    F1s = [data.F1]
+    F2s = [data.F2]
+    Alphas = [data.Alpha]
+    Deltas = [data.Delta]
+
+    print("Standard CW search:")
+    search1 = pyfstat.GridSearch(
+        label="CW",
+        outdir=data.outdir,
+        sftfilepattern=os.path.join(data.outdir, "*simulated_transient_signal*sft"),
+        F0s=F0s,
+        F1s=F1s,
+        F2s=F2s,
+        Alphas=Alphas,
+        Deltas=Deltas,
+        tref=data.tref,
+        minStartTime=data.tstart,
+        maxStartTime=maxStartTime,
+        BSGL=False,
     )
+    search1.run()
+    search1.print_max_twoF()
+    search1.save_array_to_disk(search1.data)
 
-F0 = 30.0
-F1 = -1e-10
-F2 = 0
-Alpha = 0.5
-Delta = 1
+    search1.plot_1D(xkey="F0", xlabel="freq [Hz]", ylabel="$2\\mathcal{F}$")
 
-minStartTime = 1000000000
-maxStartTime = minStartTime + 2 * 86400
-Tspan = maxStartTime - minStartTime
-tref = minStartTime
+    print("with t0,tau bands:")
+    search2 = pyfstat.TransientGridSearch(
+        label="tCW",
+        outdir=data.outdir,
+        sftfilepattern=os.path.join(data.outdir, "*simulated_transient_signal*sft"),
+        F0s=F0s,
+        F1s=F1s,
+        F2s=F2s,
+        Alphas=Alphas,
+        Deltas=Deltas,
+        tref=data.tref,
+        minStartTime=data.tstart,
+        maxStartTime=maxStartTime,
+        transientWindowType="rect",
+        t0Band=data.duration - 2 * data.Tsft,
+        tauBand=data.duration,
+        BSGL=False,
+        outputTransientFstatMap=True,
+        tCWFstatMapVersion="lal",
+    )
+    search2.run()
+    search2.print_max_twoF()
+    search2.save_array_to_disk(search2.data)
 
-Tsft = 1800
-
-m = 0.001
-dF0 = np.sqrt(12 * m) / (np.pi * Tspan)
-DeltaF0 = 100 * dF0
-F0s = [F0 - DeltaF0 / 2.0, F0 + DeltaF0 / 2.0, dF0]
-F1s = [F1]
-F2s = [F2]
-Alphas = [Alpha]
-Deltas = [Delta]
-
-print("Standard CW search:")
-search1 = pyfstat.GridSearch(
-    label="CW",
-    outdir=outdir,
-    sftfilepattern=os.path.join(outdir, "*simulated_transient_signal*sft"),
-    F0s=F0s,
-    F1s=F1s,
-    F2s=F2s,
-    Alphas=Alphas,
-    Deltas=Deltas,
-    tref=tref,
-    minStartTime=minStartTime,
-    maxStartTime=maxStartTime,
-    BSGL=False,
-)
-search1.run()
-search1.print_max_twoF()
-search1.save_array_to_disk(search1.data)
-
-search1.plot_1D(xkey="F0", xlabel="freq [Hz]", ylabel="$2\\mathcal{F}$")
-
-print("with t0,tau bands:")
-search2 = pyfstat.TransientGridSearch(
-    label="tCW",
-    outdir=outdir,
-    sftfilepattern=os.path.join(outdir, "*simulated_transient_signal*sft"),
-    F0s=F0s,
-    F1s=F1s,
-    F2s=F2s,
-    Alphas=Alphas,
-    Deltas=Deltas,
-    tref=tref,
-    minStartTime=minStartTime,
-    maxStartTime=maxStartTime,
-    transientWindowType="rect",
-    t0Band=Tspan - 2 * Tsft,
-    tauBand=Tspan,
-    BSGL=False,
-    outputTransientFstatMap=True,
-    tCWFstatMapVersion="lal",
-)
-search2.run()
-search2.print_max_twoF()
-search2.save_array_to_disk(search2.data)
-
-search2.plot_1D(xkey="F0", xlabel="freq [Hz]", ylabel="$2\\mathcal{F}$")
+    search2.plot_1D(xkey="F0", xlabel="freq [Hz]", ylabel="$2\\mathcal{F}$")

--- a/pyfstat/__init__.py
+++ b/pyfstat/__init__.py
@@ -30,6 +30,7 @@ from .grid_based_searches import (
     SliceGridSearch,
     TransientGridSearch,
 )
+from .gridcorner import gridcorner
 
 from ._version import get_versions
 

--- a/pyfstat/gridcorner.py
+++ b/pyfstat/gridcorner.py
@@ -1,0 +1,258 @@
+""" A corner plotting tool for an array (grid) of dependent values.
+
+Given an N-dimensional set of data (i.e. some function evaluated over a grid
+of coordinates), plot all possible 1D and 2D projections in the style of a
+'corner' plot.
+
+This code has been copied from Gregory Ashton's repository
+https://gitlab.aei.uni-hannover.de/GregAshton/gridcorner
+and it uses both the central idea and some specific code from
+Daniel Foreman-Mackey's
+https://github.com/dfm/corner.py
+re-used under the following licence requirements:
+
+Copyright (c) 2013-2020 Daniel Foreman-Mackey
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The views and conclusions contained in the software and documentation are those
+of the authors and should not be interpreted as representing official policies,
+either expressed or implied, of the FreeBSD Project.
+"""
+
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.ticker import MaxNLocator
+
+try:
+    from scipy.special import logsumexp
+except ImportError:
+    from scipy.misc import logsumexp
+
+
+def log_mean(loga, axis):
+    """Calculate the log(<a>) mean
+
+    Given `N` logged value `log`, calculate the log_mean
+    `log(<loga>)=log(sum(np.exp(loga))) - log(N)`. Useful for marginalizing
+    over logged likelihoods for example.
+
+    Parameters
+    ----------
+    loga: array_like
+        Input_array.
+    axies: None or int or type of ints, optional
+        Axis or axes over which the sum is taken. By default axis is None, and
+        all elements are summed.
+    Returns
+    -------
+    log_mean: ndarry
+        The logged average value (shape loga.shape)
+    """
+    loga = np.array(loga)
+    N = np.prod([loga.shape[i] for i in axis])
+    return logsumexp(loga, axis) - np.log(N)
+
+
+def max_slice(D, axis):
+    """ Return the slice along the given axis """
+    idxs = [range(D.shape[j]) for j in range(D.ndim)]
+    max_idx = list(np.unravel_index(D.argmax(), D.shape))
+    for k in np.atleast_1d(axis):
+        idxs[k] = [max_idx[k]]
+    res = np.squeeze(D[np.ix_(*tuple(idxs))])
+    return res
+
+
+def idx_array_slice(D, axis, slice_idx):
+    """ Return the slice along the given axis """
+    idxs = [range(D.shape[j]) for j in range(D.ndim)]
+    for k in np.atleast_1d(axis):
+        idxs[k] = [slice_idx[k]]
+    res = np.squeeze(D[np.ix_(*tuple(idxs))])
+    return res
+
+
+def _get_fig_and_axes(ndim, factor, whspace):
+    lbdim = 0.5 * factor  # size of left/bottom margin
+    trdim = 0.2 * factor  # size of top/right margin
+    plotdim = factor * ndim + factor * (ndim - 1.0) * whspace
+    dim = lbdim + plotdim + trdim
+    fig, axes = plt.subplots(ndim, ndim, figsize=(dim, dim))
+    axes = np.atleast_2d(axes)  # allow single-parameter plots
+
+    # Format the figure.
+    lb = lbdim / dim
+    tr = (lbdim + plotdim) / dim
+    fig.subplots_adjust(
+        left=lb, bottom=lb, right=0.98 * tr, top=tr, wspace=whspace, hspace=whspace
+    )
+    return fig, axes
+
+
+def gridcorner(
+    D,
+    xyz,
+    labels=None,
+    projection="max_slice",
+    max_n_ticks=4,
+    factor=2,
+    whspace=0.05,
+    showDvals=True,
+    lines=None,
+    label_offset=0.4,
+    **kwargs
+):
+    """Generate a grid corner plot
+
+    Parameters
+    ----------
+    D: array_like
+        N-dimensional data to plot, `D.shape` should be  `(n1, n2,..., nN)`,
+        where `N`, is the number of grid points along dimension `i`.
+    xyz: list
+        List of 1-dimensional arrays of coordinates. `xyz[i]` should have
+        length `N` (see help for `D`).
+    labels: list
+        N+1 length list of labels; the first N correspond to the coordinates
+        labels, the final label is for the dependent (D) variable.
+    projection: str or func
+        If a string, one of `{"log_mean", "max_slice"} to use inbuilt functions
+        to calculate either the logged mean or maximum slice projection. Else
+        a function to use for projection, must take an `axis` argument. Default
+        is `gridcorner.max_slice()`, to project out a slice along the
+        maximum.
+    max_n_ticks: int
+        Number of ticks for x and y axis of the `pcolormesh` plots.
+    factor: float
+        Controls the size of one window.
+    showDvals: bool
+        If true (default) show the D values on the right-hand-side of the
+        1D plots and add a label.
+    lines: array_like
+        N-dimensional list of values to delineate.
+
+    Returns
+    -------
+    fig, axes:
+        The figure and NxN set of axes
+
+    """
+
+    ndim = D.ndim
+    fig, axes = _get_fig_and_axes(ndim, factor, whspace)
+
+    if type(projection) == str:
+        if projection in ["log_mean"]:
+            projection = log_mean
+        elif projection in ["max_slice"]:
+            projection = max_slice
+        else:
+            raise ValueError("Projection {} not understood".format(projection))
+
+    for i in range(ndim):
+        projection_1D(
+            axes[i, i],
+            xyz[i],
+            D,
+            i,
+            projection=projection,
+            showDvals=showDvals,
+            lines=lines,
+            **kwargs
+        )
+        for j in range(ndim):
+            ax = axes[i, j]
+
+            if j > i:
+                ax.set_frame_on(False)
+                ax.set_xticks([])
+                ax.set_yticks([])
+                continue
+
+            ax.get_shared_x_axes().join(axes[ndim - 1, j], ax)
+            if i < ndim - 1:
+                ax.set_xticklabels([])
+            if j < i:
+                ax.get_shared_y_axes().join(axes[i, i - 1], ax)
+                if j > 0:
+                    ax.set_yticklabels([])
+            if j == i:
+                continue
+
+            ax.xaxis.set_major_locator(MaxNLocator(max_n_ticks, prune="upper"))
+            ax.yaxis.set_major_locator(MaxNLocator(max_n_ticks, prune="upper"))
+
+            ax, pax = projection_2D(
+                ax,
+                xyz[i],
+                xyz[j],
+                D,
+                i,
+                j,
+                lines=lines,
+                projection=projection,
+                **kwargs
+            )
+
+    if labels:
+        for i in range(ndim):
+            axes[-1, i].set_xlabel(labels[i])
+            if i > 0:
+                axes[i, 0].set_ylabel(labels[i])
+            if showDvals:
+                axes[i, i].set_ylabel(labels[-1])
+
+            for ax in axes[:, 0]:
+                ax.yaxis.set_label_coords(-label_offset, 0.5)
+                for ax in axes[-1, :]:
+                    ax.xaxis.set_label_coords(0.5, -label_offset)
+    return fig, axes
+
+
+def projection_2D(ax, x, y, D, xidx, yidx, projection, lines=None, **kwargs):
+    flat_idxs = list(range(D.ndim))
+    flat_idxs.remove(xidx)
+    flat_idxs.remove(yidx)
+    D2D = projection(D, axis=tuple(flat_idxs), **kwargs)
+    X, Y = np.meshgrid(x, y, indexing="ij")
+    pax = ax.pcolormesh(Y, X, D2D.T, vmin=D.min(), vmax=D.max())
+    if lines:
+        ax.axhline(lines[xidx], lw=0.5, color="w")
+        ax.axvline(lines[yidx], lw=0.5, color="w")
+    return ax, pax
+
+
+def projection_1D(ax, x, D, xidx, projection, showDvals=True, lines=None, **kwargs):
+    flat_idxs = list(range(D.ndim))
+    flat_idxs.remove(xidx)
+    D1D = projection(D, axis=tuple(flat_idxs), **kwargs)
+    ax.plot(x, D1D, color="k")
+    if showDvals:
+        ax.yaxis.tick_right()
+        ax.yaxis.set_label_position("right")
+    else:
+        ax.yaxis.set_ticklabels([])
+    if lines:
+        ax.axvline(lines[xidx], lw=0.5, color="C0")
+    return ax


### PR DESCRIPTION
See #221. Sphinx doesn't play well with executable scripts out-of-the-box, so here are two possible hacky solutions. Both will require a simple helper script to auto-generate the necessary `.rst` files so they can be easily updated as the examples suite evolves. I think solution 2 is better.

Either way, it requires properly restructuring all examples with `if __name__ == "__main__":` to be import-safe, and some adding of help strings describing what the example does (a good idea anyway). So this will be a "draft" for now; it also should wait until after #171 is merged to avoid conflicts.

Example output: 
[pyfstat-docs-7cda9931241c6a682a4a1ba48f789e6ba342597c.tar.gz](https://github.com/PyFstat/PyFstat/files/5751557/pyfstat-docs-7cda9931241c6a682a4a1ba48f789e6ba342597c.tar.gz)
