### PR TITLE
Writer.run_makefakedata(): remove dysfunctional code for removing old files

### DIFF
--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -753,12 +753,6 @@ class Writer(BaseSearchClass):
         and else runs the actual generation code.
         """
 
-        # Remove old data:
-        try:
-            os.unlink(os.path.join(self.outdir, "*" + self.label + "*.sft"))
-        except OSError:
-            pass
-
         mfd = "lalapps_Makefakedata_v5"
         cl_mfd = [mfd]
         cl_mfd.append("--outSingleSFT=TRUE")


### PR DESCRIPTION
 - It seems this wasn't actually doing anything,
   probably because unlink doesn't understand * wildcards or something.
 - It was contrary to the whole check-if-safe-to-reuse idea
   the code actually uses.

@Rodrigo-Tenorio quick sanity check please