### PR TITLE
add separate singleFstats option to all ComputeFstat classes

### DIFF
--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -1023,7 +1023,7 @@ class ComputeFstat(BaseSearchClass):
         if not self.transientWindowType:
             if self.singleFstats:
                 self.get_fullycoherent_single_IFO_twoFs()
-            if self.BSGL is False:
+            if not self.BSGL:
                 return self.twoF
             self.get_fullycoherent_log10BSGL()
             return self.log10BSGL
@@ -1785,7 +1785,7 @@ class SemiCoherentSearch(ComputeFstat):
 
         if self.singleFstats:
             self.get_semicoherent_single_IFO_twoFs(record_segments)
-        if self.BSGL is False:
+        if not self.BSGL:
             return self.twoF
         else:
             return self.get_semicoherent_log10BSGL()

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -369,6 +369,7 @@ class ComputeFstat(BaseSearchClass):
         randSeed : int or None
             random seed for on-the-fly noise generation using `injectSqrtSX`.
             Setting this to 0 or None is equivalent; both will randomise the seed,
+            following the behaviour of XLALAddGaussianNoise(),
             while any number not equal to 0 will produce a reproducible noise realisation.
         assumeSqrtSX : float or list or str
             Don't estimate noise-floors but assume this (stationary) single-sided PSD.

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -271,6 +271,7 @@ class ComputeFstat(BaseSearchClass):
         search_ranges=None,
         injectSources=None,
         injectSqrtSX=None,
+        randSeed=None,
         assumeSqrtSX=None,
         SSBprec=None,
         RngMedWindow=None,
@@ -365,6 +366,8 @@ class ComputeFstat(BaseSearchClass):
             List or comma-separated string: must match len(detectors)
             and/or the data in sftfilepattern.
             Detectors will be paired to list elements following alphabetical order.
+        randSeed : int or None
+            random seed for on-the-fly noise generation using `injectSqrtSX`.
         assumeSqrtSX : float or list or str
             Don't estimate noise-floors but assume this (stationary) single-sided PSD.
             Single float or str value: use same for all IFOs.
@@ -550,7 +553,6 @@ class ComputeFstat(BaseSearchClass):
             self.whatToCompute += lalpulsar.FSTATQ_ATOMS_PER_DET
 
         FstatOAs = lalpulsar.FstatOptionalArgs()
-        FstatOAs.randSeed = lalpulsar.FstatOptionalArgsDefaults.randSeed
         if self.SSBprec:
             logging.info("Using SSBprec={}".format(self.SSBprec))
             FstatOAs.SSBprec = self.SSBprec
@@ -630,6 +632,10 @@ class ComputeFstat(BaseSearchClass):
             ] = self.injectSqrtSX
         else:
             FstatOAs.injectSqrtSX = lalpulsar.FstatOptionalArgsDefaults.injectSqrtSX
+        if hasattr(self, "randSeed") and self.randSeed is not None:
+            FstatOAs.randSeed = self.randSeed
+        else:
+            FstatOAs.randSeed = lalpulsar.FstatOptionalArgsDefaults.randSeed
         self._set_min_max_cover_freqs()
 
         logging.info("Initialising FstatInput")
@@ -1618,6 +1624,8 @@ class SemiCoherentSearch(ComputeFstat):
         search_ranges=None,
         detectors=None,
         injectSources=None,
+        injectSqrtSX=None,
+        randSeed=None,
         assumeSqrtSX=None,
         SSBprec=None,
         RngMedWindow=None,

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -368,6 +368,8 @@ class ComputeFstat(BaseSearchClass):
             Detectors will be paired to list elements following alphabetical order.
         randSeed : int or None
             random seed for on-the-fly noise generation using `injectSqrtSX`.
+            Setting this to 0 or None is equivalent; both will randomise the seed,
+            while any number not equal to 0 will produce a reproducible noise realisation.
         assumeSqrtSX : float or list or str
             Don't estimate noise-floors but assume this (stationary) single-sided PSD.
             Single float or str value: use same for all IFOs.
@@ -632,10 +634,13 @@ class ComputeFstat(BaseSearchClass):
             ] = self.injectSqrtSX
         else:
             FstatOAs.injectSqrtSX = lalpulsar.FstatOptionalArgsDefaults.injectSqrtSX
-        if hasattr(self, "randSeed") and self.randSeed is not None:
-            FstatOAs.randSeed = self.randSeed
-        else:
-            FstatOAs.randSeed = lalpulsar.FstatOptionalArgsDefaults.randSeed
+        # Here we are treating 0 and None as equivalent
+        # (use default, which is 0 and means "randomise the seed").
+        # See XLALAddGaussianNoise().
+        FstatOAs.randSeed = (
+            getattr(self, "randSeed", None)
+            or lalpulsar.FstatOptionalArgsDefaults.randSeed
+        )
         self._set_min_max_cover_freqs()
 
         logging.info("Initialising FstatInput")

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -674,19 +674,19 @@ class ComputeFstat(BaseSearchClass):
                 p_val_threshold = 1e-6
                 Fstar0s = np.linspace(0, 1000, 10000)
                 p_vals = scipy.special.gammaincc(2 * nsegs_eff, Fstar0s)
-                Fstar0 = Fstar0s[np.argmin(np.abs(p_vals - p_val_threshold))]
-                if Fstar0 == Fstar0s[-1]:
+                self.Fstar0 = Fstar0s[np.argmin(np.abs(p_vals - p_val_threshold))]
+                if self.Fstar0 == Fstar0s[-1]:
                     raise ValueError("Max Fstar0 exceeded")
             else:
-                Fstar0 = 15.0
-            logging.info("Using Fstar0 of {:1.2f}".format(Fstar0))
+                self.Fstar0 = 15.0
+            logging.info("Using Fstar0 of {:1.2f}".format(self.Fstar0))
             # assume uniform per-detector prior line-vs-Gaussian odds
-            oLGX = np.zeros(lalpulsar.PULSAR_MAX_DETECTORS)
-            oLGX[: self.numDetectors] = 1.0 / self.numDetectors
+            self.oLGX = np.zeros(lalpulsar.PULSAR_MAX_DETECTORS)
+            self.oLGX[: self.numDetectors] = 1.0 / self.numDetectors
             self.BSGLSetup = lalpulsar.CreateBSGLSetup(
                 numDetectors=self.numDetectors,
-                Fstar0sc=Fstar0,
-                oLGX=oLGX,
+                Fstar0sc=self.Fstar0,
+                oLGX=self.oLGX,
                 useLogCorrection=True,
                 numSegments=getattr(self, "nsegs", 1),
             )

--- a/pyfstat/grid_based_searches.py
+++ b/pyfstat/grid_based_searches.py
@@ -131,7 +131,7 @@ class GridSearch(BaseSearchClass):
     def _set_output_keys(self):
         self.output_keys = self.search_keys.copy()
         self.output_keys.append("twoF")
-        if hasattr(self.search, "twoFX"):
+        if self.search.singleFstats:
             self.output_keys += [f"twoF{IFO}" for IFO in self.search.detector_names]
         if self.BSGL:
             self.output_keys.append(self.detstat)
@@ -389,7 +389,7 @@ class GridSearch(BaseSearchClass):
             thisCand = list(vals)
             detstat = self.search.get_det_stat(*vals)
             thisCand.append(self.search.twoF)
-            if hasattr(self.search, "twoFX"):
+            if self.search.singleFstats:
                 thisCand += list(self.search.twoFX[: self.search.numDetectors])
             if self.detstat != "twoF":
                 thisCand.append(detstat)
@@ -406,7 +406,7 @@ class GridSearch(BaseSearchClass):
         """Define the output precision for each parameter and computed quantity."""
         fmt_dict = helper_functions.get_doppler_params_output_format(self.output_keys)
         fmt_dict["twoF"] = self.fmt_detstat
-        if hasattr(self.search, "twoFX"):
+        if self.search.singleFstats:
             for IFO in self.search.detector_names:
                 fmt_dict[f"twoF{IFO}"] = self.fmt_detstat
         if self.BSGL:
@@ -942,7 +942,7 @@ class TransientGridSearch(GridSearch):
     def _set_output_keys(self):
         self.output_keys = self.search_keys.copy()
         self.output_keys.append("twoF")
-        if hasattr(self.search, "twoFX"):
+        if self.search.singleFstats:
             self.output_keys += [f"twoF{IFO}" for IFO in self.search.detector_names]
         self.output_keys.append("maxTwoF")
         if hasattr(self.search, "twoFXatMaxTwoF"):
@@ -1038,7 +1038,7 @@ class TransientGridSearch(GridSearch):
             windowRange = getattr(self.search, "windowRange", None)
             self.timingFstatMap += getattr(self.search, "timingFstatMap", 0.0)
             thisCand.append(self.search.twoF)
-            if hasattr(self.search, "twoFX"):
+            if self.search.singleFstats:
                 thisCand += list(self.search.twoFX[: self.search.numDetectors])
             thisCand.append(self.search.maxTwoF)
             if hasattr(self.search, "twoFXatMaxTwoF"):
@@ -1109,7 +1109,7 @@ class TransientGridSearch(GridSearch):
         """Define the output precision for each parameter and computed quantity."""
         fmt_dict = helper_functions.get_doppler_params_output_format(self.output_keys)
         fmt_dict["twoF"] = self.fmt_detstat
-        if hasattr(self.search, "twoFX"):
+        if self.search.singleFstats:
             for IFO in self.search.detector_names:
                 fmt_dict[f"twoF{IFO}"] = self.fmt_detstat
         fmt_dict["maxTwoF"] = self.fmt_detstat

--- a/tests.py
+++ b/tests.py
@@ -1026,7 +1026,27 @@ class TestComputeFstat(BaseForTestsWithData):
 
     def test_get_fully_coherent_BSGL(self):
         # first pure noise, expect log10BSGL<0
-        search_H1L1 = pyfstat.ComputeFstat(
+        search_H1L1_noBSGL = pyfstat.ComputeFstat(
+            tref=self.tref,
+            minStartTime=self.tstart,
+            maxStartTime=self.tstart + self.duration,
+            detectors="H1,L1",
+            injectSqrtSX=np.repeat(self.sqrtSX, 2),
+            minCoverFreq=self.F0 - 0.1,
+            maxCoverFreq=self.F0 + 0.1,
+            BSGL=False,
+            singleFstats=True,
+            randSeed=self.randSeed,
+        )
+        twoF = search_H1L1_noBSGL.get_fullycoherent_detstat(
+            F0=self.F0,
+            F1=self.F1,
+            F2=self.F2,
+            Alpha=self.Alpha,
+            Delta=self.Delta,
+        )
+        twoFX = search_H1L1_noBSGL.get_fullycoherent_single_IFO_twoFs()
+        search_H1L1_BSGL = pyfstat.ComputeFstat(
             tref=self.tref,
             minStartTime=self.tstart,
             maxStartTime=self.tstart + self.duration,
@@ -1035,8 +1055,9 @@ class TestComputeFstat(BaseForTestsWithData):
             minCoverFreq=self.F0 - 0.1,
             maxCoverFreq=self.F0 + 0.1,
             BSGL=True,
+            randSeed=self.randSeed,
         )
-        log10BSGL = search_H1L1.get_fullycoherent_detstat(
+        log10BSGL = search_H1L1_BSGL.get_fullycoherent_detstat(
             F0=self.F0,
             F1=self.F1,
             F2=self.F2,
@@ -1044,8 +1065,41 @@ class TestComputeFstat(BaseForTestsWithData):
             Delta=self.Delta,
         )
         self.assertTrue(log10BSGL < 0)
+        self.assertTrue(
+            log10BSGL == lalpulsar.ComputeBSGL(twoF, twoFX, search_H1L1_BSGL.BSGLSetup)
+        )
         # now with an added signal, expect log10BSGL>0
-        search_H1L1 = pyfstat.ComputeFstat(
+        search_H1L1_noBSGL = pyfstat.ComputeFstat(
+            tref=self.tref,
+            minStartTime=self.tstart,
+            maxStartTime=self.tstart + self.duration,
+            detectors="H1,L1",
+            injectSqrtSX=np.repeat(self.sqrtSX, 2),
+            injectSources="{{Alpha={:g}; Delta={:g}; h0={:g}; cosi={:g}; Freq={:g}; f1dot={:g}; f2dot={:g}; refTime={:d};}}".format(
+                self.Alpha,
+                self.Delta,
+                self.h0,
+                self.cosi,
+                self.F0,
+                self.F1,
+                self.F2,
+                self.tref,
+            ),
+            minCoverFreq=self.F0 - 0.1,
+            maxCoverFreq=self.F0 + 0.1,
+            BSGL=False,
+            singleFstats=True,
+            randSeed=self.randSeed,
+        )
+        twoF = search_H1L1_noBSGL.get_fullycoherent_detstat(
+            F0=self.F0,
+            F1=self.F1,
+            F2=self.F2,
+            Alpha=self.Alpha,
+            Delta=self.Delta,
+        )
+        twoFX = search_H1L1_noBSGL.get_fullycoherent_single_IFO_twoFs()
+        search_H1L1_BSGL = pyfstat.ComputeFstat(
             tref=self.tref,
             minStartTime=self.tstart,
             maxStartTime=self.tstart + self.duration,
@@ -1064,8 +1118,9 @@ class TestComputeFstat(BaseForTestsWithData):
             minCoverFreq=self.F0 - 0.1,
             maxCoverFreq=self.F0 + 0.1,
             BSGL=True,
+            randSeed=self.randSeed,
         )
-        log10BSGL = search_H1L1.get_fullycoherent_detstat(
+        log10BSGL = search_H1L1_BSGL.get_fullycoherent_detstat(
             F0=self.F0,
             F1=self.F1,
             F2=self.F2,
@@ -1073,6 +1128,9 @@ class TestComputeFstat(BaseForTestsWithData):
             Delta=self.Delta,
         )
         self.assertTrue(log10BSGL > 0)
+        self.assertTrue(
+            log10BSGL == lalpulsar.ComputeBSGL(twoF, twoFX, search_H1L1_BSGL.BSGLSetup)
+        )
 
     def test_cumulative_twoF(self):
         Nsft = 100


### PR DESCRIPTION
In testing #346 I noticed that the handling of single-detector F-stats (`twoFX`) didn't really make sense. It was impossible to get them without setting `BSGL`, and the corresponding function didn't fail cleanly if one tried anyway.

 - add separate singleFstats option to all ComputeFstat classes
   (core classes and grid-based searches; no MCMC classes seem to currently make use of these attributes)
 - BSGL implies this
 - but can also use it on its own
 - always pre-initialise self.twoFX
   but only set FSTATQ_2F_PER_DET
   if self.singleFstats
 - get_fullycoherent_single_IFO_twoFs()
   now fails if not self.singleFstats