### PR TITLE
remove tests from compiled docs

### DIFF
--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -14,4 +14,3 @@ other general information.
    :maxdepth: 4
 
    pyfstat
-   tests

--- a/docs/source/tests.rst
+++ b/docs/source/tests.rst
@@ -1,7 +1,0 @@
-tests module
-============
-
-.. automodule:: tests
-   :members:
-   :undoc-members:
-   :show-inheritance:


### PR DESCRIPTION
@Rodrigo-Tenorio as discussed: [the generated page](https://pyfstat.readthedocs.io/en/v1.11.2/tests.html) isn't really useful anyway, and most other packages in the field don't seem to document their test suite on Readthedocs either.