### PR TITLE
avoid duplicate checks on internal PRs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,6 +5,9 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    # We want to run on external PRs, but not on our own internal PRs as they'll be run
+    # by the push to the branch.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]


### PR DESCRIPTION
Followup to #276 trying to avoid this situation:
![Screenshot_20210211_213916](https://user-images.githubusercontent.com/28396587/107695940-97663080-6cb1-11eb-915a-78741c19a686.png)


- solution by dantup & johnbillion at https://github.community/t/duplicate-checks-on-push-and-pull-request-simultaneous-event/18012