### PR TITLE
sphinx: autodoc_member_order = "bysource"

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,3 +64,6 @@ html_static_path = ["_static"]
 # what content will be inserted into the main body of an autoclass directive
 # both: the class’ and the __init__ method’s docstring are concatenated and inserted.
 autoclass_content = "both"
+
+# how to sort automatically documented members
+autodoc_member_order = "bysource"


### PR DESCRIPTION
Order class members (and classes within a file) by order in the source .py file, instead of resorting alphabetically.