### PR TITLE
sphinx: use pyfstat.__version__ at least on local builds

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -22,5 +22,9 @@ formats:
 python:
   version: 3.8
   install:
-    - requirements: docs/requirements.txt
-    - requirements: requirements.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
+    - method: setuptools
+      path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -22,9 +22,6 @@ formats:
 python:
   version: 3.8
   install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
+    - requirements: docs/requirements.txt
     - method: setuptools
       path: .

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,6 +12,7 @@
 #
 import os
 import sys
+import pyfstat
 
 sys.path.insert(0, os.path.abspath("../../"))
 sys.path.insert(0, os.path.abspath("../../pyfstat/"))
@@ -23,7 +24,8 @@ copyright = "2020, Gregory Ashton, David Keitel, Reinhard Prix, Rodrigo Tenorio"
 author = "Gregory Ashton, David Keitel, Reinhard Prix, Rodrigo Tenorio"
 
 # The full version, including alpha/beta/rc tags
-release = "master"
+version = pyfstat.__version__
+release = version
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
For the actual readthedocs builds, this doesn't seem to be currently possible:
* https://github.com/readthedocs/readthedocs.org/issues/4529
But for PRs the extra banner is clear enough, "latest" is always "latest" by definition, and while it would be nice to say on "stable" which version it is, at least I can "activate" additional stable-stable tagged versions for posterity.