### PR TITLE
helper_functions: remove orphaned twoFDMoffThreshold()

### DIFF
--- a/pyfstat/helper_functions.py
+++ b/pyfstat/helper_functions.py
@@ -397,16 +397,6 @@ def get_covering_band(
     return minCoverFreq, maxCoverFreq
 
 
-def twoFDMoffThreshold(
-    twoFon, knee=400, twoFDMoffthreshold_below_threshold=62, prefactor=0.9, offset=0.5
-):
-    """ Calculation of the 2F_DMoff threshold, see Eq 2 of arXiv:1707.5286 """
-    if twoFon <= knee:
-        return twoFDMoffthreshold_below_threshold
-    else:
-        return 10 ** (prefactor * np.log10(twoFon - offset))
-
-
 def match_commandlines(cl1, cl2, be_strict_about_full_executable_path=False):
     """ Check if two commandlines match element-by-element, regardless of order """
     cl1s = cl1.split(" ")


### PR DESCRIPTION
cc @GregoryAshton yet another orphaned function from the DMOff functionality. This one is easy to understand and wouldn't be much maintenance effort, but it's also completely isolated with all the other parts removed, so no real use in keeping it around.