### PR TITLE
codecov: remove path_to_write_report

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -32,5 +32,4 @@ jobs:
         env_vars: PYTHON
         name: codecov-umbrella
         fail_ci_if_error: true
-        path_to_write_report: ./coverage/codecov_report.txt
         verbose: true


### PR DESCRIPTION
- to stop `Warning: Unexpected input(s)`
- seems to be unsupported according to https://github.com/codecov/codecov-action/issues/476 and https://github.com/DGEXSolutions/osrd/commit/9356438a9f17955238521a27a1e6d6451b05c763