### PR TITLE
Fix cumulative plots for transients, extend examples and tests

### DIFF
--- a/examples/mcmc_examples/PyFstat_example_fully_coherent_MCMC_search.py
+++ b/examples/mcmc_examples/PyFstat_example_fully_coherent_MCMC_search.py
@@ -9,6 +9,7 @@ fully coherent F-statistic.
 import pyfstat
 import numpy as np
 import os
+from pyfstat.helper_functions import get_predict_fstat_parameters_from_dict
 
 label = "PyFstat_example_fully_coherent_MCMC_search"
 outdir = os.path.join("PyFstat_example_data", label)
@@ -96,3 +97,14 @@ mcmc.run(
 mcmc.print_summary()
 mcmc.plot_corner(add_prior=True, truths=signal_parameters)
 mcmc.plot_prior_posterior(injection_parameters=signal_parameters)
+
+# plot cumulative 2F, first building a dict as required for PredictFStat
+d, maxtwoF = mcmc.get_max_twoF()
+for key, val in mcmc.theta_prior.items():
+    if key not in d:
+        d[key] = val
+d["h0"] = data.h0
+d["cosi"] = data.cosi
+d["psi"] = data.psi
+PFS_input = get_predict_fstat_parameters_from_dict(d)
+mcmc.plot_cumulative_max(PFS_input=PFS_input)

--- a/examples/transient_examples/PyFstat_example_make_data_for_long_transient_search.py
+++ b/examples/transient_examples/PyFstat_example_make_data_for_long_transient_search.py
@@ -25,30 +25,36 @@ duration = 200 * 86400
 
 transient_tstart = tstart + 0.25 * duration
 transient_duration = 0.5 * duration
+transientWindowType = "rect"
 tref = tstart
 
 h0 = 1e-23
 cosi = 0
+psi = 0
+phi = 0
 sqrtSX = 1e-22
 detectors = "H1,L1"
 
-transient = pyfstat.Writer(
-    label="simulated_transient_signal",
-    outdir=outdir,
-    tref=tref,
-    tstart=tstart,
-    duration=duration,
-    F0=F0,
-    F1=F1,
-    F2=F2,
-    Alpha=Alpha,
-    Delta=Delta,
-    h0=h0,
-    cosi=cosi,
-    detectors=detectors,
-    sqrtSX=sqrtSX,
-    transientStartTime=transient_tstart,
-    transientTau=transient_duration,
-    transientWindowType="rect",
-)
-transient.make_data()
+if __name__ == "__main__":
+
+    transient = pyfstat.Writer(
+        label="simulated_transient_signal",
+        outdir=outdir,
+        tref=tref,
+        tstart=tstart,
+        duration=duration,
+        F0=F0,
+        F1=F1,
+        F2=F2,
+        Alpha=Alpha,
+        Delta=Delta,
+        h0=h0,
+        cosi=cosi,
+        detectors=detectors,
+        sqrtSX=sqrtSX,
+        transientStartTime=transient_tstart,
+        transientTau=transient_duration,
+        transientWindowType=transientWindowType,
+    )
+    transient.make_data()
+    print("Predicted 2F from injection Writer:", transient.predict_fstat())

--- a/examples/transient_examples/PyFstat_example_make_data_for_short_transient_search.py
+++ b/examples/transient_examples/PyFstat_example_make_data_for_short_transient_search.py
@@ -27,10 +27,13 @@ duration = 2 * 86400
 
 transient_tstart = tstart + 0.25 * duration
 transient_duration = 0.5 * duration
+transientWindowType = "rect"
 tref = tstart
 
 h0 = 1e-23
 cosi = 0
+psi = 0
+phi = 0
 sqrtSX = 1e-22
 detectors = "H1,L1"
 
@@ -55,8 +58,9 @@ if __name__ == "__main__":
         sqrtSX=sqrtSX,
         transientStartTime=transient_tstart,
         transientTau=transient_duration,
-        transientWindowType="rect",
+        transientWindowType=transientWindowType,
         Tsft=Tsft,
         Band=0.1,
     )
     transient.make_data()
+    print("Predicted 2F from injection Writer:", transient.predict_fstat())

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -1508,6 +1508,20 @@ class ComputeFstat(BaseSearchClass):
                 alpha=0.2,
             )
 
+        if "transient_tstart" in CFS_input and "transient_duration" in CFS_input:
+            ax.axvspan(
+                (CFS_input["transient_tstart"] - actual_tstart_CFS) / 86400.0,
+                (
+                    CFS_input["transient_tstart"]
+                    + CFS_input["transient_duration"]
+                    - actual_tstart_CFS
+                )
+                / 86400.0,
+                color="lightgrey",
+                alpha=0.5,
+                label="transient duration",
+            )
+
         ax.legend(loc="best")
         if savefig:
             plt.tight_layout()

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -1256,6 +1256,8 @@ class ComputeFstat(BaseSearchClass):
         argp=None,
         tstart=None,
         tend=None,
+        transient_tstart=None,
+        transient_duration=None,
         num_segments=1000,
     ):
         """Calculate the cumulative twoF over subsets of the observation span.
@@ -1277,7 +1279,9 @@ class ComputeFstat(BaseSearchClass):
             If outside those: auto-truncated.
         num_segments: int
             Number of segments to split [tstart,tend] into.
-
+        transient_tstart, transient_duration: float or None
+            These are not actually used by this function,
+            but just included so a parameters dict can be safely passed.
         Returns
         -------
         cumulative_durations : ndarray of shape (num_segments,)

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -1455,7 +1455,7 @@ class ComputeFstat(BaseSearchClass):
         # Set up plot-related objects
         axis_kwargs = {
             "xlabel": f"Days from $t_\\mathrm{{start}}={actual_tstart_CFS:.0f}$",
-            "ylabel": "$\\log_{10}(\\mathrm{BSGL})_{\\mathrm{cumulative}$"
+            "ylabel": "$\\log_{10}(\\mathrm{BSGL})_{\\mathrm{cumulative}}$"
             if self.BSGL
             else "$\\widetilde{2\\mathcal{F}}_{\\mathrm{cumulative}}$",
             "xlim": (0, taus_CFS_days[-1]),

--- a/pyfstat/helper_functions.py
+++ b/pyfstat/helper_functions.py
@@ -898,12 +898,13 @@ def get_dictionary_from_lines(lines, comments, raise_error):
     return d
 
 
-def get_predict_fstat_parameters_from_dict(signal_parameters):
+def get_predict_fstat_parameters_from_dict(signal_parameters, transientWindowType=None):
     """Extract a subset of parameters as needed for predicting F-stats.
 
     Given a dictionary with arbitrary signal parameters,
     this extracts only those ones required by `helper_functions.predict_fstat()`:
     Freq, Alpha, Delta, h0, cosi, psi.
+    Also preserves transient parameters, if included in the input dict.
 
     Parameters
     ----------
@@ -912,16 +913,30 @@ def get_predict_fstat_parameters_from_dict(signal_parameters):
         helper_functions.predict_fstat.
         This dictionary's keys must follow
         the PyFstat convention (e.g. F0 instead of Freq).
+    transientWindowType: str
+        Transient window type to store in the output dict.
+        Currently required because the typical input dicts
+        produced by various PyFstat functions
+        tend not to store this property.
+        If there is a key with this name already, its value will be overwritten.
 
     Returns
     -------
     predict_fstat_params: dict
         The dictionary of selected parameters.
     """
-    predict_fstat_params = {
-        key: signal_parameters[key]
-        for key in ["F0", "Alpha", "Delta", "h0", "cosi", "psi"]
+    required_keys = ["F0", "Alpha", "Delta", "h0", "cosi", "psi"]
+    transient_keys = {
+        "transientWindowType": "transientWindowType",
+        "transient_tstart": "transientStartTime",
+        "transient_duration": "transientTau",
     }
+    predict_fstat_params = {key: signal_parameters[key] for key in required_keys}
+    for key in transient_keys:
+        if key in signal_parameters:
+            predict_fstat_params[transient_keys[key]] = signal_parameters[key]
+    if transientWindowType is not None:
+        predict_fstat_params["transientWindowType"] = transientWindowType
     return predict_fstat_params
 
 

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -1239,16 +1239,20 @@ class MCMCSearch(BaseSearchClass):
         `pyfstat.core.ComputeFstat.plot_twoF_cumulative` as they are, using their default argument
         otherwise.
 
-        Keep in mind that one has to explicitely set `savefig=True` to output the figure!
-
         See `pyfstat.core.ComputeFstat.plot_twoF_cumulative` for a comprehensive list of accepted
         arguments and their default values.
+
+        Unlike the core function, here savefig=True is the default,
+        for consistency with other MCMC plotting functions.
         """
         logging.info("Getting cumulative 2F")
         d, maxtwoF = self.get_max_twoF()
         for key, val in self.theta_prior.items():
             if key not in d:
                 d[key] = val
+
+        if kwargs.get("savefig") is None:
+            kwargs["savefig"] = True
 
         self.search.plot_twoF_cumulative(
             CFS_input=d, label=self.label, outdir=self.outdir, **kwargs
@@ -2577,10 +2581,10 @@ class MCMCGlitchSearch(MCMCSearch):
             p0[:, :, -self.nglitch :] = np.sort(p0[:, :, -self.nglitch :], axis=2)
         return p0
 
-    def plot_cumulative_max(self, savefig=False):
+    def plot_cumulative_max(self, savefig=True):
         """
-        Override MCMCSearch.plot_cumulative_max implementation to dea with the
-        split at gltiches.
+        Override MCMCSearch.plot_cumulative_max implementation to deal with the
+        split at glitches.
 
         Parameters
         ----------

--- a/tests.py
+++ b/tests.py
@@ -1756,7 +1756,7 @@ class TestMCMCTransientSearch(BaseForMCMCSearchTests):
         self.search.print_summary()
         self._check_twoF_predicted()
         self._check_mcmc_quantiles(transient=True)
-        # self._test_plots()
+        self._test_plots()
 
     def test_transient_MCMC_tauonly(self):
 
@@ -1782,7 +1782,7 @@ class TestMCMCTransientSearch(BaseForMCMCSearchTests):
         self.search.print_summary()
         self._check_twoF_predicted()
         self._check_mcmc_quantiles(transient=True)
-        # self._test_plots()
+        self._test_plots()
 
     def test_transient_MCMC_t0_tau(self):
 
@@ -1812,7 +1812,7 @@ class TestMCMCTransientSearch(BaseForMCMCSearchTests):
         self.search.print_summary()
         self._check_twoF_predicted()
         self._check_mcmc_quantiles(transient=True)
-        # self._test_plots()
+        self._test_plots()
 
 
 class TestGridSearch(BaseForTestsWithData):

--- a/tests.py
+++ b/tests.py
@@ -740,6 +740,7 @@ class TestPredictFstat(BaseForTestsWithOutdir):
         self.assertAlmostEqual(twoF_sigma, chi2.std(df=4), places=5)
 
     def test_PFS_signal(self):
+        duration = 10 * default_Writer_params["duration"]
         twoF_expected, twoF_sigma = pyfstat.helper_functions.predict_fstat(
             h0=1,
             cosi=0,
@@ -747,15 +748,56 @@ class TestPredictFstat(BaseForTestsWithOutdir):
             Alpha=0,
             Delta=0,
             minStartTime=default_Writer_params["tstart"],
-            duration=default_Writer_params["duration"],
+            duration=duration,
+            IFOs=default_Writer_params["detectors"],
+            assumeSqrtSX=1,
+        )
+        print("predict_fstat() returned:" f" E[2F]={twoF_expected}+-{twoF_sigma}")
+        self.assertTrue(twoF_expected > 4)
+        self.assertTrue(twoF_sigma > 0)
+        # call again but this time using a dictionary of parameters
+        params = {
+            "h0": 1,
+            "cosi": 0,
+            "psi": 0,
+            "Alpha": 0,
+            "Delta": 0,
+            "F0": 0,
+            "F1": 0,
+        }
+        params = pyfstat.helper_functions.get_predict_fstat_parameters_from_dict(params)
+        twoF_expected_dict, twoF_sigma_dict = pyfstat.helper_functions.predict_fstat(
+            **params,
+            minStartTime=default_Writer_params["tstart"],
+            duration=duration,
             IFOs=default_Writer_params["detectors"],
             assumeSqrtSX=1,
         )
         print(
-            "predict_fstat() returned: E[2F]={}+-{}".format(twoF_expected, twoF_sigma)
+            "predict_fstat() called with a dict returned:"
+            f" E[2F]={twoF_expected_dict}+-{twoF_sigma_dict}"
         )
-        self.assertTrue(twoF_expected > 4)
-        self.assertTrue(twoF_sigma > 0)
+        self.assertEqual(twoF_expected_dict, twoF_expected)
+        # add transient parameters
+        params["transientWindowType"] = "rect"
+        params["transient_tstart"] = default_Writer_params["tstart"]
+        params["transient_duration"] = 0.5 * duration
+        params = pyfstat.helper_functions.get_predict_fstat_parameters_from_dict(params)
+        (
+            twoF_expected_transient,
+            twoF_sigma_transient,
+        ) = pyfstat.helper_functions.predict_fstat(
+            **params,
+            minStartTime=default_Writer_params["tstart"],
+            duration=duration,
+            IFOs=default_Writer_params["detectors"],
+            assumeSqrtSX=1,
+        )
+        print(
+            "predict_fstat() called with a dict including a transient returned:"
+            f" E[2F]={twoF_expected_transient}+-{twoF_sigma_transient}"
+        )
+        self.assertTrue(twoF_expected_transient < twoF_expected)
 
 
 class TestBaseSearchClass(unittest.TestCase):


### PR DESCRIPTION
Followup to #315, fixes #316 and extends support for transients in CFS/PFS cumulative functions in general.

Notes:
1. Main change for non-transient applications is that the MCMC cumulative plots will now be saved to a file by default, overriding the behaviour of the core function but better matching all other MCMC plotting methods.
2. For `calculate_twoF_cumulative()` it may be cleaner to refactor it with some kwarg logic, but this will do for now.
3. The addition of a `transientWindowType` override parameter to `get_predict_fstat_parameters_from_dict()` is also a hack, and could have just done it on the level of the examples calling that function, but since it's just a "helper", I think this is fine for now.