### PR TITLE
pin numpy<1.20 to fix lalsuite incompatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy<1.20
 matplotlib>=2.1
 scipy
 ptemcee

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
     python_requires=">=%s.%s.%s" % min_python_version[:3],
     install_requires=[
-        "numpy",
+        "numpy<1.20",
         "matplotlib>=2.1",
         "scipy",
         "ptemcee",


### PR DESCRIPTION
 - see https://git.ligo.org/lscsoft/lalsuite/-/issues/414
 - should hopefully fix #272