### PR TITLE
run_examples.yml: remove external gridcorner dependency

### DIFF
--- a/.github/workflows/run_examples.yml
+++ b/.github/workflows/run_examples.yml
@@ -22,7 +22,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install git+https://gitlab.aei.uni-hannover.de/GregAshton/gridcorner
         pip install chainconsumer
     - name: Set up ephemerides
       run: |


### PR DESCRIPTION
 - should no longer need external gridcorner dependency now that we have an internal copy of it (introduced in #227 )