### PR TITLE
BSGL readiness and internal cleanup

### DIFF
--- a/examples/binary_examples/PyFstat_example_binary_mcmc_vs_grid_comparison.py
+++ b/examples/binary_examples/PyFstat_example_binary_mcmc_vs_grid_comparison.py
@@ -105,8 +105,6 @@ twoF_values = np.zeros(grid_points.shape[0])
 for ind in range(grid_points.shape[0]):
     point = grid_points[ind]
     twoF_values[ind] = compute_f_stat.get_fullycoherent_twoF(
-        tstart=data_parameters["tstart"],
-        tend=tend,
         F0=signal_parameters["F0"],
         F1=signal_parameters["F1"],
         F2=signal_parameters["F2"],

--- a/examples/grid_examples/PyFstat_example_grid_search_with_BSGL.py
+++ b/examples/grid_examples/PyFstat_example_grid_search_with_BSGL.py
@@ -1,0 +1,131 @@
+"""
+Targeted grid search with line-robust BSGL statistic
+====================================================
+
+Search for a monochromatic (no spindown) signal using
+a parameter space grid (i.e. no MCMC)
+and the line-robust BSGL statistic
+to distinguish an astrophysical signal from an artifact in a single detector.
+"""
+
+import pyfstat
+import numpy as np
+import os
+
+label = "PyFstat_example_grid_search_BSGL"
+outdir = os.path.join("PyFstat_example_data", label)
+
+F0 = 30.0
+F1 = 0
+F2 = 0
+Alpha = 1.0
+Delta = 1.5
+
+# Properties of the GW data - first we make data for two detectors,
+# both including Gaussian noise and a coherent 'astrophysical' signal.
+depth = 70
+sqrtS = "1e-23"
+h0 = float(sqrtS) / depth
+cosi = 0
+IFOs = "H1,L1"
+sqrtSX = ",".join(np.repeat(sqrtS, len(IFOs.split(","))))
+tstart = 1000000000
+duration = 100 * 86400
+tend = tstart + duration
+tref = 0.5 * (tstart + tend)
+
+data = pyfstat.Writer(
+    label=label,
+    outdir=outdir,
+    tref=tref,
+    tstart=tstart,
+    duration=duration,
+    F0=F0,
+    F1=F1,
+    F2=F2,
+    Alpha=Alpha,
+    Delta=Delta,
+    h0=h0,
+    cosi=cosi,
+    sqrtSX=sqrtSX,
+    detectors=IFOs,
+    SFTWindowType="tukey",
+    SFTWindowBeta=0.001,
+    Band=1,
+)
+data.make_data()
+
+# Now we add an additional single-detector artifact to H1 only.
+# For simplicity, this is modelled here as a fully modulated CW-like signal,
+# just restricted to the single detector.
+SFTs_H1 = data.sftfilepath.split(";")[0]
+extra_writer = pyfstat.Writer(
+    label=label,
+    outdir=outdir,
+    tref=tref,
+    F0=F0 + 0.01,
+    F1=F1,
+    F2=F2,
+    Alpha=Alpha,
+    Delta=Delta,
+    h0=10 * h0,
+    cosi=cosi,
+    sqrtSX=0,  # don't add yet another set of Gaussian noise
+    noiseSFTs=SFTs_H1,
+    SFTWindowType="tukey",
+    SFTWindowBeta=0.001,
+)
+extra_writer.make_data()
+
+# set up search parameter ranges
+dF0 = 0.0001
+DeltaF0 = 1000 * dF0
+F0s = [F0 - DeltaF0 / 2.0, F0 + DeltaF0 / 2.0, dF0]
+F1s = [F1]
+F2s = [F2]
+Alphas = [Alpha]
+Deltas = [Delta]
+
+# first search: standard F-statistic
+# This should show a weak peak from the coherent signal
+# and a larger one from the "line artifact" at higher frequency.
+searchF = pyfstat.GridSearch(
+    label + "_twoF",
+    outdir,
+    os.path.join(outdir, "*" + label + "*sft"),
+    F0s,
+    F1s,
+    F2s,
+    Alphas,
+    Deltas,
+    tref,
+    tstart,
+    tend,
+)
+searchF.run()
+
+print("Plotting 2F(F0)...")
+searchF.plot_1D(xkey="F0")
+
+# second search: line-robust statistic BSGL activated
+searchBSGL = pyfstat.GridSearch(
+    label + "_BSGL",
+    outdir,
+    os.path.join(outdir, "*" + label + "*sft"),
+    F0s,
+    F1s,
+    F2s,
+    Alphas,
+    Deltas,
+    tref,
+    tstart,
+    tend,
+    BSGL=True,
+)
+searchBSGL.run()
+
+# The actual output statistic is log10BSGL.
+# The peak at the higher frequency from the "line artifact" should now
+# be massively suppressed.
+print("Plotting log10BSGL(F0)...")
+searchBSGL.plot_1D(xkey="F0")

--- a/examples/mcmc_examples/PyFstat_example_fully_coherent_MCMC_search_with_BSGL.py
+++ b/examples/mcmc_examples/PyFstat_example_fully_coherent_MCMC_search_with_BSGL.py
@@ -1,0 +1,148 @@
+"""
+MCMC search with fully coherent BSGL statistic
+==============================================
+
+Targeted MCMC search for an isolated CW signal using the
+fully coherent line-robust BSGL-statistic.
+"""
+
+import pyfstat
+import numpy as np
+import os
+
+label = os.path.splitext(os.path.basename(__file__))[0]
+outdir = os.path.join("PyFstat_example_data", label)
+
+# Properties of the GW data - first we make data for two detectors,
+# both including Gaussian noise and a coherent 'astrophysical' signal.
+data_parameters = {
+    "sqrtSX": 1e-23,
+    "tstart": 1000000000,
+    "duration": 100 * 86400,
+    "detectors": "H1,L1",
+    "SFTWindowType": "tukey",
+    "SFTWindowBeta": 0.001,
+}
+tend = data_parameters["tstart"] + data_parameters["duration"]
+mid_time = 0.5 * (data_parameters["tstart"] + tend)
+
+# Properties of the signal
+depth = 10
+signal_parameters = {
+    "F0": 30.0,
+    "F1": -1e-10,
+    "F2": 0,
+    "Alpha": np.radians(83.6292),
+    "Delta": np.radians(22.0144),
+    "tref": mid_time,
+    "h0": data_parameters["sqrtSX"] / depth,
+    "cosi": 1.0,
+}
+
+data = pyfstat.Writer(
+    label=label, outdir=outdir, **data_parameters, **signal_parameters
+)
+data.make_data()
+
+# Now we add an additional single-detector artifact to H1 only.
+# For simplicity, this is modelled here as a fully modulated CW-like signal,
+# just restricted to the single detector.
+SFTs_H1 = data.sftfilepath.split(";")[0]
+data_parameters_line = data_parameters.copy()
+signal_parameters_line = signal_parameters.copy()
+data_parameters_line["detectors"] = "H1"
+data_parameters_line["sqrtSX"] = 0  # don't add yet another set of Gaussian noise
+signal_parameters_line["F0"] += 1e-6
+signal_parameters_line["h0"] *= 10.0
+extra_writer = pyfstat.Writer(
+    label=label,
+    outdir=outdir,
+    **data_parameters_line,
+    **signal_parameters_line,
+    noiseSFTs=SFTs_H1,
+)
+extra_writer.make_data()
+
+# The predicted twoF, given by lalapps_predictFstat can be accessed by
+twoF = data.predict_fstat()
+print("Predicted twoF value: {}\n".format(twoF))
+
+# MCMC prior ranges
+DeltaF0 = 1e-5
+DeltaF1 = 1e-13
+theta_prior = {
+    "F0": {
+        "type": "unif",
+        "lower": signal_parameters["F0"] - DeltaF0 / 2.0,
+        "upper": signal_parameters["F0"] + DeltaF0 / 2.0,
+    },
+    "F1": {
+        "type": "unif",
+        "lower": signal_parameters["F1"] - DeltaF1 / 2.0,
+        "upper": signal_parameters["F1"] + DeltaF1 / 2.0,
+    },
+}
+for key in "F2", "Alpha", "Delta":
+    theta_prior[key] = signal_parameters[key]
+
+# MCMC sampler settings - relatively cheap setup, may not converge perfectly
+ntemps = 2
+log10beta_min = -0.5
+nwalkers = 50
+nsteps = [100, 100]
+
+# we'll want to plot results relative to the injection parameters
+transform_dict = dict(
+    F0=dict(subtractor=signal_parameters["F0"], symbol="$f-f^\\mathrm{s}$"),
+    F1=dict(
+        subtractor=signal_parameters["F1"], symbol="$\\dot{f}-\\dot{f}^\\mathrm{s}$"
+    ),
+)
+
+# first search: standard F-statistic
+# This should show a weak peak from the coherent signal
+# and a larger one from the "line artifact" at higher frequency.
+mcmc_F = pyfstat.MCMCSearch(
+    label=label + "_twoF",
+    outdir=outdir,
+    sftfilepattern=os.path.join(outdir, "*{}*sft".format(label)),
+    theta_prior=theta_prior,
+    tref=mid_time,
+    minStartTime=data_parameters["tstart"],
+    maxStartTime=tend,
+    nsteps=nsteps,
+    nwalkers=nwalkers,
+    ntemps=ntemps,
+    log10beta_min=log10beta_min,
+    BSGL=False,
+)
+mcmc_F.transform_dictionary = transform_dict
+mcmc_F.run(
+    walker_plot_args={"plot_det_stat": True, "injection_parameters": signal_parameters}
+)
+mcmc_F.print_summary()
+mcmc_F.plot_corner(add_prior=True, truths=signal_parameters)
+mcmc_F.plot_prior_posterior(injection_parameters=signal_parameters)
+
+# second search: line-robust statistic BSGL activated
+mcmc_F = pyfstat.MCMCSearch(
+    label=label + "_BSGL",
+    outdir=outdir,
+    sftfilepattern=os.path.join(outdir, "*{}*sft".format(label)),
+    theta_prior=theta_prior,
+    tref=mid_time,
+    minStartTime=data_parameters["tstart"],
+    maxStartTime=tend,
+    nsteps=nsteps,
+    nwalkers=nwalkers,
+    ntemps=ntemps,
+    log10beta_min=log10beta_min,
+    BSGL=True,
+)
+mcmc_F.transform_dictionary = transform_dict
+mcmc_F.run(
+    walker_plot_args={"plot_det_stat": True, "injection_parameters": signal_parameters}
+)
+mcmc_F.print_summary()
+mcmc_F.plot_corner(add_prior=True, truths=signal_parameters)
+mcmc_F.plot_prior_posterior(injection_parameters=signal_parameters)

--- a/examples/transient_examples/PyFstat_example_short_transient_MCMC_search.py
+++ b/examples/transient_examples/PyFstat_example_short_transient_MCMC_search.py
@@ -65,8 +65,10 @@ log10beta_min = -1
 nwalkers = 100
 nsteps = [200, 200]
 
+BSGL = False
+
 mcmc = pyfstat.MCMCTransientSearch(
-    label="transient_search",
+    label="transient_search" + ("_BSGL" if BSGL else ""),
     outdir=data.outdir,
     sftfilepattern=os.path.join(data.outdir, "*simulated_transient_signal*sft"),
     theta_prior=theta_prior,
@@ -76,6 +78,7 @@ mcmc = pyfstat.MCMCTransientSearch(
     ntemps=ntemps,
     log10beta_min=log10beta_min,
     transientWindowType="rect",
+    BSGL=BSGL,
 )
 mcmc.run(walker_plot_args={"plot_det_stat": True, "injection_parameters": inj})
 mcmc.print_summary()

--- a/examples/transient_examples/PyFstat_example_short_transient_grid_search.py
+++ b/examples/transient_examples/PyFstat_example_short_transient_grid_search.py
@@ -32,9 +32,11 @@ if __name__ == "__main__":
     Alphas = [data.Alpha]
     Deltas = [data.Delta]
 
+    BSGL = False
+
     print("Standard CW search:")
     search1 = pyfstat.GridSearch(
-        label="CW",
+        label="CW" + ("-BSGL" if BSGL else ""),
         outdir=data.outdir,
         sftfilepattern=os.path.join(data.outdir, "*simulated_transient_signal*sft"),
         F0s=F0s,
@@ -43,16 +45,15 @@ if __name__ == "__main__":
         Alphas=Alphas,
         Deltas=Deltas,
         tref=data.tref,
-        BSGL=False,
+        BSGL=BSGL,
     )
     search1.run()
     search1.print_max_twoF()
-
     search1.plot_1D(xkey="F0", xlabel="freq [Hz]", ylabel="$2\\mathcal{F}$")
 
     print("with t0,tau bands:")
     search2 = pyfstat.TransientGridSearch(
-        label="tCW",
+        label="tCW" + ("-BSGL" if BSGL else ""),
         outdir=data.outdir,
         sftfilepattern=os.path.join(data.outdir, "*simulated_transient_signal*sft"),
         F0s=F0s,
@@ -64,11 +65,10 @@ if __name__ == "__main__":
         transientWindowType="rect",
         t0Band=data.duration - 2 * data.Tsft,
         tauBand=data.duration,
-        BSGL=False,
         outputTransientFstatMap=True,
         tCWFstatMapVersion="lal",
+        BSGL=BSGL,
     )
     search2.run()
     search2.print_max_twoF()
-
     search2.plot_1D(xkey="F0", xlabel="freq [Hz]", ylabel="$2\\mathcal{F}$")

--- a/examples/transient_examples/PyFstat_example_short_transient_grid_search.py
+++ b/examples/transient_examples/PyFstat_example_short_transient_grid_search.py
@@ -36,7 +36,7 @@ if __name__ == "__main__":
 
     print("Standard CW search:")
     search1 = pyfstat.GridSearch(
-        label="CW" + ("-BSGL" if BSGL else ""),
+        label="CW" + ("_BSGL" if BSGL else ""),
         outdir=data.outdir,
         sftfilepattern=os.path.join(data.outdir, "*simulated_transient_signal*sft"),
         F0s=F0s,
@@ -53,7 +53,7 @@ if __name__ == "__main__":
 
     print("with t0,tau bands:")
     search2 = pyfstat.TransientGridSearch(
-        label="tCW" + ("-BSGL" if BSGL else ""),
+        label="tCW" + ("_BSGL" if BSGL else ""),
         outdir=data.outdir,
         sftfilepattern=os.path.join(data.outdir, "*simulated_transient_signal*sft"),
         F0s=F0s,

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -1623,7 +1623,6 @@ class SemiCoherentSearch(ComputeFstat):
             to obtain the per-segment coherence time `Tcoh`.
         """
 
-        self.fs_file_name = os.path.join(self.outdir, self.label + "_FS.dat")
         self.set_ephemeris_files(earth_ephem, sun_ephem)
         self.transientWindowType = None  # will use semicoherentWindowRange instead
         self.computeAtoms = True  # for semicoh 2F from ComputeTransientFstatMap()
@@ -2080,7 +2079,6 @@ class SemiCoherentGlitchSearch(SearchForSignalWithJumps, ComputeFstat):
             signal to jump to theta (and not just from).
         """
 
-        self.fs_file_name = os.path.join(self.outdir, self.label + "_FS.dat")
         self.set_ephemeris_files(earth_ephem, sun_ephem)
         self.transientWindowType = "rect"
         self.t0Band = None

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -2079,6 +2079,11 @@ class SemiCoherentGlitchSearch(SearchForSignalWithJumps, ComputeFstat):
             signal to jump to theta (and not just from).
         """
 
+        if self.BSGL:
+            raise ValueError(
+                f"BSGL option currently not supported by {self.__class__.__name__}."
+            )
+
         self.set_ephemeris_files(earth_ephem, sun_ephem)
         self.transientWindowType = "rect"
         self.t0Band = None

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -746,6 +746,9 @@ class ComputeFstat(BaseSearchClass):
                 self.tCWFstatMapVersion == "pycuda", self.cudaDeviceName
             )
 
+            if self.BSGL:
+                self.twoFXatMaxTwoF = np.zeros(lalpulsar.PULSAR_MAX_DETECTORS)
+
     def _set_min_max_cover_freqs(self):
         # decide on which minCoverFreq and maxCoverFreq to use:
         # either from direct user input, estimate_min_max_CoverFreq(), or SFTs
@@ -949,7 +952,7 @@ class ComputeFstat(BaseSearchClass):
             maxOrbitEcc=maxOrbitEcc,
         )
 
-    def get_fullycoherent_twoF(
+    def get_fullycoherent_detstat(
         self,
         F0,
         F1,
@@ -966,8 +969,14 @@ class ComputeFstat(BaseSearchClass):
     ):
         """Computes the detection statistic (twoF or log10BSGL) fully-coherently at a single point.
 
-        If transient parameters are enabled, the transient-F-stat map will also be computed here
-        (but stored in `self.FstatMap`, not returned).
+        These are also stored to `self.twoF` and `self.log10BSGL` respectively.
+        As the basic statistic of this class, `self.twoF` is always computed.
+        If `self.BSGL`, additionally the single-detector 2F-stat values are saved
+        in `self.twoFX`.
+
+        If transient parameters are enabled (`self.transientWindowType` is set),
+        the full transient-F-stat map will also be computed here,
+        but stored in `self.FstatMap`, not returned.
 
         Parameters
         ----------
@@ -978,13 +987,66 @@ class ComputeFstat(BaseSearchClass):
         tstart, tend: int or None
             GPS times to restrict the range of data used.
             If None: falls back to self.minStartTime and self.maxStartTime.
-            If outside those: auto-truncated.
+            This is only passed on to `self.get_transient_detstat()`,
+            i.e. only used if `self.transientWindowType` is set.
 
         Returns
         -------
         stat: float
             A single value of the detection statistic (twoF or log10BSGL)
             at the input parameter values.
+            Also stored as `self.twoF` or `self.log10BSGL`.
+        """
+        self.get_fullycoherent_twoF(
+            F0, F1, F2, Alpha, Delta, asini, period, ecc, tp, argp
+        )
+        if not self.transientWindowType:
+            if self.BSGL is False:
+                return self.twoF
+            self.get_fullycoherent_single_IFO_twoFs()
+            self.get_fullycoherent_log10BSGL()
+            return self.log10BSGL
+        self.get_transient_maxTwoFstat(tstart, tend)
+        if self.BSGL is False:
+            return self.maxTwoF
+        else:
+            return self.get_transient_log10BSGL()
+
+    def get_fullycoherent_twoF(
+        self,
+        F0,
+        F1,
+        F2,
+        Alpha,
+        Delta,
+        asini=None,
+        period=None,
+        ecc=None,
+        tp=None,
+        argp=None,
+    ):
+        """Computes the fully-coherent 2F statistic at a single point.
+
+        NOTE: This always uses the full data set as defined when initialising
+        the search object.
+        If you want to restrict the range of data used for a single 2F computation,
+        you need to set a `self.transientWindowType` and then call
+        `self.get_fullycoherent_detstat()` with `tstart` and `tend` options
+        instead of this funcion.
+
+        Parameters
+        ----------
+        F0, F1, F2, Alpha, Delta: float
+            Parameters at which to compute the statistic.
+        asini, period, ecc, tp, argp: float, optional
+            Optional: Binary parameters at which to compute the statistic.
+
+        Returns
+        -------
+        twoF: float
+            A single value of the fully-coherent 2F statistic
+            at the input parameter values.
+            Also stored as `self.twoF`.
         """
         self.PulsarDopplerParams.fkdot = np.zeros(lalpulsar.PULSAR_MAX_SPINS)
         self.PulsarDopplerParams.fkdot[:3] = [F0, F1, F2]
@@ -1004,21 +1066,76 @@ class ComputeFstat(BaseSearchClass):
             numFreqBins=1,
             whatToCompute=self.whatToCompute,
         )
+        # We operate on a single frequency bin, so we grab the 0 component
+        # of what is internally a twoF array.
+        self.twoF = np.float(self.FstatResults.twoF[0])
+        return self.twoF
 
-        if not self.transientWindowType:
-            # We operate on a single frequency bin, so we grab the 0 component
-            # of what is internally a twoF array.
-            twoF = np.float(self.FstatResults.twoF[0])
-            if self.BSGL is False:
-                return twoF
-            # Else, we use the single-detector F-stats to compute log10BSGL.
-            self.twoFX[: self.FstatResults.numDetectors] = [
-                self.FstatResults.twoFPerDet(X)
-                for X in range(self.FstatResults.numDetectors)
-            ]
-            log10BSGL = lalpulsar.ComputeBSGL(twoF, self.twoFX, self.BSGLSetup)
-            return log10BSGL
+    def get_fullycoherent_single_IFO_twoFs(self):
+        """Computes single-detector F-stats at a single point.
 
+        This requires `self.get_fullycoherent_twoF()` to be run first.
+
+        Returns
+        -------
+        twoFX: list
+            A list of the single-detector detection statistics twoF.
+            Also stored as `self.twoFX`.
+        """
+        self.twoFX[: self.FstatResults.numDetectors] = [
+            self.FstatResults.twoFPerDet(X)
+            for X in range(self.FstatResults.numDetectors)
+        ]
+        return self.twoFX
+
+    def get_fullycoherent_log10BSGL(self):
+        """Computes the line-robust statistic log10BSGL at a single point.
+
+        This requires `self.get_fullycoherent_twoF()`
+        and `self.get_fullycoherent_single_IFO_twoFs()`
+        to be run first.
+
+        Returns
+        -------
+        log10BSGL: float
+            A single value of the detection statistic log10BSGL
+            at the input parameter values.
+            Also stored as `self.log10BSGL`.
+        """
+        self.log10BSGL = lalpulsar.ComputeBSGL(self.twoF, self.twoFX, self.BSGLSetup)
+        return self.log10BSGL
+
+    def get_transient_maxTwoFstat(
+        self,
+        tstart=None,
+        tend=None,
+    ):
+        """Computes the transient maxTwoF statistic at a single point.
+
+        This requires `self.get_fullycoherent_twoF()` to be run first.
+
+        The full transient-F-stat map will also be computed here,
+        but stored in `self.FstatMap`, not returned.
+
+        Parameters
+        ----------
+        F0, F1, F2, Alpha, Delta: float
+            Parameters at which to compute the statistic.
+        asini, period, ecc, tp, argp: float, optional
+            Optional: Binary parameters at which to compute the statistic.
+        tstart, tend: int or None
+            GPS times to restrict the range of data used.
+            If None: falls back to self.minStartTime and self.maxStartTime.
+            This is only passed on to `self.get_transient_detstat()`,
+            i.e. only used if `self.transientWindowType` is set.
+
+        Returns
+        -------
+        maxTwoF: float
+            A single value of the detection statistic (twoF or log10BSGL)
+            at the input parameter values.
+            Also stored as `self.maxTwoF`.
+        """
         tstart = tstart or getattr(self, "minStartTime", None)
         tend = tend or getattr(self, "maxStartTime", None)
         if tstart is None or tend is None:
@@ -1027,8 +1144,6 @@ class ComputeFstat(BaseSearchClass):
             )
         self.windowRange.t0 = int(tstart)  # TYPE UINT4
         if self.windowRange.tauBand == 0:
-            # true single-template search also in transient params:
-            # actual (t0,tau) window was set with tstart, tend before
             self.windowRange.tau = int(tend - tstart)  # TYPE UINT4
 
         self.FstatMap, self.timingFstatMap = tcw.call_compute_transient_fstat_map(
@@ -1044,11 +1159,33 @@ class ComputeFstat(BaseSearchClass):
 
         # Now instead of the overall twoF,
         # we get the maximum twoF over the transient window range.
-        twoF = 2 * np.max(F_mn)
-        if self.BSGL is False:
-            return 0 if np.isnan(twoF) else twoF
+        self.maxTwoF = 2 * np.max(F_mn)
+        if np.isnan(self.maxTwoF):
+            self.maxTwoF = 0
+        return self.maxTwoF
 
-        # If BSGL requested, we need to also compute per-detector F_mn maps.
+    def get_transient_log10BSGL(self):
+        """Computes a transient detection statistic log10BSGL at a single point.
+
+        This requires `self.get_transient_maxTwoFstat()` to be run first.
+
+        The single-detector 2F-stat values
+        used for that computation (at the index of `maxTwoF`)
+        are saved in `self.twoFXatMaxTwoF`,
+        not returned.
+
+        Returns
+        -------
+        log10BSGL: float
+            A single value of the detection statistic log10BSGL
+            at the input parameter values.
+            Also stored as `self.log10BSGL`.
+        """
+        if self.tCWFstatMapVersion == "lal":
+            F_mn = self.FstatMap.F_mn.data
+        else:
+            F_mn = self.FstatMap.F_mn
+        # First, we need to also compute per-detector F_mn maps.
         # For now, we use the t0,tau index that maximises the multi-detector F
         # to return BSGL for a signal with those parameters.
         # FIXME: should we instead compute BSGL over the whole F_mn
@@ -1079,9 +1216,11 @@ class ComputeFstat(BaseSearchClass):
                 F_mn_X = FXstatMap.F_mn.data
             else:
                 F_mn_X = FXstatMap.F_mn
-            self.twoFX[X] = 2 * F_mn_X[idx_maxTwoF]
-        log10BSGL = lalpulsar.ComputeBSGL(twoF, self.twoFX, self.BSGLSetup)
-        return log10BSGL
+            self.twoFXatMaxTwoF[X] = 2 * F_mn_X[idx_maxTwoF]
+        self.log10BSGL = lalpulsar.ComputeBSGL(
+            self.maxTwoF, self.twoFXatMaxTwoF, self.BSGLSetup
+        )
+        return self.log10BSGL
 
     def _set_up_cumulative_times(self, tstart, tend, num_segments):
         """Construct time arrays to be used in cumulative twoF computations.
@@ -1166,7 +1305,7 @@ class ComputeFstat(BaseSearchClass):
         )
 
         twoFs = [
-            self.get_fullycoherent_twoF(
+            self.get_fullycoherent_detstat(
                 tstart=tstart,
                 tend=tstart + duration,
                 F0=F0,
@@ -1487,6 +1626,10 @@ class SemiCoherentSearch(ComputeFstat):
         self.cudaDeviceName = None
         self.init_computefstatistic()
         self.init_semicoherent_parameters()
+        if self.BSGL:
+            self.twoFX_per_segment = np.zeros(
+                (lalpulsar.PULSAR_MAX_DETECTORS, self.nsegs)
+            )
 
     def _init_semicoherent_window_range(self):
         """
@@ -1579,6 +1722,55 @@ class SemiCoherentSearch(ComputeFstat):
     ):
         """Computes the detection statistic (twoF or log10BSGL) semi-coherently at a single point.
 
+        As the basic statistic of this class, `self.twoF` is always computed.
+        If `self.BSGL`, additionally the single-detector 2F-stat values are saved
+        in `self.twoFX`.
+
+        Parameters
+        ----------
+        F0, F1, F2, Alpha, Delta: float
+            Parameters at which to compute the statistic.
+        asini, period, ecc, tp, argp: float, optional
+            Optional: Binary parameters at which to compute the statistic.
+        record_segments: boolean
+            If True, store the per-segment F-stat values as `self.twoF_per_segment`
+            and (if `self.BSGL=True`) the per-detector per-segment F-stats
+            as `self.twoFX_per_segment`.
+
+        Returns
+        -------
+        stat: float
+            A single value of the detection statistic (semi-coherent twoF or log10BSGL)
+            at the input parameter values.
+            Also stored as `self.twoF` or `self.log10BSGL`.
+        """
+
+        self.get_semicoherent_twoF(
+            F0, F1, F2, Alpha, Delta, asini, period, ecc, tp, argp, record_segments
+        )
+
+        if self.BSGL is False:
+            return self.twoF
+        else:
+            self.get_semicoherent_single_IFO_twoFs(record_segments)
+            return self.get_semicoherent_log10BSGL()
+
+    def get_semicoherent_twoF(
+        self,
+        F0,
+        F1,
+        F2,
+        Alpha,
+        Delta,
+        asini=None,
+        period=None,
+        ecc=None,
+        tp=None,
+        argp=None,
+        record_segments=False,
+    ):
+        """Computes the semi-coherent twoF statistic at a single point.
+
         Parameters
         ----------
         F0, F1, F2, Alpha, Delta: float
@@ -1590,9 +1782,10 @@ class SemiCoherentSearch(ComputeFstat):
 
         Returns
         -------
-        stat: float
-            A single value of the detection statistic (semi-coherent twoF or log10BSGL)
+        twoF: float
+            A single value of the semi-coherent twoF statistic
             at the input parameter values.
+            Also stored as `self.twoF`.
         """
 
         self.PulsarDopplerParams.fkdot = np.zeros(lalpulsar.PULSAR_MAX_SPINS)
@@ -1615,56 +1808,91 @@ class SemiCoherentSearch(ComputeFstat):
         )
 
         twoF_per_segment = self._get_per_segment_twoF()
-        twoF = twoF_per_segment.sum()
+        self.twoF = twoF_per_segment.sum()
 
-        if np.isnan(twoF):
+        if np.isnan(self.twoF):
             logging.debug(
                 "NaNs in per-segment 2F treated as zero"
                 " and semi-coherent 2F re-computed."
             )
             twoF_per_segment = np.nan_to_num(twoF_per_segment, nan=0.0)
-            twoF = twoF_per_segment.sum()
+            self.twoF = twoF_per_segment.sum()
 
         if record_segments:
             self.twoF_per_segment = twoF_per_segment
 
-        if self.BSGL is False:
-            return twoF
-        else:
-            for X in range(self.FstatResults.numDetectors):
-                # For each detector, we need to build a MultiFstatAtomVector
-                # because that's what the Fstat map function expects.
-                singleIFOmultiFatoms = lalpulsar.CreateMultiFstatAtomVector(1)
-                # The first [0] index on the multiFatoms here is over frequency bins;
-                # we always operate on a single bin.
-                singleIFOmultiFatoms.data[0] = lalpulsar.CreateFstatAtomVector(
-                    self.FstatResults.multiFatoms[0].data[X].length
+    def get_semicoherent_single_IFO_twoFs(self, record_segments=False):
+        """Computes the semi-coherent single-detector F-statss at a single point.
+
+        This requires `self.get_semicoherent_twoF()` to be run first.
+
+        Parameters
+        ----------
+        record_segments: boolean
+            If True, store the per-detector per-segment F-stat values
+            as `self.twoFX_per_segment`.
+
+
+        Returns
+        -------
+        twoFX: list
+            A list of the single-detector detection statistics twoF.
+            Also stored as `self.twoFX`.
+        """
+        for X in range(self.FstatResults.numDetectors):
+            # For each detector, we need to build a MultiFstatAtomVector
+            # because that's what the Fstat map function expects.
+            singleIFOmultiFatoms = lalpulsar.CreateMultiFstatAtomVector(1)
+            # The first [0] index on the multiFatoms here is over frequency bins;
+            # we always operate on a single bin.
+            singleIFOmultiFatoms.data[0] = lalpulsar.CreateFstatAtomVector(
+                self.FstatResults.multiFatoms[0].data[X].length
+            )
+            singleIFOmultiFatoms.data[0].TAtom = (
+                self.FstatResults.multiFatoms[0].data[X].TAtom
+            )
+            singleIFOmultiFatoms.data[0].data = (
+                self.FstatResults.multiFatoms[0].data[X].data
+            )
+            FXstatMap = lalpulsar.ComputeTransientFstatMap(
+                multiFstatAtoms=singleIFOmultiFatoms,
+                windowRange=self.semicoherentWindowRange,
+                useFReg=False,
+            )
+            twoFX_per_segment = 2 * FXstatMap.F_mn.data[:, 0]
+            self.twoFX[X] = twoFX_per_segment.sum()
+            if np.isnan(self.twoFX[X]):
+                logging.debug(
+                    "NaNs in per-segment per-detector 2F treated as zero"
+                    " and sum re-computed."
                 )
-                singleIFOmultiFatoms.data[0].TAtom = (
-                    self.FstatResults.multiFatoms[0].data[X].TAtom
-                )
-                singleIFOmultiFatoms.data[0].data = (
-                    self.FstatResults.multiFatoms[0].data[X].data
-                )
-                FXstatMap = lalpulsar.ComputeTransientFstatMap(
-                    multiFstatAtoms=singleIFOmultiFatoms,
-                    windowRange=self.semicoherentWindowRange,
-                    useFReg=False,
-                )
-                twoFX_per_segment = 2 * FXstatMap.F_mn.data[:, 0]
+                twoFX_per_segment = np.nan_to_num(twoFX_per_segment, nan=0.0)
                 self.twoFX[X] = twoFX_per_segment.sum()
-                if np.isnan(self.twoFX[X]):
-                    logging.debug(
-                        "NaNs in per-segment per-detector 2F treated as zero"
-                        " and sum re-computed."
-                    )
-                    twoFX_per_segment = np.nan_to_num(twoFX_per_segment, nan=0.0)
-                    self.twoFX[X] = twoFX_per_segment.sum()
-            log10BSGL = lalpulsar.ComputeBSGL(twoF, self.twoFX, self.BSGLSetup)
-            if np.isnan(log10BSGL):
-                logging.debug("NaNs in semi-coherent log10BSGL treated as zero")
-                log10BSGL = 0.0
-            return log10BSGL
+            if record_segments:
+                self.twoFX_per_segment[
+                    : self.FstatResults.numDetectors, :
+                ] = twoFX_per_segment
+        return self.twoFX
+
+    def get_semicoherent_log10BSGL(self):
+        """Computes the semi-coherent log10BSGL statistic at a single point.
+
+        This requires `self.get_semicoherent_twoF()`
+        and `self.get_semicoherent_single_IFO_twoFs()`
+        to be run first.
+
+        Returns
+        -------
+        log10BSGL: float
+            A single value of the semi-coherent log10BSGL statistic
+            at the input parameter values.
+            Also stored as `self.log10BSGL`.
+        """
+        self.log10BSGL = lalpulsar.ComputeBSGL(self.twoF, self.twoFX, self.BSGLSetup)
+        if np.isnan(self.log10BSGL):
+            logging.debug("NaNs in semi-coherent log10BSGL treated as zero")
+            self.log10BSGL = 0.0
+        return self.log10BSGL
 
     def _get_per_segment_twoF(self):
         Fmap = lalpulsar.ComputeTransientFstatMap(
@@ -1893,7 +2121,7 @@ class SemiCoherentGlitchSearch(SearchForSignalWithJumps, ComputeFstat):
         for i, theta_i_at_tref in enumerate(thetas):
             ts, te = tboundaries[i], tboundaries[i + 1]
             if te - ts > 1800:
-                twoFVal = self.get_fullycoherent_twoF(
+                twoFVal = self.get_fullycoherent_detstat(
                     F0=theta_i_at_tref[1],
                     F1=theta_i_at_tref[2],
                     F2=theta_i_at_tref[3],
@@ -1927,7 +2155,7 @@ class SemiCoherentGlitchSearch(SearchForSignalWithJumps, ComputeFstat):
             theta_post_glitch_at_glitch, tref - tglitch
         )
 
-        twoFsegA = self.get_fullycoherent_twoF(
+        twoFsegA = self.get_fullycoherent_detstat(
             F0=theta[0],
             F1=theta[1],
             F2=theta[2],
@@ -1940,7 +2168,7 @@ class SemiCoherentGlitchSearch(SearchForSignalWithJumps, ComputeFstat):
         if tglitch == self.maxStartTime:
             return twoFsegA
 
-        twoFsegB = self.get_fullycoherent_twoF(
+        twoFsegB = self.get_fullycoherent_detstat(
             F0=theta_post_glitch[0],
             F1=theta_post_glitch[1],
             F2=theta_post_glitch[2],

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -1187,9 +1187,7 @@ class ComputeFstat(BaseSearchClass):
         # to return BSGL for a signal with those parameters.
         # FIXME: should we instead compute BSGL over the whole F_mn
         # and return the maximum of that?
-        idx_maxTwoF = np.unravel_index(
-            np.argmax(self.FstatMap.F_mn), self.FstatMap.F_mn.shape
-        )
+        idx_maxTwoF = self.FstatMap.get_maxF_idx()
         for X in range(self.FstatResults.numDetectors):
             # For each detector, we need to build a MultiFstatAtomVector
             # because that's what the Fstat map function expects.

--- a/pyfstat/grid_based_searches.py
+++ b/pyfstat/grid_based_searches.py
@@ -1048,7 +1048,9 @@ class TransientGridSearch(GridSearch):
                     )
                 if self.outputTransientFstatMap:
                     tCWfile = self.get_transient_fstat_map_filename(thisCand)
-                    self.write_F_mn(tCWfile, self.search.FstatMap.F_mn, windowRange)
+                    self.search.FstatMap.write_F_mn_to_file(
+                        tCWfile, windowRange, self.output_file_header
+                    )
                 maxidx = np.unravel_index(
                     self.search.FstatMap.F_mn.argmax(), self.search.FstatMap.F_mn.shape
                 )
@@ -1117,30 +1119,6 @@ class TransientGridSearch(GridSearch):
         fmt_dict["t0"] = "%d"
         fmt_dict["tau"] = "%d"
         return fmt_dict
-
-    def write_F_mn(self, tCWfile, F_mn, windowRange):
-        """Helper function to format a transient-F-stat matrix over `(t0,tau)`.
-
-        Parameters
-        ----------
-        tCWfile: str
-            Name of the file to write to.
-        F_mn: np.ndarray
-            The 2D matrix of transient twoF-stat values.
-        windowRange: lalpulsar.transientWindowRange_t
-            A lalpulsar structure containing the transient parameters.
-        """
-        with open(tCWfile, "w") as tfp:
-            for hline in self.output_file_header:
-                tfp.write("# {:s}\n".format(hline))
-            tfp.write("# t0 [s]     tau [s]     2F\n")
-            for m, F_m in enumerate(F_mn):
-                this_t0 = windowRange.t0 + m * windowRange.dt0
-                for n, this_F in enumerate(F_m):
-                    this_tau = windowRange.tau + n * windowRange.dtau
-                    tfp.write(
-                        "  %10d %10d %- 11.8g\n" % (this_t0, this_tau, 2.0 * this_F)
-                    )
 
     def __del__(self):
         if hasattr(self, "search"):

--- a/pyfstat/grid_based_searches.py
+++ b/pyfstat/grid_based_searches.py
@@ -155,7 +155,6 @@ class GridSearch(BaseSearchClass):
                 earth_ephem=self.earth_ephem,
                 sun_ephem=self.sun_ephem,
             )
-            self.search.get_det_stat = self.search.get_fullycoherent_detstat
         else:
             self.search = SemiCoherentSearch(
                 label=self.label,
@@ -172,7 +171,6 @@ class GridSearch(BaseSearchClass):
                 detectors=self.detectors,
                 injectSources=self.injectSources,
             )
-            self.search.get_det_stat = self.search.get_semicoherent_det_stat
         # make sure to overwrite the min/max starttime in case the user
         # passed None and they were read from SFTs
         self.minStartTime = self.search.minStartTime
@@ -940,7 +938,6 @@ class TransientGridSearch(GridSearch):
             earth_ephem=self.earth_ephem,
             sun_ephem=self.sun_ephem,
         )
-        self.search.get_det_stat = self.search.get_fullycoherent_detstat
         # make sure to overwrite the min/max starttime in case the user
         # passed None and they were read from SFTs
         self.minStartTime = self.search.minStartTime
@@ -1202,7 +1199,6 @@ class GridGlitchSearch(GridSearch):
             earth_ephem=earth_ephem,
             sun_ephem=sun_ephem,
         )
-        self.search.get_det_stat = self.search.get_semicoherent_nglitch_twoF
 
         if os.path.isdir(outdir) is False:
             os.mkdir(outdir)

--- a/pyfstat/grid_based_searches.py
+++ b/pyfstat/grid_based_searches.py
@@ -155,7 +155,7 @@ class GridSearch(BaseSearchClass):
                 earth_ephem=self.earth_ephem,
                 sun_ephem=self.sun_ephem,
             )
-            self.search.get_det_stat = self.search.get_fullycoherent_twoF
+            self.search.get_det_stat = self.search.get_fullycoherent_detstat
         else:
             self.search = SemiCoherentSearch(
                 label=self.label,
@@ -940,7 +940,7 @@ class TransientGridSearch(GridSearch):
             earth_ephem=self.earth_ephem,
             sun_ephem=self.sun_ephem,
         )
-        self.search.get_det_stat = self.search.get_fullycoherent_twoF
+        self.search.get_det_stat = self.search.get_fullycoherent_detstat
         # make sure to overwrite the min/max starttime in case the user
         # passed None and they were read from SFTs
         self.minStartTime = self.search.minStartTime

--- a/pyfstat/grid_based_searches.py
+++ b/pyfstat/grid_based_searches.py
@@ -1051,9 +1051,7 @@ class TransientGridSearch(GridSearch):
                     self.search.FstatMap.write_F_mn_to_file(
                         tCWfile, windowRange, self.output_file_header
                     )
-                maxidx = np.unravel_index(
-                    self.search.FstatMap.F_mn.argmax(), self.search.FstatMap.F_mn.shape
-                )
+                maxidx = self.search.FstatMap.get_maxF_idx()
                 thisCand += [
                     windowRange.t0 + maxidx[0] * windowRange.dt0,
                     windowRange.tau + maxidx[1] * windowRange.dtau,

--- a/pyfstat/grid_based_searches.py
+++ b/pyfstat/grid_based_searches.py
@@ -726,6 +726,20 @@ class GridSearch(BaseSearchClass):
         else:
             return ax
 
+    def get_max_det_stat(self):
+        """Get the maximum detection statistic over the grid.
+
+        This requires the `run()` method to have been called before.
+
+        Returns
+        -------
+        d: dict
+            Dictionary containing parameters and detection statistic at the maximum.
+        """
+        idx = np.argmax(self.data[self.detstat])
+        d = OrderedDict([(key, self.data[key][idx]) for key in self.output_keys])
+        return d
+
     def get_max_twoF(self):
         """Get the maximum twoF over the grid.
 

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -300,7 +300,7 @@ class MCMCSearch(BaseSearchClass):
         in_theta = copy.copy(self.fixed_theta)
         for j, theta_i in enumerate(self.theta_idxs):
             in_theta[theta_i] = theta[j]
-        twoF = search.get_fullycoherent_twoF(*in_theta)
+        twoF = search.get_fullycoherent_detstat(*in_theta)
         return twoF / 2.0 + self.likelihoodcoef
 
     def _unpack_input_theta(self):
@@ -3290,7 +3290,7 @@ class MCMCTransientSearch(MCMCSearch):
         in_theta["tend"] = in_theta["tstart"] + tau
         if in_theta["tend"] > self.maxStartTime:
             return -np.inf
-        twoF = search.get_fullycoherent_twoF(**in_theta)
+        twoF = search.get_fullycoherent_detstat(**in_theta)
         return twoF / 2.0 + self.likelihoodcoef
 
     def _unpack_input_theta(self):

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -1760,14 +1760,9 @@ class MCMCSearch(BaseSearchClass):
 
     def _get_detstat_from_loglikelihood(self, idx=None):
         """Inverts the extra terms applied in logl()."""
-        if idx is None:
-            return (
-                self.lnlikes - self.likelihoodcoef
-            ) / self.likelihooddetstatmultiplier
-        else:
-            return (
-                self.lnlikes[idx] - self.likelihoodcoef
-            ) / self.likelihooddetstatmultiplier
+        return (
+            self.lnlikes[idx if idx is not None else ...] - self.likelihoodcoef
+        ) / self.likelihooddetstatmultiplier
 
     def get_max_twoF(self):
         """Get the max. likelihood (loudest) sample and the compute

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -2410,8 +2410,6 @@ class MCMCGlitchSearch(MCMCSearch):
 
     def _initiate_search_object(self):
         logging.info("Setting up search object")
-        if self.BSGL:
-            raise ValueError("BSGL option currently not supported.")
         search_ranges = self._get_search_ranges()
         self.search = core.SemiCoherentGlitchSearch(
             label=self.label,

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -2372,36 +2372,12 @@ class MCMCGlitchSearch(MCMCSearch):
     def _set_likelihoodcoef(self):
         """Additional constant terms to turn a detection statistic into a likelihood.
 
-        In general, the (log-)likelihood can be obtained from the signal-to-noise
-        (log-)Bayes factor
-        (omitting the overall Gaussian-noise normalization term)
-        but the detection statistic may only be a monotonic function of the
-        Bayes factor, not the full thing.
-        E.g. this is the case for the standard CW F-statistic!
-
-        In the semi-coherent case, the number of segments must also be considered.
+        See MCMCSearch._set_likelihoodcoef for the base implementation.
+        This method simply extends it in order to account for the increased number
+        of segments due to the presence of glitches.
         """
-        if self.BSGL:
-            # In this case, the corresponding term is already included
-            # in the detection statistic itself.
-            # See Eq. (55) in Keitel et al (PRD 89, 064023, 2014):
-            # https://arxiv.org/abs/1311.5738
-            # where Fstarhat0 = ln(cstar**Nseg) = Nseg * ln(rhohatmax**4/70).
-            # We just need to switch to natural log basis.
-            self.likelihooddetstatmultiplier = np.log(10)
-            self.likelihoodcoef = 0
-        else:
-            # If assuming only Gaussian noise + signal,
-            # the likelihood is essentially the F-statistic,
-            # but with an extra constant term depending on the amplitude prior.
-            # See Eq. (9) of Ashton & Prix (PRD 97, 103020, 2018):
-            # https://arxiv.org/abs/1802.05450
-            # Also need to go from twoF to F,
-            # and include the number of segments ( = nglitch+1 ) explicitly.
-            self.likelihooddetstatmultiplier = 0.5
-            self.likelihoodcoef = (self.nglitch + 1) * np.log(
-                70.0 / self.rhohatmax ** 4
-            )
+        super()._set_likelihoodcoef()
+        self.likelihoodcoef *= self.nglitch + 1
 
     def _initiate_search_object(self):
         logging.info("Setting up search object")
@@ -2746,34 +2722,12 @@ class MCMCSemiCoherentSearch(MCMCSearch):
     def _set_likelihoodcoef(self):
         """Additional constant terms to turn a detection statistic into a likelihood.
 
-        In general, the (log-)likelihood can be obtained from the signal-to-noise
-        (log-)Bayes factor
-        (omitting the overall Gaussian-noise normalization term)
-        but the detection statistic may only be a monotonic function of the
-        Bayes factor, not the full thing.
-        E.g. this is the case for the standard CW F-statistic!
-
-        In the semi-coherent case, the number of segments must also be considered.
+        See MCMCSearch._set_likelihoodcoef for the base implementation.
+        This method simply extends it in order to account for the increased number
+        of segments a semicoherent search works with.
         """
-        if self.BSGL:
-            # In this case, the corresponding term is already included
-            # in the detection statistic itself.
-            # See Eq. (55) in Keitel et al (PRD 89, 064023, 2014):
-            # https://arxiv.org/abs/1311.5738
-            # where Fstarhat0 = ln(cstar**Nseg) = Nseg * ln(rhohatmax**4/70).
-            # We just need to switch to natural log basis.
-            self.likelihooddetstatmultiplier = np.log(10)
-            self.likelihoodcoef = 0
-        else:
-            # If assuming only Gaussian noise + signal,
-            # the likelihood is essentially the F-statistic,
-            # but with an extra constant term depending on the amplitude prior.
-            # See Eq. (9) of Ashton & Prix (PRD 97, 103020, 2018):
-            # https://arxiv.org/abs/1802.05450
-            # Also need to go from twoF to F,
-            # and include the number of segments explicitly.
-            self.likelihooddetstatmultiplier = 0.5
-            self.likelihoodcoef = self.nsegs * np.log(70.0 / self.rhohatmax ** 4)
+        super()._set_likelihoodcoef()
+        self.likelihoodcoef *= self.nsegs
 
     def _get_data_dictionary_to_save(self):
         d = dict(

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -323,7 +323,17 @@ class MCMCSearch(BaseSearchClass):
         return np.sum(H)
 
     def _set_point_for_evaluation(self, theta):
-        """Combines fixed and variable parameters to form a valid evaluation point."""
+        """Combines fixed and variable parameters to form a valid evaluation point.
+
+        Parameters
+        ----------
+        theta: list or np.ndarray
+            The sampled (variable) parameters.
+        Returns
+        -------
+        p: list
+            The full parameter space point as a list.
+        """
         p = copy.copy(self.fixed_theta)
         for j, theta_i in enumerate(self.theta_idxs):
             p[theta_i] = theta[j]
@@ -1721,7 +1731,10 @@ class MCMCSearch(BaseSearchClass):
             self.search.BSGL = False
             for idx, samp in enumerate(self.samples):
                 p = self._set_point_for_evaluation(samp)
-                twoF[idx] = self.search.get_det_stat(*p)
+                if isinstance(p, dict):
+                    twoF[idx] = self.search.get_det_stat(**p)
+                else:
+                    twoF[idx] = self.search.get_det_stat(*p)
             self.search.BSGL = self.BSGL
             samples_out = np.concatenate((samples_out, twoF), axis=1)
         # TODO: add single-IFO F-stats?
@@ -1791,7 +1804,10 @@ class MCMCSearch(BaseSearchClass):
                 self._initiate_search_object()
             p = self._set_point_for_evaluation(self.samples[jmax])
             self.search.BSGL = False
-            maxtwoF = self.search.get_det_stat(*p)
+            if isinstance(p, dict):
+                maxtwoF = self.search.get_det_stat(**p)
+            else:
+                maxtwoF = self.search.get_det_stat(*p)
             self.search.BSGL = self.BSGL
         else:
             # can just reuse the logl value
@@ -3375,7 +3391,18 @@ class MCMCTransientSearch(MCMCSearch):
             self.maxStartTime = self.search.maxStartTime
 
     def _set_point_for_evaluation(self, theta):
-        """Combines fixed and variable parameters to form a valid evaluation point."""
+        """Combines fixed and variable parameters to form a valid evaluation point.
+
+        Parameters
+        ----------
+        theta: list or np.ndarray
+            The sampled (variable) parameters.
+        Returns
+        -------
+        p: dict
+            The full parameter space point as a dictionary.
+            (different from base MCMCSearch class!)
+        """
         p = {
             key: self.fixed_theta[k]
             for k, key in enumerate(self.full_theta_keys)

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -1576,15 +1576,11 @@ class MCMCSearch(BaseSearchClass):
         p = pF[idx]
         p0 = self._generate_scattered_p0(p)
 
-        self.search.BSGL = False
-        twoF = self._logl(p, self.search)
-        self.search.BSGL = self.BSGL
-
         logging.info(
             (
-                "Gen. new p0 from pos {} which had det. stat.={:2.1f},"
-                " twoF={:2.1f} and lnp={:2.1f}"
-            ).format(idx[1], lnl[idx], twoF, lnp_finite[idx])
+                "Gen. new p0 from pos {} which had det. stat.={:2.1f}"
+                " and lnp={:2.1f}"
+            ).format(idx[1], lnl[idx], lnp_finite[idx])
         )
 
         return p0

--- a/pyfstat/tcw_fstat_map_funcs.py
+++ b/pyfstat/tcw_fstat_map_funcs.py
@@ -112,6 +112,16 @@ class pyTransientFstatMap:
         self.t0_ML = transientFstatMap_t.t0_ML
         self.tau_ML = transientFstatMap_t.tau_ML
 
+    def get_maxF_idx(self):
+        """Gets the 2D-unravelled index pair of the maximum of the F_mn map
+
+        Returns
+        -------
+        idx: tuple
+            The m,n indices of the map entry with maximal F value.
+        """
+        return np.unravel_index(np.argmax(self.F_mn), self.F_mn.shape)
+
     def write_F_mn_to_file(self, tCWfile, windowRange, header=[]):
         """Format a 2D transient-F-stat matrix over `(t0,tau)` and write as a text file.
 

--- a/pyfstat/tcw_fstat_map_funcs.py
+++ b/pyfstat/tcw_fstat_map_funcs.py
@@ -141,7 +141,7 @@ class pyTransientFstatMap:
         with open(tCWfile, "w") as tfp:
             for hline in header:
                 tfp.write("# {:s}\n".format(hline))
-            tfp.write("# t0 [s]     tau [s]     2F\n")
+            tfp.write("# t0[s]     tau[s]     2F\n")
             for m, F_m in enumerate(self.F_mn):
                 this_t0 = windowRange.t0 + m * windowRange.dt0
                 for n, this_F in enumerate(F_m):

--- a/pyfstat/tcw_fstat_map_funcs.py
+++ b/pyfstat/tcw_fstat_map_funcs.py
@@ -112,6 +112,34 @@ class pyTransientFstatMap:
         self.t0_ML = transientFstatMap_t.t0_ML
         self.tau_ML = transientFstatMap_t.tau_ML
 
+    def write_F_mn_to_file(self, tCWfile, windowRange, header=[]):
+        """Format a 2D transient-F-stat matrix over `(t0,tau)` and write as a text file.
+
+        Apart from the optional extra header lines,
+        the format is consistent with lalpulsar.write_transientFstatMap_to_fp().
+
+        Parameters
+        ----------
+        tCWfile: str
+            Name of the file to write to.
+        windowRange: lalpulsar.transientWindowRange_t
+            A lalpulsar structure containing the transient parameters.
+        header: list
+            A list of additional header lines
+            to print at the start of the file.
+        """
+        with open(tCWfile, "w") as tfp:
+            for hline in header:
+                tfp.write("# {:s}\n".format(hline))
+            tfp.write("# t0 [s]     tau [s]     2F\n")
+            for m, F_m in enumerate(self.F_mn):
+                this_t0 = windowRange.t0 + m * windowRange.dt0
+                for n, this_F in enumerate(F_m):
+                    this_tau = windowRange.tau + n * windowRange.dtau
+                    tfp.write(
+                        "  %10d %10d %- 11.8g\n" % (this_t0, this_tau, 2.0 * this_F)
+                    )
+
 
 fstatmap_versions = {
     "lal": lambda multiFstatAtoms, windowRange: lalpulsar_compute_transient_fstat_map(

--- a/pyfstat/tcw_fstat_map_funcs.py
+++ b/pyfstat/tcw_fstat_map_funcs.py
@@ -63,7 +63,11 @@ class pyTransientFstatMap:
     Attributes
     ----------
     F_mn: np.ndarray
-        2D array of F values (not 2F!).
+        2D array of F values (not 2F!),
+        with `m` an index over start-times `t0`,
+        and  `n` an index over duration parameters `tau`,
+        in steps of `dt0`  in `[t0,  t0+t0Band]`,
+        and `dtau` in `[tau, tau+tauBand]`.
     maxF: float
         Maximum of F (not 2F!) over the array.
     t0_ML: float
@@ -72,7 +76,7 @@ class pyTransientFstatMap:
         Maximum likelihood estimate of the transient duration `tau`.
     """
 
-    def __init__(self, N_t0Range, N_tauRange):
+    def __init__(self, N_t0Range=None, N_tauRange=None, transientFstatMap_t=None):
         """
         The class can be initialized with the following:
 
@@ -82,29 +86,44 @@ class pyTransientFstatMap:
             Number of `t0` values covered.
         N_tauRange: int
             Number of `tau` values covered.
+        transientFstatMap_t: lalpulsar.transientFstatMap_t
+            pre-allocated matrix from lalpulsar.
         """
+        if transientFstatMap_t:
+            self._init_from_lalpulsar_type(transientFstatMap_t)
+        else:
+            if not N_t0Range or not N_tauRange:
+                raise ValueError(
+                    "Need either a transientFstatMap_t or a pair of (N_t0Range, N_tauRange)!."
+                )
+            self.F_mn = np.zeros((N_t0Range, N_tauRange), dtype=np.float32)
+            # Initializing maxF to a negative value ensures
+            # that we always update at least once and hence return
+            # sane t0_d_ML, tau_d_ML
+            # even if there is only a single bin where F=0 happens.
+            self.maxF = float(-1.0)
+            self.t0_ML = float(0.0)
+            self.tau_ML = float(0.0)
 
-        self.F_mn = np.zeros((N_t0Range, N_tauRange), dtype=np.float32)
-        # Initializing maxF to a negative value ensures
-        # that we always update at least once and hence return
-        # sane t0_d_ML, tau_d_ML
-        # even if there is only a single bin where F=0 happens.
-        self.maxF = float(-1.0)
-        self.t0_ML = float(0.0)
-        self.tau_ML = float(0.0)
+    def _init_from_lalpulsar_type(self, transientFstatMap_t):
+        """This essentially just strips out a redundant member level from the lalpulsar structure."""
+        self.F_mn = transientFstatMap_t.F_mn.data
+        self.maxF = transientFstatMap_t.maxF
+        self.t0_ML = transientFstatMap_t.t0_ML
+        self.tau_ML = transientFstatMap_t.tau_ML
 
 
 fstatmap_versions = {
-    "lal": lambda multiFstatAtoms, windowRange: getattr(
-        lalpulsar, "ComputeTransientFstatMap"
-    )(multiFstatAtoms, windowRange, False),
+    "lal": lambda multiFstatAtoms, windowRange: lalpulsar_compute_transient_fstat_map(
+        multiFstatAtoms, windowRange
+    ),
     "pycuda": lambda multiFstatAtoms, windowRange: pycuda_compute_transient_fstat_map(
         multiFstatAtoms, windowRange
     ),
 }
 """Dictionary of the actual callable transient F-stat map functions this module supports.
 
-Actual runtime variability depends on the corresponding external modules
+Actual runtime availability depends on the corresponding external modules
 being available.
 """
 
@@ -305,6 +324,32 @@ def call_compute_transient_fstat_map(
     return FstatMap, timingFstatMap
 
 
+def lalpulsar_compute_transient_fstat_map(multiFstatAtoms, windowRange):
+    """Wrapper for the standard lalpulsar function for computing a transient F-statistic map.
+
+    See https://lscsoft.docs.ligo.org/lalsuite/lalpulsar/_transient_c_w__utils_8h.html
+    for the wrapped function.
+
+    Parameters
+    ----------
+    multiFstatAtoms: lalpulsar.MultiFstatAtomVector
+        The time-dependent F-stat atoms previously computed by `ComputeFstat`.
+    windowRange: lalpulsar.transientWindowRange_t
+        The structure defining the transient parameters.
+
+    Returns
+    -------
+    FstatMap: pyTransientFstatMap
+        The computed results, see the class definition for details.
+    """
+    FstatMap_lalpulsar = lalpulsar.ComputeTransientFstatMap(
+        multiFstatAtoms=multiFstatAtoms,
+        windowRange=windowRange,
+        useFReg=False,
+    )
+    return pyTransientFstatMap(transientFstatMap_t=FstatMap_lalpulsar)
+
+
 def reshape_FstatAtomsVector(atomsVector):
     """Make a dictionary of ndarrays out of an F-stat atoms 'vector' structure.
 
@@ -388,12 +433,7 @@ def pycuda_compute_transient_fstat_map(multiFstatAtoms, windowRange):
     Returns
     -------
     FstatMap: pyTransientFstatMap
-        A 2D matrix `F_mn`,
-        with `m` an index over start-times `t0`,
-        and  `n` an index over duration parameters `tau`,
-        in steps of `dt0`  in `[t0,  t0+t0Band]`,
-        and `dtau` in `[tau, tau+tauBand]`
-        as defined in the `windowRange` input.
+        The computed results, see the class definition for details.
     """
 
     if windowRange.type >= lalpulsar.TRANSIENT_LAST:

--- a/tests.py
+++ b/tests.py
@@ -787,7 +787,7 @@ class TestComputeFstat(BaseForTestsWithData):
             maxCoverFreq=self.F0 + 0.1,
             BSGL=True,
         )
-        log10BSGL = search_H1L1.get_fullycoherent_twoF(
+        log10BSGL = search_H1L1.get_fullycoherent_detstat(
             F0=self.F0,
             F1=self.F1,
             F2=self.F2,
@@ -816,7 +816,7 @@ class TestComputeFstat(BaseForTestsWithData):
             maxCoverFreq=self.F0 + 0.1,
             BSGL=True,
         )
-        log10BSGL = search_H1L1.get_fullycoherent_twoF(
+        log10BSGL = search_H1L1.get_fullycoherent_detstat(
             F0=self.F0,
             F1=self.F1,
             F2=self.F2,
@@ -846,7 +846,7 @@ class TestComputeFstat(BaseForTestsWithData):
             self.Writer.Delta,
             num_segments=Nsft + 1,
         )
-        twoF = search.get_fullycoherent_twoF(
+        twoF = search.get_fullycoherent_detstat(
             F0=self.Writer.F0,
             F1=self.Writer.F1,
             F2=self.Writer.F2,
@@ -857,7 +857,7 @@ class TestComputeFstat(BaseForTestsWithData):
         )
         reldiff = np.abs(twoF_cumulative[-1] - twoF) / twoF
         print(
-            "2F from get_fullycoherent_twoF() is {:.4f}"
+            "2F from get_fullycoherent_detstat() is {:.4f}"
             " while last value from calculate_twoF_cumulative() is {:.4f};"
             " relative difference: {:g}".format(twoF, twoF_cumulative[-1], reldiff)
         )

--- a/tests.py
+++ b/tests.py
@@ -1593,6 +1593,7 @@ class TestGridSearch(BaseForTestsWithData):
     F0s = [29.999, 30.001, 1e-4]
     F1s = [-1e-10, 0, 1e-11]
     Band = 0.5
+    BSGL = False
 
     def test_grid_search(self):
         search = pyfstat.GridSearch(
@@ -1605,6 +1606,7 @@ class TestGridSearch(BaseForTestsWithData):
             Alphas=[self.Writer.Alpha],
             Deltas=[self.Writer.Delta],
             tref=self.tref,
+            BSGL=self.BSGL,
         )
         search.run()
         self.assertTrue(os.path.isfile(search.out_file))
@@ -1638,7 +1640,7 @@ class TestGridSearch(BaseForTestsWithData):
         cl_CFSv2.append("--FreqBand {}".format(self.F0s[1] - self.F0s[0]))
         cl_CFSv2.append("--dFreq {}".format(self.F0s[2]))
         cl_CFSv2.append("--f1dot {} --f1dotBand 0".format(self.F1))
-        cl_CFSv2.append("--DataFiles " + self.Writer.sftfilepath)
+        cl_CFSv2.append("--DataFiles '{}'".format(self.Writer.sftfilepath))
         cl_CFSv2.append("--refTime {}".format(self.tref))
         earth_ephem, sun_ephem = pyfstat.helper_functions.get_ephemeris_files()
         if earth_ephem is not None:
@@ -1678,6 +1680,7 @@ class TestGridSearch(BaseForTestsWithData):
             Deltas=[self.Writer.Delta],
             tref=self.tref,
             nsegs=2,
+            BSGL=self.BSGL,
         )
         search.run()
         self.assertTrue(os.path.isfile(search.out_file))
@@ -1694,9 +1697,16 @@ class TestGridSearch(BaseForTestsWithData):
             Deltas=[self.Writer.Delta],
             tref=self.tref,
             tglitchs=[self.tref],
+            # BSGL=self.BSGL,  # not supported by this class
         )
         search.run()
         self.assertTrue(os.path.isfile(search.out_file))
+
+
+class TestGridSearchBSGL(TestGridSearch):
+    label = "TestGridSearchBSGL"
+    detectors = "H1,L1"
+    BSGL = True
 
 
 class TestTransientGridSearch(BaseForTestsWithData):


### PR DESCRIPTION
Here's another big messy PR changing lots of internals, with the main goal to fix the BSGL implementation, but along the way cleaning up the way the likelihood and detection statistic functions are called and outputs are stored. It also adds some basic test cases and examples for BSGL usage in both grid and MCMC classes, resolving #99.

Some highlights from the commits:
---
- fixed basic twoFX and BSGL computation logic for transient and semicoherent cases, generalized to Ndet>2
- split up the various detection statistic methods into generic and specific ones
- introduce generic `_get_detstat_from_loglikelihood()`
- fix missing logic for BSGL case in various places
- for MCMC classes:
  - clarify likelihood-detstat relation, `_set_likelihoodcoef()` now also takes care of twoF->F and of BSGL case
  - new `_set_point_for_evaluation` method to centrally merge fixed and samples parameters
  - in BSGL case, export both twoF and BSGL, but not yet twoFX
- for grid classes:
  - in BSGL case, export all of twoF, twoFX and BSGL
  - now call `_initiate_search_object()` from `__init__()` instead of from `run()`
- for transients: explicitly call the standard detection statistic `maxTwoF`
- new test cases and examples
- lots of documentation and cleanup changes

_Not_ done in this PR:
---
- enable BSGL for glitch search classes; put in an explicit error message instead
- adding explicit user options for the BSGL tuning parameters (note that MCMC classes already have a `rhohatmax` option which could be reused, as that happens to be an equivalent parameter to BSGL's `Fstar0`)
- adding strict quantitative tests
- changing the choices for how "transient BSGL" is done, which may not be the best currently
- finishing up the implementation and output of single-IFO F-stats on multi-IFO searches - currently these are only computed when `BSGL` option is set, and only exported from grid- not from MCMC searches. A followup should compute and export them always when Ndet>=2 (as they're essentially for free).
- further work on transient detection statistic choices - we should also wrap the PGM11 transient marginalized Bayes factor

Review / status:
---
@GregoryAshton @Rodrigo-Tenorio this will have to wait to be rebased on top of #226 #227 #243 anyway, but comments are welcome already. As announced, the diff is messy though. @ReinhardPrix several of the changes here should have a lot of nostalgic value for you too. ;)