### PR TITLE
ComputeFstat: remove get_full_CFSv2_output()

### DIFF
--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -1246,30 +1246,6 @@ class ComputeFstat(BaseSearchClass):
             plt.close()
         return ax
 
-    def get_full_CFSv2_output(self, tstart, tend, F0, F1, F2, Alpha, Delta, tref):
-        """ Basic wrapper around CFSv2 to get the full (h0..) output """
-        cl_CFSv2 = "lalapps_ComputeFstatistic_v2 --minStartTime={} --maxStartTime={} --Freq={} --f1dot={} --f2dot={} --Alpha={} --Delta={} --refTime={} --DataFiles='{}' --outputLoudest='{}' --ephemEarth={} --ephemSun={}"
-        LoudestFile = "loudest.temp"
-        helper_functions.run_commandline(
-            cl_CFSv2.format(
-                tstart,
-                tend,
-                F0,
-                F1,
-                F2,
-                Alpha,
-                Delta,
-                tref,
-                self.sftfilepattern,
-                LoudestFile,
-                self.earth_ephem,
-                self.sun_ephem,
-            )
-        )
-        loudest = self.read_par(filename=LoudestFile, raise_error=False)
-        os.remove(LoudestFile)
-        return loudest
-
     def write_atoms_to_file(self, fnamebase=""):
         multiFatoms = getattr(self.FstatResults, "multiFatoms", None)
         if multiFatoms and multiFatoms[0]:


### PR DESCRIPTION
This specialised CFSv2 wrapper has been unused since #215. Contrary to its name, it actually was dedicated to getting "loudest" outputs. MCMCSearch has its own version in `generate_loudest()` of that which has been more recently maintained, and if there is a need to have an equivalent at the core level (e.g. so grid-based searches can also use it), it'd be better to promote that one.