### PR TITLE
refactor generate_loudest() and add to GridSearch

### DIFF
--- a/examples/grid_examples/PyFstat_example_grid_search_F0.py
+++ b/examples/grid_examples/PyFstat_example_grid_search_F0.py
@@ -13,17 +13,8 @@ import os
 label = "PyFstat_example_grid_search_F0"
 outdir = os.path.join("PyFstat_example_data", label)
 
-F0 = 30.0
-F1 = 0
-F2 = 0
-Alpha = 1.0
-Delta = 1.5
-
 # Properties of the GW data
-depth = 70
 sqrtS = "1e-23"
-h0 = float(sqrtS) / depth
-cosi = 0
 IFOs = "H1"
 # IFOs = "H1,L1"
 sqrtSX = ",".join(np.repeat(sqrtS, len(IFOs.split(","))))
@@ -32,54 +23,75 @@ duration = 100 * 86400
 tend = tstart + duration
 tref = 0.5 * (tstart + tend)
 
+# parameters for injected signals
+depth = 70
+inj = {
+    "tref": tref,
+    "F0": 30.0,
+    "F1": 0,
+    "F2": 0,
+    "Alpha": 1.0,
+    "Delta": 1.5,
+    "h0": float(sqrtS) / depth,
+    "cosi": 0.0,
+}
+
 data = pyfstat.Writer(
     label=label,
     outdir=outdir,
-    tref=tref,
     tstart=tstart,
-    F0=F0,
-    F1=F1,
-    F2=F2,
     duration=duration,
-    Alpha=Alpha,
-    Delta=Delta,
-    h0=h0,
-    cosi=cosi,
     sqrtSX=sqrtSX,
     detectors=IFOs,
+    **inj,
 )
 data.make_data()
 
 m = 0.001
 dF0 = np.sqrt(12 * m) / (np.pi * duration)
 DeltaF0 = 800 * dF0
-F0s = [F0 - DeltaF0 / 2.0, F0 + DeltaF0 / 2.0, dF0]
-F1s = [F1]
-F2s = [F2]
-Alphas = [Alpha]
-Deltas = [Delta]
+F0s = [inj["F0"] - DeltaF0 / 2.0, inj["F0"] + DeltaF0 / 2.0, dF0]
+F1s = [inj["F1"]]
+F2s = [inj["F2"]]
+Alphas = [inj["Alpha"]]
+Deltas = [inj["Delta"]]
 search = pyfstat.GridSearch(
-    label,
-    outdir,
-    os.path.join(outdir, "*" + label + "*sft"),
-    F0s,
-    F1s,
-    F2s,
-    Alphas,
-    Deltas,
-    tref,
-    tstart,
-    tend,
+    label=label,
+    outdir=outdir,
+    sftfilepattern=os.path.join(outdir, "*" + label + "*sft"),
+    F0s=F0s,
+    F1s=F1s,
+    F2s=F2s,
+    Alphas=Alphas,
+    Deltas=Deltas,
+    tref=tref,
+    minStartTime=tstart,
+    maxStartTime=tend,
 )
 search.run()
+
+# report details of the maximum point
+max_dict = search.get_max_twoF()
+print(
+    "max2F={:.4f} from GridSearch, offsets from injection: {:s}.".format(
+        max_dict["twoF"],
+        ", ".join(
+            [
+                "{:.4e} in {:s}".format(max_dict[key] - inj[key], key)
+                for key in max_dict.keys()
+                if not key == "twoF"
+            ]
+        ),
+    )
+)
 
 print("Plotting 2F(F0)...")
 fig, ax = plt.subplots()
 frequencies = search.data["F0"]
 twoF = search.data["twoF"]
-# mismatch = np.sign(x-F0)*(duration * np.pi * (x - F0))**2 / 12.0
+# mismatch = np.sign(x-inj["F0"])*(duration * np.pi * (x - inj["F0"]))**2 / 12.0
 ax.plot(frequencies, twoF, "k", lw=1)
-DeltaF = frequencies - F0
+DeltaF = frequencies - inj["F0"]
 sinc = np.sin(np.pi * DeltaF * duration) / (np.pi * DeltaF * duration)
 A = np.abs((np.max(twoF) - 4) * sinc ** 2 + 4)
 ax.plot(frequencies, A, "-r", lw=1)
@@ -87,7 +99,7 @@ ax.set_ylabel("$\\widetilde{2\\mathcal{F}}$")
 ax.set_xlabel("Frequency")
 ax.set_xlim(F0s[0], F0s[1])
 dF0 = np.sqrt(12 * 1) / (np.pi * duration)
-xticks = [F0 - 10 * dF0, F0, F0 + 10 * dF0]
+xticks = [inj["F0"] - 10 * dF0, inj["F0"], inj["F0"] + 10 * dF0]
 ax.set_xticks(xticks)
 xticklabels = ["$f_0 {-} 10\\Delta f$", "$f_0$", "$f_0 {+} 10\\Delta f$"]
 ax.set_xticklabels(xticklabels)

--- a/examples/grid_examples/PyFstat_example_grid_search_F0.py
+++ b/examples/grid_examples/PyFstat_example_grid_search_F0.py
@@ -84,6 +84,7 @@ print(
         ),
     )
 )
+search.generate_loudest()
 
 print("Plotting 2F(F0)...")
 fig, ax = plt.subplots()

--- a/examples/grid_examples/PyFstat_example_grid_search_F0F1.py
+++ b/examples/grid_examples/PyFstat_example_grid_search_F0F1.py
@@ -12,12 +12,6 @@ import os
 label = "PyFstat_example_grid_search_F0F1"
 outdir = os.path.join("PyFstat_example_data", label)
 
-F0 = 30.0
-F1 = 1e-10
-F2 = 0
-Alpha = 1.0
-Delta = 1.5
-
 # Properties of the GW data
 sqrtSX = 1e-23
 tstart = 1000000000
@@ -26,26 +20,27 @@ tend = tstart + duration
 tref = 0.5 * (tstart + tend)
 IFOs = "H1"
 
+# parameters for injected signals
 depth = 20
-
-h0 = sqrtSX / depth
-cosi = 0
+inj = {
+    "tref": tref,
+    "F0": 30.0,
+    "F1": -1e-10,
+    "F2": 0,
+    "Alpha": 1.0,
+    "Delta": 1.5,
+    "h0": sqrtSX / depth,
+    "cosi": 0.0,
+}
 
 data = pyfstat.Writer(
     label=label,
     outdir=outdir,
-    tref=tref,
     tstart=tstart,
-    F0=F0,
-    F1=F1,
-    F2=F2,
     duration=duration,
-    Alpha=Alpha,
-    Delta=Delta,
-    h0=h0,
-    cosi=cosi,
     sqrtSX=sqrtSX,
     detectors=IFOs,
+    **inj,
 )
 data.make_data()
 
@@ -56,25 +51,40 @@ dF2 = 1e-17
 N = 100
 DeltaF0 = N * dF0
 DeltaF1 = N * dF1
-F0s = [F0 - DeltaF0 / 2.0, F0 + DeltaF0 / 2.0, dF0]
-F1s = [F1 - DeltaF1 / 2.0, F1 + DeltaF1 / 2.0, dF1]
-F2s = [F2]
-Alphas = [Alpha]
-Deltas = [Delta]
+F0s = [inj["F0"] - DeltaF0 / 2.0, inj["F0"] + DeltaF0 / 2.0, dF0]
+F1s = [inj["F1"] - DeltaF1 / 2.0, inj["F1"] + DeltaF1 / 2.0, dF1]
+F2s = [inj["F2"]]
+Alphas = [inj["Alpha"]]
+Deltas = [inj["Delta"]]
 search = pyfstat.GridSearch(
-    label,
-    outdir,
-    data.sftfilepath,
-    F0s,
-    F1s,
-    F2s,
-    Alphas,
-    Deltas,
-    tref,
-    tstart,
-    tend,
+    label=label,
+    outdir=outdir,
+    sftfilepattern=data.sftfilepath,
+    F0s=F0s,
+    F1s=F1s,
+    F2s=F2s,
+    Alphas=Alphas,
+    Deltas=Deltas,
+    tref=tref,
+    minStartTime=tstart,
+    maxStartTime=tend,
 )
 search.run()
+
+# report details of the maximum point
+max_dict = search.get_max_twoF()
+print(
+    "max2F={:.4f} from GridSearch, offsets from injection: {:s}.".format(
+        max_dict["twoF"],
+        ", ".join(
+            [
+                "{:.4e} in {:s}".format(max_dict[key] - inj[key], key)
+                for key in max_dict.keys()
+                if not key == "twoF"
+            ]
+        ),
+    )
+)
 
 print("Plotting 2F(F0)...")
 search.plot_1D(xkey="F0", xlabel="freq [Hz]", ylabel="$2\\mathcal{F}$")
@@ -84,8 +94,8 @@ print("Plotting 2F(F0,F1)...")
 search.plot_2D(xkey="F0", ykey="F1", colorbar=True)
 
 print("Making gridcorner plot...")
-F0_vals = np.unique(search.data["F0"]) - F0
-F1_vals = np.unique(search.data["F1"]) - F1
+F0_vals = np.unique(search.data["F0"]) - inj["F0"]
+F1_vals = np.unique(search.data["F1"]) - inj["F1"]
 twoF = search.data["twoF"].reshape((len(F0_vals), len(F1_vals)))
 xyz = [F0_vals, F1_vals]
 labels = [

--- a/examples/grid_examples/PyFstat_example_grid_search_F0F1.py
+++ b/examples/grid_examples/PyFstat_example_grid_search_F0F1.py
@@ -85,6 +85,7 @@ print(
         ),
     )
 )
+search.generate_loudest()
 
 print("Plotting 2F(F0)...")
 search.plot_1D(xkey="F0", xlabel="freq [Hz]", ylabel="$2\\mathcal{F}$")

--- a/examples/grid_examples/PyFstat_example_grid_search_F0F1F2.py
+++ b/examples/grid_examples/PyFstat_example_grid_search_F0F1F2.py
@@ -12,12 +12,6 @@ import os
 label = "PyFstat_example_grid_search_F0F1F2"
 outdir = os.path.join("PyFstat_example_data", label)
 
-F0 = 30.0
-F1 = 1e-10
-F2 = 0
-Alpha = 1.0
-Delta = 1.5
-
 # Properties of the GW data
 sqrtSX = 1e-23
 tstart = 1000000000
@@ -26,26 +20,26 @@ tend = tstart + duration
 tref = 0.5 * (tstart + tend)
 IFOs = "H1"
 
+# parameters for injected signals
 depth = 20
-
-h0 = sqrtSX / depth
-cosi = 0
-
+inj = {
+    "tref": tref,
+    "F0": 30.0,
+    "F1": -1e-10,
+    "F2": 0,
+    "Alpha": 1.0,
+    "Delta": 1.5,
+    "h0": sqrtSX / depth,
+    "cosi": 0.0,
+}
 data = pyfstat.Writer(
     label=label,
     outdir=outdir,
-    tref=tref,
     tstart=tstart,
-    F0=F0,
-    F1=F1,
-    F2=F2,
     duration=duration,
-    Alpha=Alpha,
-    Delta=Delta,
-    h0=h0,
-    cosi=cosi,
     sqrtSX=sqrtSX,
     detectors=IFOs,
+    **inj,
 )
 data.make_data()
 
@@ -57,25 +51,40 @@ N = 100
 DeltaF0 = N * dF0
 DeltaF1 = N * dF1
 DeltaF2 = N * dF2
-F0s = [F0 - DeltaF0 / 2.0, F0 + DeltaF0 / 2.0, dF0]
-F1s = [F1 - DeltaF1 / 2.0, F1 + DeltaF1 / 2.0, dF1]
-F2s = [F2 - DeltaF2 / 2.0, F2 + DeltaF2 / 2.0, dF2]
-Alphas = [Alpha]
-Deltas = [Delta]
+F0s = [inj["F0"] - DeltaF0 / 2.0, inj["F0"] + DeltaF0 / 2.0, dF0]
+F1s = [inj["F1"] - DeltaF1 / 2.0, inj["F1"] + DeltaF1 / 2.0, dF1]
+F2s = [inj["F2"] - DeltaF2 / 2.0, inj["F2"] + DeltaF2 / 2.0, dF2]
+Alphas = [inj["Alpha"]]
+Deltas = [inj["Delta"]]
 search = pyfstat.GridSearch(
-    label,
-    outdir,
-    data.sftfilepath,
-    F0s,
-    F1s,
-    F2s,
-    Alphas,
-    Deltas,
-    tref,
-    tstart,
-    tend,
+    label=label,
+    outdir=outdir,
+    sftfilepattern=data.sftfilepath,
+    F0s=F0s,
+    F1s=F1s,
+    F2s=F2s,
+    Alphas=Alphas,
+    Deltas=Deltas,
+    tref=tref,
+    minStartTime=tstart,
+    maxStartTime=tend,
 )
 search.run()
+
+# report details of the maximum point
+max_dict = search.get_max_twoF()
+print(
+    "max2F={:.4f} from GridSearch, offsets from injection: {:s}.".format(
+        max_dict["twoF"],
+        ", ".join(
+            [
+                "{:.4e} in {:s}".format(max_dict[key] - inj[key], key)
+                for key in max_dict.keys()
+                if not key == "twoF"
+            ]
+        ),
+    )
+)
 
 # FIXME: workaround for matplotlib "Exceeded cell block limit" errors
 agg_chunksize = 10000
@@ -98,9 +107,9 @@ search.plot_1D(xkey="Delta", agg_chunksize=agg_chunksize)
 # search.plot_2D(xkey="F1",ykey="F2",colorbar=True)
 
 print("Making gridcorner plot...")
-F0_vals = np.unique(search.data["F0"]) - F0
-F1_vals = np.unique(search.data["F1"]) - F1
-F2_vals = np.unique(search.data["F2"]) - F2
+F0_vals = np.unique(search.data["F0"]) - inj["F0"]
+F1_vals = np.unique(search.data["F1"]) - inj["F1"]
+F2_vals = np.unique(search.data["F2"]) - inj["F2"]
 twoF = search.data["twoF"].reshape((len(F0_vals), len(F1_vals), len(F2_vals)))
 xyz = [F0_vals, F1_vals, F2_vals]
 labels = [

--- a/examples/grid_examples/PyFstat_example_grid_search_F0F1F2.py
+++ b/examples/grid_examples/PyFstat_example_grid_search_F0F1F2.py
@@ -85,6 +85,7 @@ print(
         ),
     )
 )
+search.generate_loudest()
 
 # FIXME: workaround for matplotlib "Exceeded cell block limit" errors
 agg_chunksize = 10000

--- a/examples/mcmc_examples/PyFstat_example_fully_coherent_MCMC_search.py
+++ b/examples/mcmc_examples/PyFstat_example_fully_coherent_MCMC_search.py
@@ -98,6 +98,8 @@ mcmc.print_summary()
 mcmc.plot_corner(add_prior=True, truths=signal_parameters)
 mcmc.plot_prior_posterior(injection_parameters=signal_parameters)
 
+mcmc.generate_loudest()
+
 # plot cumulative 2F, first building a dict as required for PredictFStat
 d, maxtwoF = mcmc.get_max_twoF()
 for key, val in mcmc.theta_prior.items():

--- a/examples/mcmc_vs_grid_simple_example/PyFstat_example_simple_mcmc_vs_grid_comparison.py
+++ b/examples/mcmc_vs_grid_simple_example/PyFstat_example_simple_mcmc_vs_grid_comparison.py
@@ -166,6 +166,7 @@ if __name__ == "__main__":
     )
     gridsearch.run()
     gridsearch.print_max_twoF()
+    gridsearch.generate_loudest()
 
     # do some plots of the GridSearch results
     if not sky:  # this plotter can't currently deal with too large result arrays

--- a/pyfstat/grid_based_searches.py
+++ b/pyfstat/grid_based_searches.py
@@ -780,6 +780,24 @@ class GridSearch(BaseSearchClass):
         for k, v in d.items():
             print("  {}={}".format(k, v))
 
+    def generate_loudest(self):
+        """Use lalapps_ComputeFstatistic_v2 to produce a .loudest file"""
+        max_params = self.get_max_twoF()
+        max_params.pop("twoF")
+        max_params = self.translate_keys_to_lal(max_params)
+        self.loudest_file = helper_functions.generate_loudest_file(
+            max_params=max_params,
+            tref=self.tref,
+            outdir=self.outdir,
+            label=self.label,
+            sftfilepattern=self.sftfilepattern,
+            minStartTime=self.minStartTime,
+            maxStartTime=self.maxStartTime,
+            transientWindowType=getattr(self, "transientWindowType", None),
+            earth_ephem=self.earth_ephem,
+            sun_ephem=self.sun_ephem,
+        )
+
     def set_out_file(self, extra_label=None):
         """Set (or reset) the name of the main output file.
 

--- a/pyfstat/helper_functions.py
+++ b/pyfstat/helper_functions.py
@@ -1176,7 +1176,7 @@ def generate_loudest_file(
         "ephemEarth": earth_ephem,
         "ephemSun": sun_ephem,
     }
-    CFSv2_params.update({par: key for par, key in opt_params.items() if key})
+    CFSv2_params.update({key: val for key, val in opt_params.items() if val})
     cmd += " ".join([f"--{key}={val}" for key, val in CFSv2_params.items()])
 
     run_commandline(cmd, return_output=False)

--- a/pyfstat/helper_functions.py
+++ b/pyfstat/helper_functions.py
@@ -1105,3 +1105,79 @@ def parse_list_of_numbers(val):
             f" Got exception: {e}."
         )
     return out
+
+
+def generate_loudest_file(
+    max_params,
+    tref,
+    outdir,
+    label,
+    sftfilepattern,
+    minStartTime=None,
+    maxStartTime=None,
+    transientWindowType=None,
+    earth_ephem=None,
+    sun_ephem=None,
+):
+    """Use lalapps_ComputeFstatistic_v2 to produce a .loudest file.
+
+    Parameters
+    -------
+    max_params: dict
+        Dictionary of a single parameter-space point.
+        This needs to already have been translated to lal conventions
+        and must NOT include detection statistic entries!
+    tref: int
+        Reference time of the max_params.
+    outdir: str
+        Directory to place the .loudest file in.
+    label: str
+        Search name bit to be used in the output filename.
+    sftfilepattern: str
+        Pattern to match SFTs using wildcards (`*?`) and ranges [0-9];
+        mutiple patterns can be given separated by colons.
+    minStartTime, maxStartTime: int or None
+        GPS seconds of the start time and end time;
+        default: use al available data.
+    transientWindowType: str or None
+        optional: transient window type,
+        needs to go with t0 and tau parameters inside max_params.
+    earth_ephem: str or None
+        optional: user-set Earth ephemeris file
+    sun_ephem: str or None
+        optional: user-set Sun ephemeris file
+
+    Returns
+    -------
+    loudest_file: str
+        The filename of the CFSv2 output file.
+    """
+    logging.info("Running CFSv2 to get .loudest file")
+    if np.any([key in max_params for key in ["delta_F0", "delta_F1", "tglitch"]]):
+        raise RuntimeError("CFSv2 --outputLoudest cannot deal with glitch parameters.")
+    if transientWindowType:
+        logging.warning(
+            "CFSv2 --outputLoudest always reports the maximum of the"
+            " standard CW 2F-statistic, not the transient max2F."
+        )
+
+    loudest_file = os.path.join(outdir, label + ".loudest")
+    cmd = "lalapps_ComputeFstatistic_v2 "
+    CFSv2_params = {
+        "DataFiles": f'"{sftfilepattern}"',
+        "outputLoudest": loudest_file,
+        "refTime": tref,
+    }
+    CFSv2_params.update(max_params)
+    opt_params = {
+        "minStartTime": minStartTime,
+        "maxStartTime": maxStartTime,
+        "transient-WindowType": transientWindowType,
+        "ephemEarth": earth_ephem,
+        "ephemSun": sun_ephem,
+    }
+    CFSv2_params.update({par: key for par, key in opt_params.items() if key})
+    cmd += " ".join([f"--{key}={val}" for key, val in CFSv2_params.items()])
+
+    run_commandline(cmd, return_output=False)
+    return loudest_file

--- a/tests.py
+++ b/tests.py
@@ -2286,6 +2286,24 @@ class TestGridSearch(BaseForTestsWithData):
         self.assertTrue(np.max(np.abs(CFSv2_out["freq"] - pyfstat_out["F0"]) < 1e-16))
         self.assertTrue(np.max(np.abs(CFSv2_out["2F"] - pyfstat_out["twoF"]) < 1))
         self.assertTrue(np.max(CFSv2_out["2F"]) == np.max(pyfstat_out["twoF"]))
+        self.search.generate_loudest()
+        self.assertTrue(os.path.isfile(self.search.loudest_file))
+        loudest = {}
+        for run, f in zip(
+            ["CFSv2", "PyFstat"], [CFSv2_loudest_file, self.search.loudest_file]
+        ):
+            loudest[run] = pyfstat.helper_functions.read_par(
+                filename=f,
+                suffix="loudest",
+                raise_error=False,
+            )
+        for key in ["Alpha", "Delta", "Freq", "f1dot", "f2dot", "f3dot"]:
+            self.assertTrue(
+                np.abs(loudest["CFSv2"][key] - loudest["PyFstat"][key]) < 1e-16
+            )
+        self.assertTrue(
+            np.abs(loudest["CFSv2"]["twoF"] - loudest["PyFstat"]["twoF"]) < 1
+        )
 
     def test_semicoherent_grid_search(self):
         # FIXME this one doesn't check the results at all yet


### PR DESCRIPTION
- add generate_loudest() method to GridSearch via new helper function
    
     - add helper_functions.generate_loudest_file()
     - make GridSearch and MCMCSearch wrap that
     - add to examples and tests
 
- improve grid examples
    
     - report max point with injection offsets
     - use inj dictionaries
     - inject negative f1dot to be more typical
     - call GridSearch with named parameters