### PR TITLE
Add parent flag to mkdir for venv ephemerides

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ or by creating a `~/.pyfstat.conf` file as described further below.
 If you are working with a virtual environment,
 you should be able to get a full working ephemerides installation with these commands:
 ```
-mkdir $VIRTUAL_ENV/share/lalpulsar
+mkdir -p $VIRTUAL_ENV/share/lalpulsar
 wget https://git.ligo.org/lscsoft/lalsuite/raw/master/lalpulsar/lib/earth00-40-DE405.dat.gz -P $VIRTUAL_ENV/share/lalpulsar
 wget https://git.ligo.org/lscsoft/lalsuite/raw/master/lalpulsar/lib/sun00-40-DE405.dat.gz -P $VIRTUAL_ENV/share/lalpulsar
 echo 'export LALPULSAR_DATADIR=$VIRTUAL_ENV/share/lalpulsar' >> ${VIRTUAL_ENV}/bin/activate


### PR DESCRIPTION
Hi, I'm doing the review for the JOSS submission about PyFstat (openjournals/joss-reviews#3000) and while following the installation instructions ran into a minor issue with the venv ephemerides installation snippet, it says to run `mkdir $VIRTUAL_ENV/share/lalpulsar` which can fail if `mkdir $VIRTUAL_ENV/share` does not exist with a `mkdir: cannot create directory` error.

This PR just adds a `-p` flag to the mkdir command so create any missing parent directories.