### PR TITLE
FrequencyModulatedArtifactWriter: Juggle input params to circumvent a parent check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
  - pinned numpy dependency to <1.20 to fix incompatibility with lalsuite 6.81
  - updated ephemerides instructions and citation requests in README
+ - fixed setup of FrequencyModulatedArtifactWriter class
 
 ## 1.11.1 [26/01/2021]
 

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -1262,7 +1262,14 @@ class FrequencyModulatedArtifactWriter(Writer):
         self.phi = 0
         self.F2 = 0
 
+        self.cosi = 0
+        self.noiseSFTs = None
+
+        h0_value = self.h0
+        self.h0 = None
         self._basic_setup()
+        self.h0 = h0_value
+
         self.set_ephemeris_files(earth_ephem, sun_ephem)
         self.tstart = int(tstart)
         self.duration = int(duration)
@@ -1275,7 +1282,6 @@ class FrequencyModulatedArtifactWriter(Writer):
         self.nsfts = int(np.ceil(self.duration / self.Tsft))
         self.calculate_fmin_Band()
 
-        self.cosi = 0
         self.Fmax = F0
 
         if Alpha is not None and Delta is not None:

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -1264,7 +1264,11 @@ class FrequencyModulatedArtifactWriter(Writer):
 
         self.cosi = 0
         self.noiseSFTs = None
-
+# The _basic_setup() method inherited from Writer
+# requires additional CW signal parameters if h0>0,
+# which an artifact doesn't need to have,
+# hence we temporarily unset it here as a workaround
+# and restore it after the method call.
         h0_value = self.h0
         self.h0 = None
         self._basic_setup()

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -1264,11 +1264,11 @@ class FrequencyModulatedArtifactWriter(Writer):
 
         self.cosi = 0
         self.noiseSFTs = None
-# The _basic_setup() method inherited from Writer
-# requires additional CW signal parameters if h0>0,
-# which an artifact doesn't need to have,
-# hence we temporarily unset it here as a workaround
-# and restore it after the method call.
+        # The _basic_setup() method inherited from Writer
+        # requires additional CW signal parameters if h0>0,
+        # which an artifact doesn't need to have,
+        # hence we temporarily unset it here as a workaround
+        # and restore it after the method call.
         h0_value = self.h0
         self.h0 = None
         self._basic_setup()


### PR DESCRIPTION
- Checks in `_basic_setup` clash against different options in Artifact.
- Now it works.