### PR TITLE
retry MCMC quantile failures thrice via flaky

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,8 +182,8 @@ plotting methods and some of the [example scripts](./examples).
 * `style`: Includes the `flake8` linter ([flake8.pycqa](https://flake8.pycqa.org/en/latest))
   and `black` style checker ([black.readthedocs](https://black.readthedocs.io)). These checks are required to pass
   by the online integration pipeline.
-* `test`: For running the test suite locally using [pytest](https://docs.pytest.org) 
-  (`python -m pytest tests.py`).
+* `test`: For running the test suite locally using [pytest](https://docs.pytest.org) and some of its addons
+  (`python -m pytest tests/`).
 * `wheel`: Includes `wheel` and `check-wheel-contents`.
 * `dev`: Collects `style`, `test` and `wheel`.
 * `docs`: Required dependencies to build the documentation.

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ extras_require = {
         "flake8-docstrings",
         "flake8-executable",
     ],
-    "test": ["pytest", "pytest-cov"],
+    "test": ["pytest", "pytest-cov", "flaky"],
     "wheel": ["wheel", "check-wheel-contents"],
 }
 for key in ["style", "test", "wheel"]:


### PR DESCRIPTION
 - refs #264 (but doesn't resolve the underlying randomness)

Thanks to @mj-will for recommending [flaky](https://github.com/box/flaky)!

@Rodrigo-Tenorio please have a look. On top of standard filter trick recommended in the flaky README, I'm using a custom exception to only trigger the reruns in the specific places where we know there is non-determinism.