### PR TITLE
fix BSGL/lnBSGL chaos to consistent log10BSGL

### DIFF
--- a/examples/grid_examples/PyFstat_example_grid_search_F0.py
+++ b/examples/grid_examples/PyFstat_example_grid_search_F0.py
@@ -65,7 +65,6 @@ search = pyfstat.GridSearch(
     tref,
     tstart,
     tend,
-    BSGL=False,
 )
 search.run()
 

--- a/examples/mcmc_vs_grid_simple_example/PyFstat_example_simple_mcmc_vs_grid_comparison.py
+++ b/examples/mcmc_vs_grid_simple_example/PyFstat_example_simple_mcmc_vs_grid_comparison.py
@@ -106,7 +106,6 @@ gridsearch = pyfstat.GridSearch(
     Alphas=Alphas,
     Deltas=Deltas,
     tref=inj["tref"],
-    BSGL=False,
 )
 gridsearch.run()
 gridsearch.print_max_twoF()

--- a/examples/transient_examples/PyFstat_example_short_transient_grid_search.py
+++ b/examples/transient_examples/PyFstat_example_short_transient_grid_search.py
@@ -45,7 +45,6 @@ search1 = pyfstat.GridSearch(
     Alphas=Alphas,
     Deltas=Deltas,
     tref=tref,
-    BSGL=False,
 )
 search1.run()
 search1.print_max_twoF()
@@ -66,7 +65,6 @@ search2 = pyfstat.TransientGridSearch(
     transientWindowType="rect",
     t0Band=Tspan - 2 * Tsft,
     tauBand=Tspan,
-    BSGL=False,
     outputTransientFstatMap=True,
     tCWFstatMapVersion="lal",
 )

--- a/pyfstat/grid_based_searches.py
+++ b/pyfstat/grid_based_searches.py
@@ -35,7 +35,7 @@ class GridSearch(BaseSearchClass):
         "Alpha": r"$\alpha$",
         "Delta": r"$\delta$",
         "twoF": r"$\widetilde{2\mathcal{F}}$",
-        "BSGL": r"$\log_{10}{\mathcal{B}_{\mathrm{SGL}}$",
+        "log10BSGL": r"$\log_{10}\mathcal{B}_{\mathrm{SGL}}$",
     }
     tex_labels0 = {
         "F0": r"$-f_0$",
@@ -103,11 +103,10 @@ class GridSearch(BaseSearchClass):
         self.search_keys = ["F0", "F1", "F2", "Alpha", "Delta"]
         self.output_keys = self.search_keys.copy()
         if self.BSGL:
-            self.detstat = "BSGL"
-            self.output_keys += ["logBSGL"]
+            self.detstat = "log10BSGL"
         else:
             self.detstat = "twoF"
-            self.output_keys += [self.detstat]
+        self.output_keys.append(self.detstat)
         for k in self.search_keys:
             setattr(self, k, np.atleast_1d(getattr(self, k + "s")))
         self.output_file_header = self.get_output_file_header()
@@ -710,11 +709,10 @@ class TransientGridSearch(GridSearch):
         self.search_keys = ["F0", "F1", "F2", "Alpha", "Delta"]
         self.output_keys = self.search_keys.copy()
         if self.BSGL:
-            self.detstat = "BSGL"
-            self.output_keys += ["logBSGL"]
+            self.detstat = "log10BSGL"
         else:
             self.detstat = "twoF"
-            self.output_keys += ["twoF"]
+        self.output_keys.append(self.detstat)
         # for consistency below, t0/tau must come after detstat
         # they are not included in self.search_keys because the main Fstat
         # code does not loop over them

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -327,7 +327,7 @@ class MCMCSearch(BaseSearchClass):
         self.theta_keys = [self.theta_keys[i] for i in idxs]
 
         self.output_keys = self.theta_keys.copy()
-        self.output_keys += ["logBSGL" if self.BSGL else "twoF"]
+        self.output_keys += ["log10BSGL" if self.BSGL else "twoF"]
 
     def _evaluate_logpost(self, p0vec):
         init_logp = np.array(
@@ -1516,7 +1516,7 @@ class MCMCSearch(BaseSearchClass):
                     )
                     pass
                 if self.BSGL:
-                    axes[-1].set_xlabel(r"$\mathcal{B}_\mathrm{S/GL}$")
+                    axes[-1].set_xlabel(r"$\log_{10}\mathcal{B}_\mathrm{S/GL}$")
                 else:
                     axes[-1].set_xlabel(r"$\widetilde{2\mathcal{F}}$")
                 axes[-1].set_ylabel(r"$\mathrm{Counts}$")
@@ -2416,7 +2416,7 @@ class MCMCGlitchSearch(MCMCSearch):
                     self.theta_idxs[i] += 1
 
         self.output_keys = self.theta_keys.copy()
-        self.output_keys += ["logBSGL" if self.BSGL else "twoF"]
+        self.output_keys += ["log10BSGL" if self.BSGL else "twoF"]
 
     def _get_data_dictionary_to_save(self):
         d = dict(
@@ -3412,7 +3412,7 @@ class MCMCTransientSearch(MCMCSearch):
         self.theta_keys = [self.theta_keys[i] for i in idxs]
 
         self.output_keys = self.theta_keys.copy()
-        self.output_keys += ["logBSGL" if self.BSGL else "twoF"]
+        self.output_keys += ["log10BSGL" if self.BSGL else "twoF"]
 
     def get_savetxt_fmt_dict(self):
         fmt = helper_functions.get_doppler_params_output_format(self.theta_keys)

--- a/tests.py
+++ b/tests.py
@@ -776,7 +776,7 @@ class TestComputeFstat(BaseForTestsWithData):
         self.assertTrue(FS_from_dict == FS_from_file)
 
     def test_get_fully_coherent_BSGL(self):
-        # first pure noise, expect lnBSGL<0
+        # first pure noise, expect log10BSGL<0
         search_H1L1 = pyfstat.ComputeFstat(
             tref=self.tref,
             minStartTime=self.tstart,
@@ -787,15 +787,15 @@ class TestComputeFstat(BaseForTestsWithData):
             maxCoverFreq=self.F0 + 0.1,
             BSGL=True,
         )
-        lnBSGL = search_H1L1.get_fullycoherent_twoF(
+        log10BSGL = search_H1L1.get_fullycoherent_twoF(
             F0=self.F0,
             F1=self.F1,
             F2=self.F2,
             Alpha=self.Alpha,
             Delta=self.Delta,
         )
-        self.assertTrue(lnBSGL < 0)
-        # now with an added signal, expect lnBSGL>0
+        self.assertTrue(log10BSGL < 0)
+        # now with an added signal, expect log10BSGL>0
         search_H1L1 = pyfstat.ComputeFstat(
             tref=self.tref,
             minStartTime=self.tstart,
@@ -816,14 +816,14 @@ class TestComputeFstat(BaseForTestsWithData):
             maxCoverFreq=self.F0 + 0.1,
             BSGL=True,
         )
-        lnBSGL = search_H1L1.get_fullycoherent_twoF(
+        log10BSGL = search_H1L1.get_fullycoherent_twoF(
             F0=self.F0,
             F1=self.F1,
             F2=self.F2,
             Alpha=self.Alpha,
             Delta=self.Delta,
         )
-        self.assertTrue(lnBSGL > 0)
+        self.assertTrue(log10BSGL > 0)
 
     def test_cumulative_twoF(self):
         Nsft = 100


### PR DESCRIPTION
`BSGL` option to `GridSearch` was broken, giving a key error at some point. That alone would have been a two-line fix, but it's better to clean things up a bit more, changing our output log base following the decisions made ages ago for LALSuite:

 - lnBSGL is the more natural quantity (analogous to F~lnBSG)
   but log10BSGL as the output is consistent with lalapps choices
 - also fixes issues with output format keys in GridSearch
 - also removes a few superfluous explicit `BSGL=false` settings from examples to reduce clutter