### PR TITLE
Update SFT NB file name convention, require python>=3.7 and lalsuite>=7.1

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
     env:
       LALPULSAR_DATADIR: ${{ github.workspace }}/ephem
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.12 [in preparation]
+
+ - drop python 3.6 support
+ - require LALSuite >= 7.1
+ - no longer pinning numpy
+ - resolved various deprecation warnings
+ - new `allowedMismatchFromSFTLength` option
+   for core and MCMC classes
+
 ## 1.11.6 [14/04/2021]
 
  - new reference paper for PyFstat: https://doi.org/10.21105/joss.03000

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Latest development versions can
 [also be installed with pip](#pip-install-from-github)
 or [from a local git clone](#install-pyfstat-from-source-zenodo-or-git-clone).
 
-If you don't have a recent `python` installation (`3.6+`) on your system,
+If you don't have a recent `python` installation (`3.7+`) on your system,
 then `Docker` or `conda` are the easiest paths.
 
 In either case, be sure to also check out the notes on
@@ -259,7 +259,7 @@ for advice or just jump in and submit an
 [pull request](https://github.com/PyFstat/PyFstat/compare).
 
 Here's what you need to know:
-* The github automated tests currently run on `python` [3.6,3.7,3.8] and new PRs need to pass all these.
+* The github automated tests currently run on `python` [3.7,3.8,3.9] and new PRs need to pass all these.
 * The automated test also runs
   the [black](https://black.readthedocs.io) style checker
   and the [flake8](https://flake8.pycqa.org/en/latest/) linter.

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -1559,7 +1559,7 @@ class FrequencyModulatedArtifactWriter(Writer):
         # instead we use wildcards there.
         outfreq = int(np.floor(self.fmin))
         outwidth = int(np.floor(self.Band))
-        SFTFilename += f"_NB_F{outfreq:04d}Hz*_W{outwidth:04d}Hz*"
+        SFTFilename += f"_NBF{outfreq:04d}Hz*W{outwidth:04d}Hz*"
         SFTFilename += f"-{self.tstart}-{self.duration}.sft"
         SFTFile_fullpath = os.path.join(self.outdir, SFTFilename)
 

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -1576,6 +1576,9 @@ class FrequencyModulatedArtifactWriter(Writer):
         helper_functions.run_commandline(cl_splitSFTS)
         helper_functions.run_commandline(f"rm -r {self.tmp_outdir}")
         outglob = glob.glob(SFTFile_fullpath)
+        print("concatenate_sft_files: self.sftfilepath is", self.sftfilepath)
+        print("concatenate_sft_files: self.outdir is", self.outdir)
+        print("concatenate_sft_files: self.outdir contains", os.listdir(self.outdir))
         if len(outglob) != 1:
             raise IOError(
                 f"Expected to produce exactly 1 merged file matching pattern '{SFTFile_fullpath}',"

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -1576,9 +1576,6 @@ class FrequencyModulatedArtifactWriter(Writer):
         helper_functions.run_commandline(cl_splitSFTS)
         helper_functions.run_commandline(f"rm -r {self.tmp_outdir}")
         outglob = glob.glob(SFTFile_fullpath)
-        print("concatenate_sft_files: self.sftfilepath is", self.sftfilepath)
-        print("concatenate_sft_files: self.outdir is", self.outdir)
-        print("concatenate_sft_files: self.outdir contains", os.listdir(self.outdir))
         if len(outglob) != 1:
             raise IOError(
                 f"Expected to produce exactly 1 merged file matching pattern '{SFTFile_fullpath}',"

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 import versioneer
 
 # check python version
-min_python_version = (3, 6, 0)  # (major,minor,micro)
+min_python_version = (3, 7, 0)  # (major,minor,micro)
 python_version = sys.version_info
 print("Running Python version %s.%s.%s" % python_version[:3])
 if python_version < min_python_version:
@@ -86,7 +86,7 @@ setup(
         "bashplotlib",
         "corner",
         "dill",
-        "lalsuite>=6.80",
+        "lalsuite>=7.1",
         "matplotlib>=2.1",
         "numpy",
         "pathos",


### PR DESCRIPTION
Fixes #340 by switching to the `lalapps_SplitSFTs` "NB" file name convention from https://git.ligo.org/lscsoft/lalsuite/-/merge_requests/1687 in `FrequencyModulatedArtifactWriter.concatenate_sft_files() and dropping python 3.6, which is no longer supported for recent LALSuite versions.

We'll want a 1.12.0 release with this.