### PR TITLE
sphinx: autoclass_content = 'both'

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -59,3 +59,8 @@ html_theme = "sphinx_rtd_theme"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
+
+# -- autodoc options ---------------------------------------------------------
+# what content will be inserted into the main body of an autoclass directive
+# both: the class’ and the __init__ method’s docstring are concatenated and inserted.
+autoclass_content = "both"


### PR DESCRIPTION
- includes documentation of each __init__() method into the documentation of its class