### PR TITLE
Sphinx include readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 *pyc
 *swp
 docs/build/
-source/*_examples/
+docs/source/*_example*/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a python package providing an interface to perform F-statistic based
 continuous gravitational wave (CW) searches,
-built on top of the [LALSuite](https://doi.org/10.7935/GT1W-FZ16) library.
+built on top of the [LALSuite library](https://doi.org/10.7935/GT1W-FZ16).
 
 Getting started:
 * This README provides information on
@@ -71,7 +71,7 @@ If getting PyFstat from conda-forge, it already includes the required ephemeride
 PyPi releases are available from https://pypi.org/project/PyFstat/.
 
 Note that the PyFstat installation will fail at the
-[LALSuite](https://pypi.org/project/lalsuite/) dependency stage
+LALSuite dependency stage
 if your `pip` is too old (e.g. 18.1); to be on the safe side, before starting do
 ```
 pip install --upgrade pip
@@ -181,7 +181,7 @@ For a general introduction to installing modules, see
   as these checks are required to pass by the online integration pipeline.
 * Some optional plotting methods depend on the additional package
   [chainconsumer](https://github.com/Samreay/ChainConsumer)
-  and some of the [examples](./examples) require this to run.
+  and some of the [example scripts](./examples) require this to run.
   For `pip` users, this is most conveniently installed by
 ```
 pip install chainconsumer
@@ -283,8 +283,14 @@ Other contributors:
 ## Citing this work
 
 If you use `PyFstat` in a publication we would appreciate if you cite both a DOI for the software itself (see below)
-and the original paper introducing the code: Ashton&Prix 2018 [[inspire](https://inspirehep.net/literature/1655200)] [[ADS](https://ui.adsabs.harvard.edu/abs/2018PhRvD..97j3020A/)].
-If you use the transient module, please also cite: Keitel&Ashton 2018 [[inspire](https://inspirehep.net/literature/1673205)] [[ADS](https://ui.adsabs.harvard.edu/abs/2018CQGra..35t5003K/)].
+and the original paper introducing the code:
+[Ashton&Prix 2018](https://doi.org/10.1103/PhysRevD.97.103020)
+([inspire:1655200](https://inspirehep.net/literature/1655200)
+/ [ADS:2018PhRvD..97j3020A](https://ui.adsabs.harvard.edu/abs/2018PhRvD..97j3020A/)).
+If you use the transient module, please also cite:
+[Keitel&Ashton 2018](https://doi.org/10.1088/1361-6382/aade34)
+([inspire:1673205](https://inspirehep.net/literature/1673205)
+/ [ADS:2018CQGra..35t5003K](https://ui.adsabs.harvard.edu/abs/2018CQGra..35t5003K/)).
 
 If you'd like to cite the `PyFstat` package in general,
 or versions from 1.5.x upwards,
@@ -313,7 +319,10 @@ the DOIs for those versions can be found from the sidebar at
 [this older Zenodo record](https://doi.org/10.5281/zenodo.1243930)
 and please amend the BibTeX entry accordingly.
 
-PyFstat makes generous use of functionality from the [LALSuite](https://doi.org/10.7935/GT1W-FZ16) library
+PyFstat makes generous use of functionality from the LALSuite library
 and it will usually be appropriate to also cite that project
-(see [here](https://git.ligo.org/lscsoft/lalsuite/#acknowledgment) for a recommended bibtex entry)
-and also [Wette 2020](https://doi.org/10.1016/j.softx.2020.100634) ([inspire](https://inspirehep.net/literature/1837108) / [ADS](https://ui.adsabs.harvard.edu/abs/2020SoftX..1200634W/abstract)) for the C-to-python [SWIG](http://www.swig.org) bindings.
+(see [this recommended bibtex entry](https://git.ligo.org/lscsoft/lalsuite/#acknowledgment))
+and also [Wette 2020](https://doi.org/10.1016/j.softx.2020.100634)
+([inspire:1837108](https://inspirehep.net/literature/1837108)
+/ [ADS:2020SoftX..1200634W](https://ui.adsabs.harvard.edu/abs/2020SoftX..1200634W/))
+for the C-to-python [SWIG](http://www.swig.org) bindings.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ sphinx==3.4.3
 sphinx_rtd_theme==0.5.1
 sphinx_gallery==0.8.2
 m2r2==0.2.7
+Pillow==8.1.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
-sphinx==3.4.1
-sphinx_rtd_theme==0.5.0
+sphinx==3.4.3
+sphinx_rtd_theme==0.5.1
 sphinx_gallery==0.8.2
+m2r2==0.2.7

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,6 +37,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
     "sphinx_gallery.gen_gallery",
+    "m2r2",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -24,11 +24,11 @@ meaning for example that you'll need to use the jupyter file browser to find
 the plots which are saved to files instead of being directly displayed.
 
 .. toctree::
-    binary_examples/index
-    followup_examples/index
-    glitch_examples/index
     grid_examples/index
     mcmc_examples/index
     mcmc_vs_grid_simple_example/index
-    other_examples/index
+    followup_examples/index
+    binary_examples/index
+    glitch_examples/index
     transient_examples/index
+    other_examples/index

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -1,11 +1,27 @@
 Examples
 =========================
 
+This part of the documentation covers a suite of examples
+intended to demonstrate the various applications of PyFstat
+in searching for
+`continuous gravitational waves (CWs) <https://www.ligo.org/science/GW-Continuous.php>`_,
+using different grid- and MCMC-based methods,
+as well as some of the additional helper utilities included in the package.
+
+The examples are simple stand-alone python scripts that can be run
+after
+:doc:`installing the PyFstat package <readme>`
+and downloading the example itself from these pages
+(or from `github <https://github.com/PyFstat/PyFstat/tree/master/examples>`_).
+Alternatively, they can be run interactively through Binder:
+
 .. image:: https://img.shields.io/badge/Run%20jupyter%20notebooks-binder-579ACA.svg?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFkAAABZCAMAAABi1XidAAAB8lBMVEX///9XmsrmZYH1olJXmsr1olJXmsrmZYH1olJXmsr1olJXmsrmZYH1olL1olJXmsr1olJXmsrmZYH1olL1olJXmsrmZYH1olJXmsr1olL1olJXmsrmZYH1olL1olJXmsrmZYH1olL1olL0nFf1olJXmsrmZYH1olJXmsq8dZb1olJXmsrmZYH1olJXmspXmspXmsr1olL1olJXmsrmZYH1olJXmsr1olL1olJXmsrmZYH1olL1olLeaIVXmsrmZYH1olL1olL1olJXmsrmZYH1olLna31Xmsr1olJXmsr1olJXmsrmZYH1olLqoVr1olJXmsr1olJXmsrmZYH1olL1olKkfaPobXvviGabgadXmsqThKuofKHmZ4Dobnr1olJXmsr1olJXmspXmsr1olJXmsrfZ4TuhWn1olL1olJXmsqBi7X1olJXmspZmslbmMhbmsdemsVfl8ZgmsNim8Jpk8F0m7R4m7F5nLB6jbh7jbiDirOEibOGnKaMhq+PnaCVg6qWg6qegKaff6WhnpKofKGtnomxeZy3noG6dZi+n3vCcpPDcpPGn3bLb4/Mb47UbIrVa4rYoGjdaIbeaIXhoWHmZYHobXvpcHjqdHXreHLroVrsfG/uhGnuh2bwj2Hxk17yl1vzmljzm1j0nlX1olL3AJXWAAAAbXRSTlMAEBAQHx8gICAuLjAwMDw9PUBAQEpQUFBXV1hgYGBkcHBwcXl8gICAgoiIkJCQlJicnJ2goKCmqK+wsLC4usDAwMjP0NDQ1NbW3Nzg4ODi5+3v8PDw8/T09PX29vb39/f5+fr7+/z8/Pz9/v7+zczCxgAABC5JREFUeAHN1ul3k0UUBvCb1CTVpmpaitAGSLSpSuKCLWpbTKNJFGlcSMAFF63iUmRccNG6gLbuxkXU66JAUef/9LSpmXnyLr3T5AO/rzl5zj137p136BISy44fKJXuGN/d19PUfYeO67Znqtf2KH33Id1psXoFdW30sPZ1sMvs2D060AHqws4FHeJojLZqnw53cmfvg+XR8mC0OEjuxrXEkX5ydeVJLVIlV0e10PXk5k7dYeHu7Cj1j+49uKg7uLU61tGLw1lq27ugQYlclHC4bgv7VQ+TAyj5Zc/UjsPvs1sd5cWryWObtvWT2EPa4rtnWW3JkpjggEpbOsPr7F7EyNewtpBIslA7p43HCsnwooXTEc3UmPmCNn5lrqTJxy6nRmcavGZVt/3Da2pD5NHvsOHJCrdc1G2r3DITpU7yic7w/7Rxnjc0kt5GC4djiv2Sz3Fb2iEZg41/ddsFDoyuYrIkmFehz0HR2thPgQqMyQYb2OtB0WxsZ3BeG3+wpRb1vzl2UYBog8FfGhttFKjtAclnZYrRo9ryG9uG/FZQU4AEg8ZE9LjGMzTmqKXPLnlWVnIlQQTvxJf8ip7VgjZjyVPrjw1te5otM7RmP7xm+sK2Gv9I8Gi++BRbEkR9EBw8zRUcKxwp73xkaLiqQb+kGduJTNHG72zcW9LoJgqQxpP3/Tj//c3yB0tqzaml05/+orHLksVO+95kX7/7qgJvnjlrfr2Ggsyx0eoy9uPzN5SPd86aXggOsEKW2Prz7du3VID3/tzs/sSRs2w7ovVHKtjrX2pd7ZMlTxAYfBAL9jiDwfLkq55Tm7ifhMlTGPyCAs7RFRhn47JnlcB9RM5T97ASuZXIcVNuUDIndpDbdsfrqsOppeXl5Y+XVKdjFCTh+zGaVuj0d9zy05PPK3QzBamxdwtTCrzyg/2Rvf2EstUjordGwa/kx9mSJLr8mLLtCW8HHGJc2R5hS219IiF6PnTusOqcMl57gm0Z8kanKMAQg0qSyuZfn7zItsbGyO9QlnxY0eCuD1XL2ys/MsrQhltE7Ug0uFOzufJFE2PxBo/YAx8XPPdDwWN0MrDRYIZF0mSMKCNHgaIVFoBbNoLJ7tEQDKxGF0kcLQimojCZopv0OkNOyWCCg9XMVAi7ARJzQdM2QUh0gmBozjc3Skg6dSBRqDGYSUOu66Zg+I2fNZs/M3/f/Grl/XnyF1Gw3VKCez0PN5IUfFLqvgUN4C0qNqYs5YhPL+aVZYDE4IpUk57oSFnJm4FyCqqOE0jhY2SMyLFoo56zyo6becOS5UVDdj7Vih0zp+tcMhwRpBeLyqtIjlJKAIZSbI8SGSF3k0pA3mR5tHuwPFoa7N7reoq2bqCsAk1HqCu5uvI1n6JuRXI+S1Mco54YmYTwcn6Aeic+kssXi8XpXC4V3t7/ADuTNKaQJdScAAAAAElFTkSuQmCC
    :target: https://mybinder.org/v2/gh/PyFstat/PyFstat/master
 
-Application of PyFstat to different continuous wave (CW) sources using 
-different search methods:
+Note though that the examples have currently not yet been optimized
+the interactive notebook experience,
+meaning for example that you'll need to use the jupyter file browser to find
+the plots which are saved to files instead of being directly displayed.
 
 .. toctree::
     binary_examples/index

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,12 +1,14 @@
 Welcome to PyFstat's documentation!
 ===================================
 
-NOTE the html documentation is work in progress,
-likely contains many formatting issues,
-and is not guaranteed to be complete.
+This is a python package providing an interface to perform F-statistic based
+searches for
+`continuous gravitational waves (CWs) <https://www.ligo.org/science/GW-Continuous.php>`_,
+built on top of the
+`LALSuite library <https://doi.org/10.7935/GT1W-FZ16>`_.
 
-The main repository for PYFstat can be found at
-`github.com/PyFstat/PyFstat <https://github.com/PyFstat/PyFstat>`_
+The source repository and issue tracker for PyFstat can be found at
+`github.com/PyFstat/PyFstat <https://github.com/PyFstat/PyFstat>`_.
 
 .. toctree::
    :maxdepth: 3

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,10 +5,14 @@ NOTE the html documentation is work in progress,
 likely contains many formatting issues,
 and is not guaranteed to be complete.
 
+The main repository for PYFstat can be found at
+`github.com/PyFstat/PyFstat <https://github.com/PyFstat/PyFstat>`_
+
 .. toctree::
    :maxdepth: 3
    :caption: Contents:
 
+   readme
    modules
    examples
 

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -5,6 +5,11 @@
 PyFstat module documentation
 ============================
 
+These pages document the full API and set of classes provided by PyFstat.
+
+See :doc:`here <readme>` for installation instructions and
+other general information.
+
 .. toctree::
    :maxdepth: 4
 

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -2,8 +2,8 @@
    sphinx-apidoc -f -o source ../ ../versioneer.py ../setup.py
    (everything after the first "../" are exclude patterns)
 
-PyFstat
-=======
+PyFstat module documentation
+============================
 
 .. toctree::
    :maxdepth: 4

--- a/docs/source/pyfstat.rst
+++ b/docs/source/pyfstat.rst
@@ -1,6 +1,11 @@
 pyfstat package
 ===============
 
+These pages document the full API and set of classes provided by PyFstat.
+
+See :doc:`here <readme>` for installation instructions and
+other general information.
+
 Submodules
 ----------
 

--- a/docs/source/readme.rst
+++ b/docs/source/readme.rst
@@ -6,4 +6,7 @@ This is equivalent to the package's
 `README.md file <https://github.com/PyFstat/PyFstat/blob/master/README.md>`_
 .
 
+See :doc:`here <pyfstat>` for the full API documentation.
+
+
 .. mdinclude:: ../../README.md 

--- a/docs/source/readme.rst
+++ b/docs/source/readme.rst
@@ -1,0 +1,9 @@
+This page contains basic information about the PyFstat package,
+including installation instructions,
+a contributing guide
+and the proper way to cite the package and the underlying scientific literature.
+This is equivalent to the package's
+`README.md file <https://github.com/PyFstat/PyFstat/blob/master/README.md>`_
+.
+
+.. mdinclude:: ../../README.md 


### PR DESCRIPTION
Uses [m2r2](https://pypi.org/project/m2r2/) to directly include the `README.md` into the sphinx html pages. Notes:

- most tutorials still recommend the original `m2r` but it seems to be abandoned
- md->rst involves conforming to rst's very picky standards, which include issuing warnings for multiple external links with the displayed text ("Duplicate explicit target name"). I didn't find a simple workaround, so I just modified the README to only use unique link texts.
- `readme.rst` doesn't have a heading on purpose, because that would lead to duplication in the TOC.

Also:

- [x] add `Pillow` dependency since, according to https://sphinx-gallery.github.io/stable/index.html#install-via-pip:
> Sphinx-Gallery will not manage its dependencies when installing
- [x] followup `.gitignore` fix from #247