### PR TITLE
Add Python API to compute SNR

### DIFF
--- a/docs/source/pyfstat.rst
+++ b/docs/source/pyfstat.rst
@@ -41,6 +41,14 @@ pyfstat.helper\_functions module
    :undoc-members:
    :show-inheritance:
 
+pyfstat.injection\_parameters module
+------------------------------------
+
+.. automodule:: pyfstat.injection_parameters
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 pyfstat.make\_sfts module
 -------------------------
 
@@ -61,6 +69,14 @@ pyfstat.optimal\_setup\_functions module
 ----------------------------------------
 
 .. automodule:: pyfstat.optimal_setup_functions
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pyfstat.snr module
+------------------
+
+.. automodule:: pyfstat.snr
    :members:
    :undoc-members:
    :show-inheritance:

--- a/pyfstat/__init__.py
+++ b/pyfstat/__init__.py
@@ -37,6 +37,8 @@ from .grid_based_searches import (
 )
 from .gridcorner import gridcorner
 
+from .snr import DetectorStates, SignalToNoiseRatio
+
 from ._version import get_versions
 
 __version__ = get_versions()["version"]

--- a/pyfstat/snr.py
+++ b/pyfstat/snr.py
@@ -11,22 +11,22 @@ from pyfstat.helper_functions import get_ephemeris_files
 @define(kw_only=True, slots=False)
 class SignalToNoiseRatio:
     """
-    Compute the optimal signal-to-noise ratio (and derived quantities)
+    Compute the optimal signal-to-noise ratio (and derived quantities, such as the F-statistic)
     of a CW signal on Gaussian noise or an arbitrary dataset of SFTs.
 
     The definition of SNR (shortcut for "optimal signal-to-noise ratio")
-    is taken from Eq. (76) of https://dcc.ligo.org/LIGO-T0900149 and is
+    is taken from Eq. (76) of https://dcc.ligo.org/T0900149-v6/public and is
     such that `<2F> = 4 + SNR^2`, where `<2F>` represents the expected
-    value over noise realization of twice the F-statistic of a prefectly
+    value over noise realizations of twice the F-statistic of a perfectly
     matched template to an existing signal in the data.
 
     Computing SNR^2 requires two quantities:
-        - The M matrix, which depends on the sky position and polarization angle
+        - The antenna pattern matrix `M`, which depends on the sky position and polarization angle
         and encodes the effect of the detector's antenna pattern over the course
         of the observing run.
-        - The JKS amplitude paramaters {A^0, A^1, A^2, A^3}, which are functions
-        of the CW's amplitude parameters (h0, cosi, psi) or, alternatively,
-        (aPlus, aCross, psi).
+        - The JKS amplitude parameters `{A^0, A^1, A^2, A^3}`, which are functions
+        of the CW's amplitude parameters `(h0, cosi, psi)` or, alternatively,
+        `(aPlus, aCross, psi)`.
 
     Parameters
     ----------
@@ -35,7 +35,7 @@ class SignalToNoiseRatio:
         Provides the required information to compute the antenna pattern contribution.
     noise_weights: Union[lalpulsar.MultiNoiseWeights, None]
         Optional, incompatible with `(assumeSqrtSX, Tsft)`.
-        Can be compute from SFTs using `SignalToNoiseRatio.from_sfts`.
+        Can be computed from SFTs using `SignalToNoiseRatio.from_sfts`.
         Vector of noise weights to account for a varying noise floor or unequal noise
         floors in different detectors.
     assumeSqrtSX: float
@@ -124,10 +124,10 @@ class SignalToNoiseRatio:
         """
         Compute the SNR^2 of a CW signal using XLALComputeOptimalSNR2FromMmunu.
         Parameters correspond to the standard ones used to describe a CW
-        (see e.g. Eqs. (16), (26), (30) of https://dcc.ligo.org/LIGO-T0900149).
+        (see e.g. Eqs. (16), (26), (30) of https://dcc.ligo.org/T0900149-v6/public ).
 
         Mind that this function returns *squared* SNR
-        (Eq. (76) of https://dcc.ligo.org/LIGO-T0900149),
+        (Eq. (76) of https://dcc.ligo.org/T0900149-v6/public ),
         which can be directly related to the expected F-statistic as
         ```
         <2F> = 4 + SNR^2.
@@ -241,7 +241,7 @@ class SignalToNoiseRatio:
 
     def _convert_amplitude_parameters(self, h0, cosi, aPlus, aCross):
         """
-        Internal method to check and convert the given amplitude parametrs
+        Internal method to check and convert the given amplitude parameters
         into the required format.
         """
         h0_cosi = h0 is not None and cosi is not None
@@ -273,7 +273,7 @@ class DetectorStates:
         time_stamps: array-like or dict
             GPS timestamps at which detector states will be retrieved.
             If array, use the same set of timestamps for all detectors,
-            which must be explicitly given by the user via`detectors`.
+            which must be explicitly given by the user via `detectors`.
             If dictionary, each key should correspond to a valid detector name
             to be parsed by XLALParseMultiLALDetector and the associated value
             should be an array-like set of GPS timestamps for each individual detector.
@@ -328,7 +328,7 @@ class DetectorStates:
         sft_constraint: lalpulsar.SFTConstraint
             Optional argument to specify further constraints in XLALSFTdataFind.
         return_sfts: bool
-            If True, also return the loaded SFTs. This is useful to compute futher
+            If True, also return the loaded SFTs. This is useful to compute further
             quantities such as noise weights.
 
         Returns
@@ -373,7 +373,7 @@ class DetectorStates:
             if detectors is not None:
                 raise ValueError("`timestamps`' keys are redundant with `detectors`. ")
 
-            logging.debug("Retrieving detectors from tiemstamps dictionary.")
+            logging.debug("Retrieving detectors from timestamps dictionary.")
             detectors = list(timestamps.key())
             timestamps = timestamps.values()
 

--- a/pyfstat/snr.py
+++ b/pyfstat/snr.py
@@ -279,6 +279,7 @@ class DetectorStates:
             separation between consecutive timestamps.
         detectors: list[str] or comma-separated string
             List of detectors to be parsed using XLALParseMultiLALDetector.
+            Conflicts with dictionary of `time_stamps`, required otherwise.
         time_offset: float
             Timestamp offset to retrieve detector states.
 
@@ -400,7 +401,8 @@ class DetectorStates:
     @staticmethod
     def _numpy_array_to_LIGOTimeGPSVector(numpy_array, Tsft=None):
         """
-        Maps a numpy array of into a LIGOTimeGPS array using `np.floor`.
+        Maps a numpy array of floats into a LIGOTimeGPS array using `np.floor`
+        to separate seconds and nanoseconds.
         """
 
         if numpy_array.ndim != 1:

--- a/pyfstat/snr.py
+++ b/pyfstat/snr.py
@@ -10,24 +10,25 @@ from pyfstat.helper_functions import get_ephemeris_files
 
 @define(kw_only=True, slots=False)
 class SignalToNoiseRatio:
-    """
-    Compute the optimal signal-to-noise ratio (and derived quantities, such as the F-statistic)
-    of a CW signal on Gaussian noise or an arbitrary dataset of SFTs.
+    r"""Compute the optimal SNR of a CW signal as expected in Gaussian noise.
 
     The definition of SNR (shortcut for "optimal signal-to-noise ratio")
     is taken from Eq. (76) of https://dcc.ligo.org/T0900149-v6/public and is
-    such that `<2F> = 4 + SNR^2`, where `<2F>` represents the expected
-    value over noise realizations of twice the F-statistic of a perfectly
-    matched template to an existing signal in the data.
+    such that :math:`\langle 2\mathcal{F}\rangle = 4 + \textrm{SNR}^2`,
+    where  :math:`\langle 2\mathcal{F}\rangle` represents the expected
+    value over noise realizations of twice the F-statistic of a template
+    perfectly matched to an existing signal in the data.
 
-    Computing SNR^2 requires two quantities:
-        - The antenna pattern matrix `M`, which depends on the sky position and polarization angle
-        and encodes the effect of the detector's antenna pattern over the course
-        of the observing run.
-        - The JKS amplitude parameters `{A^0, A^1, A^2, A^3}`
-        [Jaranowski, Krolak, Schutz Phys. Rev. D 58 063001,(1998)], which are functions
-        of the CW's amplitude parameters `(h0, cosi, psi, phi0)` or, alternatively,
-        `(aPlus, aCross, psi, phi0)`.
+    Computing :math:`\textrm{SNR}^2` requires two quantities:
+
+    * | The antenna pattern matrix :math:`\mathcal{M}`, which depends on the sky position :math:`\vec{n}`
+      | and polarization angle :math:`\psi` and encodes the effect of the detector's antenna pattern response
+      | over the course of the observing run.
+    * | The JKS amplitude parameters :math:`(\mathcal{A}^0, \mathcal{A}^1, \mathcal{A}^2, \mathcal{A}^3)`
+      | [JKS1998]_ which are functions of the CW's amplitude parameters :math:`(h_0,\cos\iota, \psi, \phi_0)` or,
+      | alternatively, :math:`(A_{+}, A_{\times}, \psi, \phi_0)`.
+
+    .. [JKS1998] `Jaranowski, Krolak, Schuz Phys. Rev. D58 063001, 1998 <https://arxiv.org/abs/gr-qc/9804014>`_
 
     Parameters
     ----------
@@ -41,11 +42,11 @@ class SignalToNoiseRatio:
         floors in different detectors.
     assumeSqrtSX: float
         Optional, incompatible with `noise_weights`.
-        *Single-sided* *amplitude* spectral density (ASD) of the detector noise.
+        Single-sided amplitude spectral density (ASD) of the detector noise.
         This value is used for all detectors, meaning it's not currently possible to manually
         specify different noise floors without creating SFT files.
         (To be improved in the future; developer note:
-         will require SWIG constructor for MultiNoiseWeights.)
+        will require SWIG constructor for MultiNoiseWeights.)
     """
 
     detector_states: lalpulsar.MultiDetectorStateSeries = field()
@@ -80,7 +81,8 @@ class SignalToNoiseRatio:
     ):
         """
         Alternative constructor to retrieve detector states and noise weights from SFT files.
-        This method is based on `DetectorStates.multi_detector_states_from_sfts`.
+        This method is based on
+        :py:meth:`DetectorStates.multi_detector_states_from_sfts`.
         This is currently the other way in which varying / different noise floors can be used
         when computing SNRs.
 
@@ -125,17 +127,15 @@ class SignalToNoiseRatio:
     def compute_snr2(
         self, Alpha, Delta, psi, phi0, h0=None, cosi=None, aPlus=None, aCross=None
     ):
-        """
-        Compute the SNR^2 of a CW signal using XLALComputeOptimalSNR2FromMmunu.
+        r"""
+        Compute the :math:`\textrm{SNR}^2` of a CW signal using XLALComputeOptimalSNR2FromMmunu.
         Parameters correspond to the standard ones used to describe a CW
         (see e.g. Eqs. (16), (26), (30) of https://dcc.ligo.org/T0900149-v6/public ).
 
         Mind that this function returns *squared* SNR
         (Eq. (76) of https://dcc.ligo.org/T0900149-v6/public ),
         which can be directly related to the expected F-statistic as
-        ```
-        <2F> = 4 + SNR^2.
-        ```
+        :math:`\langle 2\mathcal{F}\rangle = 4 + \textrm{SNR}^2`.
 
         Parameters
         ----------
@@ -181,13 +181,11 @@ class SignalToNoiseRatio:
         return lalpulsar.ComputeOptimalSNR2FromMmunu(Aphys, M)
 
     def compute_twoF(self, *args, **kwargs):
-        """
-        Compute the expected 2F value of a CW signal from the result of `compute_snr2`.
+        r"""
+        Compute the expected :math:`2\mathcal{F}` value of a CW signal from the result of `compute_snr2`.
 
-        ```
-        expected_2F = 4 + SNR^2.
-        stdev_2F = sqrt(8 + 4 * SNR^2)
-        ```
+        .. math:: \langle 2\mathcal{F}\rangle = 4 + \textrm{SNR}^2
+        .. math:: \sigma_{\2\mathcal{F}} =  \sqrt{8 + 4 \textrm{SNR}^2}
 
         Input parameters are passed untouched to `self.compute_snr2`.
         See corresponding docstring for a list of valid parameters.

--- a/pyfstat/snr.py
+++ b/pyfstat/snr.py
@@ -1,0 +1,174 @@
+from attrs import define, field
+import lal
+import lalpulsar
+import logging
+import numpy as np
+from typing import Union
+
+from pyfstat.helper_functions import get_ephemeris_files
+
+
+@define(kw_only=True, slots=False)
+class SignalToNoiseRatio:
+
+    detector_states: lalpulsar.MultiDetectorStateSeries = field()
+    noise_weights: Union[lalpulsar.MultiNoiseWeights, None] = field(default=None)
+    assumeSqrtSX: float = field(default=None)
+    Tsft: float = field(default=None)
+
+    @classmethod
+    def from_sfts(cls):
+        """
+        Allow to include noise weights from SFTs.
+        This will mean detector states will be retrieved from SFTs directly
+        """
+        pass
+
+    def __attrs_post_init__(self):
+        if self.noise_weights is None:
+            if self.assumeSqrtSX is not None and self.Tsft is not None:
+                self.Sinv_Tsft = self.Tsft / self.assumeSqrtSX**2
+            else:
+                raise ValueError(
+                    "Need either (`assumeSqrtSX`, `Tsft`) or `noise_weights` to account for background noise"
+                )
+
+    def compute_snr2(
+        self, Alpha, Delta, psi, phi0, h0=None, cosi=None, aPlus=None, aCross=None
+    ):
+        aPlus, aCross = self._convert_amplitude_parameters(
+            h0=h0, cosi=cosi, aPlus=aPlus, aCross=aCross
+        )
+
+        Aphys = lalpulsar.PulsarAmplitudeParams()
+        Aphys.psi = psi
+        Aphys.phi0 = phi0
+        Aphys.aPlus = aPlus
+        Aphys.aCross = aCross
+
+        # FIXME Here as well!!!!!
+        M = self.compute_Mmunu(Alpha=Alpha, Delta=Delta)
+        M.Sinv_Tsft = self.Sinv_Tsft
+
+        return lalpulsar.ComputeOptimalSNR2FromMmunu(Aphys, M)
+
+    def compute_Mmunu(self, Alpha, Delta):
+
+        sky = lal.SkyPosition()
+        sky.longitude = Alpha
+        sky.latitude = Delta
+        sky.system = lal.COORDINATESYSTEM_EQUATORIAL
+        lal.NormalizeSkyPosition(sky.longitude, sky.latitude)
+
+        # FIXME Missing Mmunu.Sinv_Tsft = t_sft / psd !!!!!!
+        return lalpulsar.ComputeMultiAMCoeffs(
+            multiDetStates=self.detector_states,
+            multiWeights=self.noise_weights,
+            skypos=sky,
+        ).Mmunu
+
+    def _convert_amplitude_parameters(self, h0, cosi, aPlus, aCross):
+        h0_cosi = h0 is not None and cosi is not None
+        aPlusCross = aPlus is not None and aCross is not None
+
+        if h0_cosi == aPlusCross:
+            raise ValueError("Need either (h0, cosi) or (aPlus, aCross), but not both")
+
+        if h0_cosi:
+            aPlus = 0.5 * h0 * (1 + cosi**2)
+            aCross = h0 * cosi
+            return aPlus, aCross
+
+        return aPlus, aCross
+
+
+class DetectorStates:
+    def __init__(self):
+        self.ephems = lalpulsar.InitBarycenter(*get_ephemeris_files())
+
+    def multi_detector_states(self, timestamps, detectors=None, time_offset=0):
+        """
+        Parameters
+        ----------
+        time_stamps: array-like or dict
+            GPS timestamps at which detector states will be retrieved.
+            If array, use the same set of timestamps for all detectors,
+            which must be explicitly given by the user via`detectors`.
+            If dictionary, each key should correspond to a valid detector name
+            to be parsed by XLALParseMultiLALDetector and the associated value
+            should be an array-like set of GPS timestamps for each individual detector.
+
+        detectors: list[str] or comma-separated string
+            List of detectors to be parsed using XLALParseMultiLALDetector.
+
+        time_offset: float
+            Timestamp offset to retrieve detector states.
+
+
+        Returns
+        -------
+        multi_detector_states: lalpulsar.MultiDetectorStateSeries
+            Resulting multi-detector states produced by XLALGetMultiDetectorStates
+        """
+
+        self._parse_timestamps_and_detectors(timestamps, detectors)
+        return lalpulsar.GetMultiDetectorStates(
+            self.multi_timestamps,
+            self.multi_detector,
+            self.ephems,
+            time_offset,
+        )
+
+    def multi_detector_states_from_sfts(self, sftpath, time_offset):
+        pass
+
+    def _parse_timestamps_and_detectors(self, timestamps, detectors):
+
+        if isinstance(timestamps, dict):
+
+            if detectors is not None:
+                raise ValueError("`timestamps`' keys are redundant with `detectors`. ")
+
+            logging.debug("Retrieving detectors from tiemstamps dictionary.")
+            detectors = list(timestamps.key())
+            timestamps = timestamps.values()
+
+        elif detectors is not None:
+            if isinstance(detectors, str):
+                logging.debug("Converting `detectors` string to list")
+                detectors = detectors.replace(" ", "").split(",")
+
+            logging.debug("Checking integrity of `timestamps`")
+            ts = np.array(timestamps)
+            if ts.dtype == np.dtype("O") or ts.ndim > 1:
+                raise ValueError("`timestamps` is not a 1D list of numerical values")
+            timestamps = (ts for ifo in detectors)
+
+        self.multi_detector = lalpulsar.MultiLALDetector()
+        lalpulsar.ParseMultiLALDetector(self.multi_detector, detectors)
+
+        self.multi_timestamps = lalpulsar.CreateMultiLIGOTimeGPSVector(
+            self.multi_detector.length
+        )
+        for ind, ts in enumerate(timestamps):
+            self.multi_timestamps.data[ind] = self._numpy_array_to_LIGOTimeGPSVector(ts)
+
+    @staticmethod
+    def _numpy_array_to_LIGOTimeGPSVector(numpy_array):
+        """Pure brute force conversion"""
+
+        if numpy_array.ndim != 1:
+            raise ValueError(
+                f"Time stamps array must be 1D: Current one has {numpy_array.ndim}."
+            )
+
+        seconds_array = np.floor(numpy_array)
+        nanoseconds_array = np.floor(1e9 * (numpy_array - seconds_array))
+
+        time_gps_vector = lalpulsar.CreateTimestampVector(numpy_array.shape[0])
+        for ind in range(time_gps_vector.length):
+            time_gps_vector.data[ind] = lal.LIGOTimeGPS(
+                int(seconds_array[ind]), int(nanoseconds_array[ind])
+            )
+
+        return time_gps_vector

--- a/pyfstat/snr.py
+++ b/pyfstat/snr.py
@@ -218,7 +218,7 @@ class SignalToNoiseRatio:
         Returns
         -------
         Mmunu: lalpulsar.AntennaPatternMatrix
-            Mmunu matrix enconding the response of the given detector network
+            Mmunu matrix encoding the response of the given detector network
             to a CW at the specified sky position.
         """
 

--- a/pyfstat/snr.py
+++ b/pyfstat/snr.py
@@ -24,7 +24,7 @@ class SignalToNoiseRatio:
         - The antenna pattern matrix `M`, which depends on the sky position and polarization angle
         and encodes the effect of the detector's antenna pattern over the course
         of the observing run.
-        - The JKS amplitude parameters `{A^0, A^1, A^2, A^3}` 
+        - The JKS amplitude parameters `{A^0, A^1, A^2, A^3}`
         [Jaranowski, Krolak, Schutz Phys. Rev. D 58 063001,(1998)], which are functions
         of the CW's amplitude parameters `(h0, cosi, psi, phi0)` or, alternatively,
         `(aPlus, aCross, psi, phi0)`.
@@ -100,7 +100,10 @@ class SignalToNoiseRatio:
             Optional argument to specify further constraints in XLALSFTdataFind.
         """
 
-        detector_states, multi_sfts = DetectorStates().multi_detector_states_from_sfts(
+        (
+            detector_states,
+            multi_sfts,
+        ) = DetectorStates().get_multi_detector_states_from_sfts(
             sftfilepath=sftfilepath,
             central_frequency=F0,
             frequency_wing_bins=running_median_window // 2
@@ -266,7 +269,9 @@ class DetectorStates:
     def __init__(self):
         self.ephems = lalpulsar.InitBarycenter(*get_ephemeris_files())
 
-    def multi_detector_states(self, timestamps, Tsft, detectors=None, time_offset=0):
+    def get_multi_detector_states(
+        self, timestamps, Tsft, detectors=None, time_offset=0
+    ):
         """
         Parameters
         ----------
@@ -301,7 +306,7 @@ class DetectorStates:
             time_offset,
         )
 
-    def multi_detector_states_from_sfts(
+    def get_multi_detector_states_from_sfts(
         self,
         sftfilepath,
         central_frequency,

--- a/pyfstat/snr.py
+++ b/pyfstat/snr.py
@@ -74,7 +74,7 @@ class SignalToNoiseRatio:
         cls,
         F0,
         sftfilepath,
-        time_offset,
+        time_offset=None,
         running_median_window=lalpulsar.FstatOptionalArgsDefaults.runningMedianWindow,
         sft_constraint=None,
     ):
@@ -93,6 +93,7 @@ class SignalToNoiseRatio:
             Path to SFT files in a format compatible with XLALSFTdataFind.
         time_offset: float
             Timestamp offset to retrieve detector states.
+            Defaults to LALSuite's default of using the central time of an STF (SFT's timestamp + Tsft/2).
         running_median_window: int
             Window used to compute the running-median noise floor estimation.
             Default value is consistent with that used in lalapps_PredictFstat.
@@ -270,7 +271,7 @@ class DetectorStates:
         self.ephems = lalpulsar.InitBarycenter(*get_ephemeris_files())
 
     def get_multi_detector_states(
-        self, timestamps, Tsft, detectors=None, time_offset=0
+        self, timestamps, Tsft, detectors=None, time_offset=None
     ):
         """
         Parameters
@@ -290,13 +291,15 @@ class DetectorStates:
             Conflicts with dictionary of `time_stamps`, required otherwise.
         time_offset: float
             Timestamp offset to retrieve detector states.
-
+            Defaults to LALSuite's default of using the central time of an STF (SFT's timestamp + Tsft/2).
 
         Returns
         -------
         multi_detector_states: lalpulsar.MultiDetectorStateSeries
             Resulting multi-detector states produced by XLALGetMultiDetectorStates
         """
+        if time_offset is None:
+            time_offset = 0.5 * Tsft
 
         self._parse_timestamps_and_detectors(timestamps, Tsft, detectors)
         return lalpulsar.GetMultiDetectorStates(
@@ -310,7 +313,7 @@ class DetectorStates:
         self,
         sftfilepath,
         central_frequency,
-        time_offset=0,
+        time_offset=None,
         frequency_wing_bins=1,
         sft_constraint=None,
         return_sfts=False,
@@ -326,6 +329,7 @@ class DetectorStates:
             retrieved from the SFTs (i.e. `return_sfts=True`).
         time_offset: float
             Timestamp offset to retrieve detector states.
+            Defaults to LALSuite's default of using the central time of an STF (SFT's timestamp + Tsft/2).
         frequency_wing_bins: int
             Frequency bins around the central frequency to retrieve from
             SFT data. Bin size is determined using the SFT baseline time
@@ -356,6 +360,10 @@ class DetectorStates:
             fMin=central_frequency - wing_Hz,
             fMax=central_frequency + wing_Hz,
         )
+
+        if time_offset is None:
+            time_offset = 0.5 / df
+
         multi_detector_states = lalpulsar.GetMultiDetectorStatesFromMultiSFTs(
             multiSFTs=multi_sfts, edat=self.ephems, tOffset=time_offset
         )

--- a/pyfstat/snr.py
+++ b/pyfstat/snr.py
@@ -36,7 +36,7 @@ class SignalToNoiseRatio:
     noise_weights: Union[lalpulsar.MultiNoiseWeights, None]
         Optional, incompatible with `(assumeSqrtSX, Tsft)`.
         Can be computed from SFTs using `SignalToNoiseRatio.from_sfts`.
-        Vector of noise weights to account for a varying noise floor or unequal noise
+        Noise weights to account for a varying noise floor or unequal noise
         floors in different detectors.
     assumeSqrtSX: float
         Optional, incompatible with `noise_weights`.

--- a/pyfstat/snr.py
+++ b/pyfstat/snr.py
@@ -24,9 +24,10 @@ class SignalToNoiseRatio:
         - The antenna pattern matrix `M`, which depends on the sky position and polarization angle
         and encodes the effect of the detector's antenna pattern over the course
         of the observing run.
-        - The JKS amplitude parameters `{A^0, A^1, A^2, A^3}`, which are functions
-        of the CW's amplitude parameters `(h0, cosi, psi)` or, alternatively,
-        `(aPlus, aCross, psi)`.
+        - The JKS amplitude parameters `{A^0, A^1, A^2, A^3}` 
+        [Jaranowski, Krolak, Schutz Phys. Rev. D 58 063001,(1998)], which are functions
+        of the CW's amplitude parameters `(h0, cosi, psi, phi0)` or, alternatively,
+        `(aPlus, aCross, psi, phi0)`.
 
     Parameters
     ----------
@@ -41,8 +42,10 @@ class SignalToNoiseRatio:
     assumeSqrtSX: float
         Optional, incompatible with `noise_weights`.
         *Single-sided* *amplitude* spectral density (ASD) of the detector noise.
-        This value is used for all detectors, meaning it's not possible to manually
+        This value is used for all detectors, meaning it's not currently possible to manually
         specify different noise floors without creating SFT files.
+        (To be improved in the future; developer note:
+         will require SWIG constructor for MultiNoiseWeights.)
     """
 
     detector_states: lalpulsar.MultiDetectorStateSeries = field()
@@ -275,7 +278,7 @@ class DetectorStates:
             to be parsed by XLALParseMultiLALDetector and the associated value
             should be an array-like set of GPS timestamps for each individual detector.
         Tsft: float
-            Timespan covered by each timestamp. I does not need to coincide with the
+            Timespan covered by each timestamp. It does not need to coincide with the
             separation between consecutive timestamps.
         detectors: list[str] or comma-separated string
             List of detectors to be parsed using XLALParseMultiLALDetector.

--- a/pyfstat/snr.py
+++ b/pyfstat/snr.py
@@ -52,6 +52,12 @@ class SignalToNoiseRatio:
 
         return lalpulsar.ComputeOptimalSNR2FromMmunu(Aphys, M)
 
+    def compute_twoF(self, *args, **kwargs):
+        snr2 = self.compute_snr2(*args, **kwargs)
+        expected_2F = snr2 + 4.0
+        stdev_2F = np.sqrt(8.0 + 4.0 * snr2)
+        return expected_2F, stdev_2F
+
     def compute_Mmunu(self, Alpha, Delta):
 
         sky = lal.SkyPosition()

--- a/tests.py
+++ b/tests.py
@@ -966,7 +966,7 @@ def multi_detector_states():
     ts = np.arange(tstart, tstart + default_Writer_params["duration"], Tsft)
     detectors = default_Writer_params["detectors"]
 
-    return ds.multi_detector_states(
+    return ds.get_multi_detector_states(
         timestamps=ts, detectors=detectors, Tsft=Tsft, time_offset=Tsft / 2
     )
 

--- a/tests.py
+++ b/tests.py
@@ -978,11 +978,10 @@ def test_SignalToNoiseRatio(multi_detector_states):
     snr = pyfstat.SignalToNoiseRatio(
         detector_states=multi_detector_states, assumeSqrtSX=1, Tsft=1800
     )
-    twoF_from_snr2 = snr.compute_snr2(**params)
-    twoF_from_snr2 += 4
+    twoF_from_snr2, twoF_stdev_from_snr2 = snr.compute_twoF(**params)
 
     params.pop("phi0")
-    predicted_twoF, _ = pyfstat.helper_functions.predict_fstat(
+    predicted_twoF, predicted_stdev_twoF = pyfstat.helper_functions.predict_fstat(
         **params,
         minStartTime=default_Writer_params["tstart"],
         duration=default_Writer_params["duration"],
@@ -990,6 +989,7 @@ def test_SignalToNoiseRatio(multi_detector_states):
         assumeSqrtSX=snr.assumeSqrtSX,
     )
     np.testing.assert_allclose(twoF_from_snr2, predicted_twoF, rtol=1e-3)
+    np.testing.assert_allclose(twoF_stdev_from_snr2, predicted_stdev_twoF, rtol=1e-3)
 
 
 class TestBaseSearchClass(unittest.TestCase):

--- a/tests.py
+++ b/tests.py
@@ -52,7 +52,12 @@ def writer_using_fixtures():
     kwargs["F0"] = 10.0
     kwargs["Band"] = 0.1
     kwargs["sqrtSX"] = 1e-23
-    return pyfstat.Writer(**kwargs)
+    kwargs["outdir"] = "TestData/"
+
+    this_writer = pyfstat.Writer(**kwargs)
+    yield this_writer
+    if os.path.isdir(this_writer.outdir):
+        shutil.rmtree(this_writer.outdir)
 
 
 default_signal_params_no_sky = {

--- a/tests.py
+++ b/tests.py
@@ -2361,6 +2361,7 @@ class TestGridSearch(BaseForTestsWithData):
         self.search = pyfstat.GridSearch(
             "grid_search",
             self.outdir,
+            self.Writer.sftfilepath,
             F0s=self.F0s,
             F1s=[self.Writer.F1],
             F2s=[self.Writer.F2],

--- a/tests.py
+++ b/tests.py
@@ -967,7 +967,7 @@ def multi_detector_states():
     detectors = default_Writer_params["detectors"]
 
     return ds.multi_detector_states(
-        timestamps=ts, detectors=detectors, time_offset=Tsft / 2
+        timestamps=ts, detectors=detectors, Tsft=Tsft, time_offset=Tsft / 2
     )
 
 
@@ -975,7 +975,6 @@ def multi_detector_states():
 def snr_object(multi_detector_states):
     return pyfstat.SignalToNoiseRatio(
         detector_states=multi_detector_states,
-        Tsft=default_Writer_params["Tsft"],
         assumeSqrtSX=default_Writer_params["sqrtSX"],
     )
 
@@ -995,7 +994,6 @@ def test_SignalToNoiseRatio(writer_using_fixtures, multi_detector_states):
     snr = pyfstat.SignalToNoiseRatio(
         detector_states=multi_detector_states,
         assumeSqrtSX=writer_using_fixtures.sqrtSX,
-        Tsft=writer_using_fixtures.Tsft,
     )
     twoF_from_snr2, twoF_stdev_from_snr2 = snr.compute_twoF(**params)
 


### PR DESCRIPTION
(Must be merged after #378)

Implement a new module to compute SNRs using PyFstat. 
Incidentally, this also....
- Adds class to parse detectors states, which may come in handy for other methods.
- Allows to directly access the M matrix from PyFstat. 

To do:
- [x] Compute SNR using `assumeSqrtSX *fixed and common to all detectors*.
- [x] Compute SNR using weights.
- [x] Add derived quantities such as E[2F] and Var[2F].

Testing will consist in comparing against LALSuite's PFS via helper functions.