### PR TITLE
Fix line writer cache

### DIFF
--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -223,6 +223,18 @@ class Writer(BaseSearchClass):
     LAL routines would silently parse them wrongly.
     """
 
+    required_signal_params = [
+        # leaving out "F1","F2","psi","phi","tref" as they have defaults
+        "F0",
+        "Alpha",
+        "Delta",
+        "cosi",
+    ]
+    """List of parameters required for a successful execution of Makefakedata_v5.
+    The rest of available parameters are not required as they have default values
+    silently given by Makefakedata_v5
+    """
+
     @helper_functions.initializer
     def __init__(
         self,
@@ -501,19 +513,12 @@ class Writer(BaseSearchClass):
         self.config_file_name = os.path.join(self.outdir, self.label + ".cff")
         self.theta = np.array([self.phi, self.F0, self.F1, self.F2])
 
-        required_signal_params = [
-            # leaving out "F1","F2","psi","phi","tref" as they have defaults
-            "F0",
-            "Alpha",
-            "Delta",
-            "cosi",
-        ]
         if self.h0 and np.any(
-            [getattr(self, k, None) is None for k in required_signal_params]
+            [getattr(self, k, None) is None for k in self.required_signal_params]
         ):
             raise ValueError(
                 "If h0>0, also need all of ({:s})".format(
-                    ",".join(required_signal_params)
+                    ",".join(self.required_signal_params)
                 )
             )
 

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -1024,8 +1024,7 @@ class LineWriter(Writer):
     NOTE: This functionality is implemented via `lalapps_MakeFakeData_v4`'s `lineFeature` option.
     This version of MFD only supports one interferometer at a time.
 
-    NOTE: All signal parameters except for `h0` and `cosi` will be ignored.
-    `cosi` is used to rescale `h0` with the usual `sqrt(cosi**4 + 6*cosi**2 + 1)` relation.
+    NOTE: All signal parameters except for `h0`, `Freq`, `phi0` and transient parameters will be ignored.
     """
 
     mfd = "lalapps_Makefakedata_v4"
@@ -1035,7 +1034,6 @@ class LineWriter(Writer):
         "Freq",
         "phi0",
         "h0",
-        "cosi",
         "transientWindowType",
         "transientStartTime",
         "transientTau",
@@ -1089,16 +1087,6 @@ class LineWriter(Writer):
             self.signal_formats["transientTauDays"] = self.signal_formats.pop(
                 "transientTau"
             )
-
-        if "cosi" in self.signal_parameters:
-            logging.info(
-                "Computing h0_eff from h0 and cosi. "
-                "This value will be stored in h0, "
-                "as cosi is *not* used by lineFeature."
-            )
-            eta = self.signal_parameters["cosi"]
-            eta2 = eta * eta
-            self.signal_parameters["h0"] *= np.sqrt(eta2 * eta2 + 6 * eta2 + 1)
 
     def calculate_fmin_Band(self):
         """Set fmin and Band for the output SFTs to cover.

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -1035,15 +1035,20 @@ class LineWriter(Writer):
     mfd = "lalapps_Makefakedata_v4"
     """The executable (older version that supports the `--lineFeature` option)."""
 
-    required_mfd_line_parameters = [
+    required_signal_params = [
         "Freq",
         "phi0",
         "h0",
+    ]
+    """Required parameters for Makefakedata_v4 to success. Any other parameter is
+    silently given a default value by Makefakedata_v4.
+    """
+    signal_parameters_labels = required_signal_params + [
         "transientWindowType",
         "transientStartTime",
         "transientTau",
     ]
-    """Other signal parameters will be removed before passing to MFDv4."""
+    """Other signal parameters will be removed before passing to Makefakedata_v4."""
 
     def __init__(self, *args, **kwargs):
 
@@ -1066,8 +1071,7 @@ class LineWriter(Writer):
         super()._parse_args_consistent_with_mfd()
 
         if any(
-            key not in self.required_mfd_line_parameters
-            for key in self.signal_parameters
+            key not in self.required_signal_params for key in self.signal_parameters
         ):
             logging.warning(
                 "Injection of line artifacts only uses the following parameters:\n"
@@ -1075,7 +1079,7 @@ class LineWriter(Writer):
                 "Any other parameter will be purged from this class now"
             )
             params_to_purge = list(
-                set(self.signal_parameters) - set(self.required_mfd_line_parameters)
+                set(self.signal_parameters) - set(self.required_signal_params)
             )
             logging.info(
                 "Purging input parameters that are not meaningful for LineWriter: {}".format(

--- a/tests.py
+++ b/tests.py
@@ -45,7 +45,7 @@ default_Writer_params = {
     "Band": None,
 }
 
-default_signal_params = {
+default_signal_params_no_sky = {
     "F0": 30.0,
     "F1": -1e-10,
     "F2": 0,
@@ -53,8 +53,11 @@ default_signal_params = {
     "cosi": 0,
     "psi": 0,
     "phi": 0,
-    "Alpha": 5e-1,
-    "Delta": 1.2,
+}
+
+default_signal_params = {
+    **default_signal_params_no_sky,
+    **{"Alpha": 5e-1, "Delta": 1.2},
 }
 
 
@@ -503,6 +506,7 @@ class TestWriter(BaseForTestsWithData):
 class TestLineWriter(TestWriter):
     label = "TestLineWriter"
     writer_class_to_test = pyfstat.make_sfts.LineWriter
+    signal_parameters = default_signal_params_no_sky
     multi_detectors = "H1"
 
     def test_multi_ifo_fails(self):

--- a/tests.py
+++ b/tests.py
@@ -520,6 +520,9 @@ class TestLineWriter(TestWriter):
                 **self.signal_parameters,
             )
 
+    def test_makefakedata_usecached(self):
+        pass
+
     def _check_maximum_power_consistency(self, writer, return_line_power=False):
         times, freqs, data = pyfstat.helper_functions.get_sft_array(writer.sftfilepath)
         max_power_freq_index = np.argmax(data, axis=0)
@@ -563,35 +566,6 @@ class TestLineWriter(TestWriter):
         writer.make_data(verbose=True)
 
         self._check_maximum_power_consistency(writer)
-
-    def test_cosi_scaling(self):
-        signal_params = default_signal_params.copy()
-        writer = self.writer_class_to_test(
-            outdir=self.outdir,
-            **default_Writer_params,
-            **signal_params,
-            **default_transient_params,
-        )
-
-        writer.make_data()
-        basic_power = self._check_maximum_power_consistency(
-            writer, return_line_power=True
-        )
-
-        signal_params["cosi"] = 1.0
-        writer = self.writer_class_to_test(
-            outdir=self.outdir,
-            **default_Writer_params,
-            **signal_params,
-            **default_transient_params,
-        )
-        writer.make_data()
-        corrected_power = self._check_maximum_power_consistency(
-            writer, return_line_power=True
-        )
-        self.assertTrue(
-            np.allclose(corrected_power / basic_power, np.sqrt(8), rtol=0, atol=1e-2)
-        )
 
 
 class TestWriterOtherTsft(TestWriter):

--- a/tests.py
+++ b/tests.py
@@ -521,7 +521,28 @@ class TestLineWriter(TestWriter):
             )
 
     def test_makefakedata_usecached(self):
-        pass
+
+        # Make everything from scratch
+        writer = self.writer_class_to_test(
+            outdir=self.outdir,
+            **default_Writer_params,
+            **default_signal_params,
+            **default_transient_params,
+        )
+        writer.make_data(verbose=True)
+        first_time = os.path.getmtime(writer.sftfilepath)
+
+        # Re-run, and should be unchanged
+        writer.make_data(verbose=True)
+        second_time = os.path.getmtime(writer.sftfilepath)
+        self.assertTrue(first_time == second_time)
+
+        # third run: touch the .cff to force regeneration
+        time.sleep(1)  # make sure timestamp is actually different!
+        os.system("touch {}".format(writer.config_file_name))
+        writer.run_makefakedata()
+        third_time = os.path.getmtime(writer.sftfilepath)
+        self.assertFalse(first_time == third_time)
 
     def _check_maximum_power_consistency(self, writer, return_line_power=False):
         times, freqs, data = pyfstat.helper_functions.get_sft_array(writer.sftfilepath)

--- a/tests.py
+++ b/tests.py
@@ -238,21 +238,29 @@ class TestWriter(BaseForTestsWithData):
             os.remove(self.Writer.config_file_name)
         if os.path.isfile(self.Writer.sftfilepath):
             os.remove(self.Writer.sftfilepath)
+
         # first run: make everything from scratch
         self.Writer.make_cff(verbose=True)
         self.Writer.run_makefakedata()
         time_first = os.path.getmtime(self.Writer.sftfilepath)
+
         # second run: should re-use .cff and .sft
         self.Writer.make_cff(verbose=True)
         self.Writer.run_makefakedata()
         time_second = os.path.getmtime(self.Writer.sftfilepath)
         self.assertTrue(time_first == time_second)
+
         # third run: touch the .cff to force regeneration
         time.sleep(1)  # make sure timestamp is actually different!
         os.system("touch {}".format(self.Writer.config_file_name))
         self.Writer.run_makefakedata()
         time_third = os.path.getmtime(self.Writer.sftfilepath)
         self.assertFalse(time_first == time_third)
+
+        # fourth run: delete .cff and expect a RuntimeError
+        os.remove(self.Writer.config_file_name)
+        with pytest.raises(RuntimeError):
+            self.Writer.run_makefakedata()
 
     def test_noise_sfts(self):
         randSeed = 69420


### PR DESCRIPTION
Here's the reason for the current test to fail: ~Executables are different~
```
/home/rodrigo/opt/miniconda3/envs/pyfstat-conda/bin/lalapps_Makefakedata_v4 --outSingleSFT=TRUE --outSFTbname="TestData/H-4_H1_1800SFT_testing_cache-700000000-7200.sft" --IFO="H1" --ephemEarth="/home/rodrigo/gravity/venv/pyfstat/share/lalpulsar/earth00-40-DE405.dat.gz" --ephemSun="/home/rodrigo/gravity/venv/pyfstat/share/lalpulsar/sun00-40-DE405.dat.gz" --startTime=700000000 --duration=7200 --fmin=29.96404307059555 --Band=0.07191313888519033 --Tsft=1800 --window="tukey" --tukeyBeta=0.001 --h0=5 --cosi=0 --phi0=0 --Freq=30 --noiseSqrtSh=1 --lineFeature=TRUE --randSeed=42

lalapps_Makefakedata_v4 --lineFeature=TRUE --outSingleSFT=TRUE --outSFTbname="TestData/H-4_H1_1800SFT_testing_cache-700000000-7200.sft" --IFO=H1 --noiseSqrtSh="1" --window="tukey" --tukeyBeta=0.001 --startTime=700000000 --duration=7200 --fmin=29.96404307059555 --Band=0.07191313888519033 --Tsft=1800 --h0 5.0 --Freq 30.0 --phi0 0 --cosi=0 --ephemEarth="/home/rodrigo/gravity/venv/pyfstat/share/lalpulsar/earth00-40-DE405.dat.gz" --ephemSun="/home/rodrigo/gravity/venv/pyfstat/share/lalpulsar/sun00-40-DE405.dat.gz" --randSeed=42
```