### PR TITLE
bump to lalsuite>=6.80 and use lalpulsar.ValidateSFTFile()

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ tqdm
 bashplotlib
 peakutils
 pathos
-lalsuite>=6.76
+lalsuite>=6.80
 versioneer

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         "bashplotlib",
         "peakutils",
         "pathos",
-        "lalsuite>=6.76",
+        "lalsuite>=6.80",
         "versioneer",
     ],
 )

--- a/tests.py
+++ b/tests.py
@@ -219,10 +219,7 @@ class TestWriter(BaseForTestsWithData):
             ),
         )
         self.assertTrue(os.path.isfile(expected_outfile))
-        cl_validate = "lalapps_SFTvalidate " + expected_outfile
-        pyfstat.helper_functions.run_commandline(
-            cl_validate, raise_error=True, return_output=False
-        )
+        self.assertTrue(lalpulsar.ValidateSFTFile(expected_outfile) == 0)
 
     def test_makefakedata_usecached(self):
         if os.path.isfile(self.Writer.config_file_name):


### PR DESCRIPTION
This was introduced in https://git.ligo.org/lscsoft/lalsuite/-/merge_requests/1428 and can now be used instead of the `lalapps` equivalent. We only used that one once in the tests, though.

Using the opportunity for a general lalsuite requirement version bump too, also to exercise our release and upgrade chain when it comes to those...

@Rodrigo-Tenorio main review question: am I overlooking any other place where versions are defined for conda/docker/...?