### PR TITLE
stop pinning numpy<1.20

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
         "dill",
         "lalsuite>=6.80",
         "matplotlib>=2.1",
-        "numpy<1.20",
+        "numpy",
         "pathos",
         "peakutils",
         "ptemcee",


### PR DESCRIPTION
Since a month or two, LALSuite and numpy are supposed to be on speaking terms again. Let's see if this works.