### PR TITLE
Pump Python3.8 to Python3.9 in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-buster
+FROM python:3.9-buster
 
 WORKDIR /pyfstat-repo
 


### PR DESCRIPTION
Python is dead, long live Python.

