### PR TITLE
integration tests: add weekly and manual triggers

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,6 +1,11 @@
 name: Integration Tests
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron:  '42 9 * * 1'
 
 jobs:
   build:


### PR DESCRIPTION
If I got the syntax right, this should allow triggering the standard integration tests

- manually from the [actions tab](https://github.com/PyFstat/PyFstat/actions), like already for the examples action
- every Monday morning

So we don't risk piling up breaking changes from dependency updates.