### PR TITLE
Simplify ephems handling part 1

### DIFF
--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -89,14 +89,8 @@ class BaseSearchClass:
             respectively at evenly spaced times, as passed to CreateFstatInput
         """
         earth_ephem_default, sun_ephem_default = helper_functions.get_ephemeris_files()
-        if earth_ephem is None:
-            self.earth_ephem = earth_ephem_default
-        else:
-            self.earth_ephem = earth_ephem
-        if sun_ephem is None:
-            self.sun_ephem = sun_ephem_default
-        else:
-            self.sun_ephem = sun_ephem
+        self.earth_ephem = earth_ephem or earth_ephem_default
+        self.sun_ephem = sun_ephem or sun_ephem_default
 
     def _set_init_params_dict(self, argsdict):
         """Store the initial input arguments, e.g. for logging output."""


### PR DESCRIPTION
Addressing the first half of #356:

 - deprecate `$LALPULSAR_DATADIR` solution
 - fall back to standard `[earth/sun]00-40-DE405.dat.gz` file names
   and relying on lal's path resolution
   instead of "None"
 - this should now work reliably on conda and pip installs
   after https://git.ligo.org/lscsoft/lalsuite/-/merge_requests/1746

As long as not actually removing the `$LALPULSAR_DATADIR` hack from both the code and the actions setup, this step should be backwards-compatible for now.