### PR TITLE
MCMC: initiate search object before checking for old data, plus cumulative fixes

### DIFF
--- a/examples/glitch_examples/PyFstat_example_glitch_robust_directed_MCMC_search_on_1_glitch.py
+++ b/examples/glitch_examples/PyFstat_example_glitch_robust_directed_MCMC_search_on_1_glitch.py
@@ -89,7 +89,7 @@ mcmc.plot_corner(
     truth_color="C3",
 )
 
-mcmc.plot_cumulative_max()
+mcmc.plot_cumulative_max(savefig=True)
 
 print(("Prior widths =", F0_width, F1_width))
 print(("Actual run time = {}".format(dT)))

--- a/examples/glitch_examples/PyFstat_example_standard_directed_MCMC_search_on_1_glitch.py
+++ b/examples/glitch_examples/PyFstat_example_standard_directed_MCMC_search_on_1_glitch.py
@@ -54,4 +54,4 @@ mcmc.transform_dictionary["F1"] = dict(
 mcmc.run()
 mcmc.print_summary()
 mcmc.plot_corner()
-mcmc.plot_cumulative_max()
+mcmc.plot_cumulative_max(savefig=True)

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -1156,6 +1156,7 @@ class ComputeFstat(BaseSearchClass):
             Optional axis formatting options.
         savefig : bool
             If true, save the figure in outdir.
+            If false, return an axis object.
         label: str
             Output filename (ignored unless savefig is True).
         outdir: str

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -621,6 +621,8 @@ class MCMCSearch(BaseSearchClass):
 
         """
 
+        self._initiate_search_object()
+
         self.old_data_is_okay_to_use = self._check_old_data_is_okay_to_use()
         if self.old_data_is_okay_to_use is True:
             logging.warning("Using saved data from {}".format(self.pickle_path))
@@ -632,7 +634,6 @@ class MCMCSearch(BaseSearchClass):
             self.chain = d["chain"]
             return
 
-        self._initiate_search_object()
         self._estimate_run_time()
 
         walker_plot_args = walker_plot_args or {}
@@ -1242,9 +1243,6 @@ class MCMCSearch(BaseSearchClass):
             if key not in d:
                 d[key] = val
 
-        if hasattr(self, "search") is False:
-            self._initiate_search_object()
-
         self.search.plot_twoF_cumulative(
             CFS_input=d, label=self.label, outdir=self.outdir, **kwargs
         )
@@ -1775,6 +1773,10 @@ class MCMCSearch(BaseSearchClass):
         twoF within `threshold` (relative) to the max twoF
 
         """
+        if not hasattr(self, "search"):
+            raise RuntimeError(
+                "Object has no self.lnlikes attribute, please execute .run() first."
+            )
         if any(np.isposinf(self.lnlikes)):
             logging.info("lnlike values contain positive infinite values")
         if any(np.isneginf(self.lnlikes)):

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -2432,7 +2432,17 @@ class MCMCGlitchSearch(MCMCSearch):
             p0[:, :, -self.nglitch :] = np.sort(p0[:, :, -self.nglitch :], axis=2)
         return p0
 
-    def plot_cumulative_max(self):
+    def plot_cumulative_max(self, savefig=False):
+        """Here we override the standard version to deal with the split at glitches.
+
+        Parameters
+        ----------
+        savefig: boolean
+            included for consistency with core plot_twoF_cumulative() function.
+            If true, save the figure in outdir.
+            If false, return an axis object.
+        """
+
         logging.info("Getting cumulative 2F")
         fig, ax = plt.subplots()
         d, maxtwoF = self.get_max_twoF()
@@ -2489,8 +2499,10 @@ class MCMCGlitchSearch(MCMCSearch):
             ax.plot(actual_ts + taus, twoFs)
 
         ax.set_xlabel("GPS time")
-        fig.savefig(os.path.join(self.outdir, self.label + "_twoFcumulative.png"))
-        plt.close(fig)
+        if savefig:
+            fig.savefig(os.path.join(self.outdir, self.label + "_twoFcumulative.png"))
+            plt.close(fig)
+        return ax
 
     def get_savetxt_fmt(self):
         fmt = helper_functions.get_doppler_params_output_format(


### PR DESCRIPTION
   - Fixes #228 (i.e. re-run safety of `MCMCGlitchSearch.plot_cumulative_max()`
   - `MCMCSearch.plot_cumulative_max()` now no longer needs to re-initiate the search object to be on the safe side
   - It still cannot be run before `.run()`, but I've also added an earlier explicit error message about that at the point where the old version would already have failed too.
   - As discussed, this means SFTs are also checked and a catalog loaded _before_ reusing data from disk. But another check would have already failed if SFTs were deleted and only the results pickle file still kept, so this doesn't hurt in that case, and since it's only loading a catalog (not the full data, I think at least that's what it does) it should also not slow things down too much.
   - Fixes `PyFstat_example_standard_directed_MCMC_search_on_1_glitch.py` to actually save the cumulative plot.
   - And changed the overridden `MCMCGlitchSearch.plot_cumulative_max()` to be consistent with the base version, i.e. it now takes a `savefig` argument as well which also defaults to `false`.