### PR TITLE
do NOT always set matplotlib backend to agg

### DIFF
--- a/pyfstat/helper_functions.py
+++ b/pyfstat/helper_functions.py
@@ -48,7 +48,6 @@ def set_up_optional_tqdm():
 
 def set_up_matplotlib_defaults():
     """Sets some defaults for matplotlib plotting."""
-    plt.switch_backend("Agg")
     plt.rcParams["text.usetex"] = shutil.which("latex") is not None
     plt.rcParams["axes.formatter.useoffset"] = False
 


### PR DESCRIPTION
 - this was still done through helper_functions.set_up_matplotlib_defaults()
 - instead, we should only rely on the optional import logic
   based on whether "DISPLAY" is set in the env
 - closes #268

Works for me on my laptop and on CIT. @Rodrigo-Tenorio any concerns this may be a problem in docker containers?