### PR TITLE
 MCMCSearch.plot_corner(): fix deprecation warning v2

### DIFF
--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -964,10 +964,10 @@ class MCMCSearch(BaseSearchClass):
 
                 for tick in ax.xaxis.get_major_ticks():
                     # tick.label1.set_fontsize(8)
-                    tick.label.set_rotation(30)
+                    tick.label1.set_rotation(30)
                 for tick in ax.yaxis.get_major_ticks():
                     # tick.label1.set_fontsize(8)
-                    tick.label.set_rotation(30)
+                    tick.label1.set_rotation(30)
 
             plt.tight_layout()
             fig.subplots_adjust(hspace=0.1, wspace=0.1)


### PR DESCRIPTION
 - following https://matplotlib.org/3.1.0/api/api_changes.html#deprecation-of-redundant-tick-attributes
 - previously missed these lines in ba891805757cd3131acea3faffa1f822e94e7162