### PR TITLE
add .readthedocs.yml to allow using both requirements.txt files

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,25 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+
+# Build documentation with MkDocs
+#mkdocs:
+#  configuration: mkdocs.yml
+
+# Optionally build your docs in additional formats such as PDF
+formats:
+  - pdf
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.8
+  install:
+    - requirements: docs/requirements.txt
+    - requirements: requirements.txt


### PR DESCRIPTION
The [first readthedocs builds off master](https://readthedocs.org/projects/pyfstat/builds/12655554/) actually didn't include the autodoc-generated contents as they failed to import dependencies. The web interface only allows to load in one `requirements.txt` file; let's see if through a yml we can use both the one in `docs` and the root-level one of PyFstat itself.

PS: as per https://docs.readthedocs.io/en/stable/config-file/v2.html#requirements-file