### PR TITLE
bump pillow to 8.1.2 in docs/

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,4 @@ sphinx==3.4.3
 sphinx_rtd_theme==0.5.1
 sphinx_gallery==0.8.2
 m2r2==0.2.7
-Pillow==8.1.1
+Pillow==8.1.2


### PR DESCRIPTION
 - dependabot bumped it from 8.1.0 to 8.1.1 in https://github.com/PyFstat/PyFstat/pull/292
 - but next version is also a security fix: https://pillow.readthedocs.io/en/stable/releasenotes/8.1.2.html