### PR TITLE
MCMCSearch.plot_corner(): fix deprecation warning

### DIFF
--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -963,10 +963,10 @@ class MCMCSearch(BaseSearchClass):
                 ax.set_rasterization_zorder(-10)
 
                 for tick in ax.xaxis.get_major_ticks():
-                    # tick.label.set_fontsize(8)
+                    # tick.label1.set_fontsize(8)
                     tick.label.set_rotation(30)
                 for tick in ax.yaxis.get_major_ticks():
-                    # tick.label.set_fontsize(8)
+                    # tick.label1.set_fontsize(8)
                     tick.label.set_rotation(30)
 
             plt.tight_layout()


### PR DESCRIPTION
 - following https://matplotlib.org/3.1.0/api/api_changes.html#deprecation-of-redundant-tick-attributes
 - closes #344 

Visual diff passes.

cc @Rodrigo-Tenorio but I'll auto-merge this