### PR TITLE
Use isort for sorting import statement, more pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,7 @@ repos:
     rev: 5.10.1
     hooks:
       - id: isort
+        args: ["--profile", "black", "--filter-files"]
         name: isort (python)
   - repo: https://github.com/ambv/black
     rev: 22.1.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,19 @@
 repos:
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        name: isort (python)
   - repo: https://github.com/ambv/black
     rev: 22.1.0
     hooks:
       - id: black
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+    rev: 4.0.1
     hooks:
     - id: flake8
       additional_dependencies: [
           'flake8-docstrings==1.6.0',
           'flake8-executable==2.1.1',
+          'flake8-import-order==0.18.1',
       ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,17 @@
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
+    hooks:
+        - id: check-added-large-files
+        - id: check-case-conflict
+        - id: check-json
+        - id: check-merge-conflict
+        - id: check-symlinks
+        - id: check-toml
+        - id: check-yaml
+        - id: detect-private-key
+        - id: end-of-file-fixer
+        - id: trailing-whitespace
   - repo: https://github.com/pycqa/isort
     rev: 5.10.1
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,12 @@
    or comma-separated string of files per detector
    (`timestampsFiles` input is now deprecated)
  - some simplifications to `Writer` internal methods
- - started splitting up test suite by module,
-   full suite can now be run with `pytest tests/`
- - flaky MCMC tests will be rerun 3 times if needed
+ - for developers:
+   - test suite now split up by module,
+     full suite can now be run with `pytest tests/`
+   - flaky MCMC tests will be rerun 3 times if needed
+   - now enforcing isort import ordering style
+     and some other simple pre-commit-hook rules
 
 ## 1.13.1 [15/02/2022]
 

--- a/README.md
+++ b/README.md
@@ -179,9 +179,10 @@ plotting methods and some of the [example scripts](./examples).
 * `pycuda` ([PyPI](https://pypi.org/project/pycuda/)): Required for the `tCWFstatMapVersion=pycuda`
   option of the `TransientGridSearch` class. (Note: Installing `pycuda` requires a working 
   `nvcc` compiler in your path.)
-* `style`: Includes the `flake8` linter ([flake8.pycqa](https://flake8.pycqa.org/en/latest))
-  and `black` style checker ([black.readthedocs](https://black.readthedocs.io)). These checks are required to pass
-  by the online integration pipeline.
+* `style`: Includes the `flake8` linter ([flake8.pycqa](https://flake8.pycqa.org/en/latest)),
+  `black` style checker ([black.readthedocs](https://black.readthedocs.io)),
+  and `isort` for import ordering ([pycqa.github.io](https://pycqa.github.io/isort/)).
+  These checks are required to pass by the online integration pipeline.
 * `test`: For running the test suite locally using [pytest](https://docs.pytest.org) and some of its addons
   (`python -m pytest tests/`).
 * `wheel`: Includes `wheel` and `check-wheel-contents`.
@@ -249,17 +250,19 @@ Here's what you need to know:
 * The github automated tests currently run on `python` [3.7,3.8,3.9,3.10]
   and new PRs need to pass all these.
 * The automated test also runs
-  the [black](https://black.readthedocs.io) style checker
-  and the [flake8](https://flake8.pycqa.org/en/latest/) linter.
-  If at all possible, please run these two tools locally before pushing changes / submitting PRs:
+  the [black](https://black.readthedocs.io) style checker,
+  the [flake8](https://flake8.pycqa.org/en/latest/) linter,
+  and the [isort](https://pycqa.github.io/isort/) import ordering helper.
+  If at all possible, please run these tools locally before pushing changes / submitting PRs:
+  `isort .` to sort package imports,
   `flake8 --count --statistics .` to find common coding errors and then fix them manually,
-  and then
   `black --check --diff .` to show the required style changes, or `black .` to automatically apply them.
 * `bin/setup-dev-tools.sh` gets your virtual environment ready for you. After making sure you are 
 using a virtual environment (venv or conda),
 it installs `black`, `flake8`, `pre-commit`, `pytest`, `wheel` via `pip` and uses `pre-commit` to run
-the `black` and `flake8` using a pre-commit hook. In this way, you will be prompted a warning whenever you
-forget to run `black` or `flake8` before doing your commit :wink:.
+`isort`, `black`, `flake8` and other pre-commit hooks
+to automatically reformat your code to match our style
+and/or get warnings for things to fix that would fail on the github integration tests.
 
 ## Contributors
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,6 +12,7 @@
 #
 import os
 import sys
+
 import pyfstat
 
 sys.path.insert(0, os.path.abspath("../../"))

--- a/examples/binary_examples/PyFstat_example_binary_mcmc_vs_grid_comparison.py
+++ b/examples/binary_examples/PyFstat_example_binary_mcmc_vs_grid_comparison.py
@@ -7,10 +7,12 @@ to a simple grid search accross the parameter space corresponding
 to a CW source in a binary system.
 """
 
-import pyfstat
 import os
-import numpy as np
+
 import matplotlib.pyplot as plt
+import numpy as np
+
+import pyfstat
 
 # Set to false to include eccentricity
 circular_orbit = False

--- a/examples/binary_examples/PyFstat_example_semi_coherent_binary_search_using_MCMC.py
+++ b/examples/binary_examples/PyFstat_example_semi_coherent_binary_search_using_MCMC.py
@@ -6,9 +6,11 @@ MCMC search of a CW signal produced by a source in a binary
 system using the semicoherent F-statistic.
 """
 
-import pyfstat
-import numpy as np
 import os
+
+import numpy as np
+
+import pyfstat
 
 # If False, sky priors are used
 directed_search = True

--- a/examples/followup_examples/PyFstat_example_semi_coherent_directed_follow_up.py
+++ b/examples/followup_examples/PyFstat_example_semi_coherent_directed_follow_up.py
@@ -5,10 +5,12 @@ Follow up example
 Multi-stage MCMC follow up of a CW signal produced by an isolated
 source using a ladder of coherent times.
 """
-import pyfstat
-import numpy as np
-import matplotlib.pyplot as plt
 import os
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import pyfstat
 
 label = "PyFstat_example_semi_coherent_directed_follow_up"
 outdir = os.path.join("PyFstat_example_data", label)

--- a/examples/glitch_examples/PyFstat_example_glitch_robust_directed_MCMC_search_on_1_glitch.py
+++ b/examples/glitch_examples/PyFstat_example_glitch_robust_directed_MCMC_search_on_1_glitch.py
@@ -7,13 +7,11 @@ be present in the data. The setup corresponds to a targeted search,
 and the simulated signal contains a single glitch.
 """
 
-import numpy as np
-import pyfstat
+import os
 import time
+
+import numpy as np
 from PyFstat_example_make_data_for_search_on_1_glitch import (
-    tstart,
-    duration,
-    tref,
     F0,
     F1,
     F2,
@@ -21,9 +19,13 @@ from PyFstat_example_make_data_for_search_on_1_glitch import (
     Delta,
     delta_F0,
     dtglitch,
+    duration,
     outdir,
+    tref,
+    tstart,
 )
-import os
+
+import pyfstat
 
 label = "PyFstat_example_glitch_robust_directed_MCMC_search_on_1_glitch"
 

--- a/examples/glitch_examples/PyFstat_example_glitch_robust_directed_grid_search_on_1_glitch.py
+++ b/examples/glitch_examples/PyFstat_example_glitch_robust_directed_grid_search_on_1_glitch.py
@@ -7,23 +7,25 @@ be present in the data. The setup corresponds to a targeted search,
 and the simulated signal contains a single glitch.
 """
 
-import pyfstat
+import os
+import time
+
 import numpy as np
 from PyFstat_example_make_data_for_search_on_1_glitch import (
-    tstart,
-    duration,
-    tref,
     F0,
     F1,
     F2,
     Alpha,
     Delta,
     delta_F0,
-    outdir,
     dtglitch,
+    duration,
+    outdir,
+    tref,
+    tstart,
 )
-import time
-import os
+
+import pyfstat
 
 label = "PyFstat_example_glitch_robust_directed_grid_search_on_1_glitch"
 

--- a/examples/glitch_examples/PyFstat_example_make_data_for_search_on_1_glitch.py
+++ b/examples/glitch_examples/PyFstat_example_make_data_for_search_on_1_glitch.py
@@ -5,9 +5,11 @@ Glitch examples: Make data
 Generate the data to run examples on glitch-robust searches.
 """
 
-from pyfstat import Writer, GlitchWriter
-import numpy as np
 import os
+
+import numpy as np
+
+from pyfstat import GlitchWriter, Writer
 
 outdir = os.path.join("PyFstat_example_data", "PyFstat_example_glitch_robust_search")
 

--- a/examples/glitch_examples/PyFstat_example_standard_directed_MCMC_search_on_1_glitch.py
+++ b/examples/glitch_examples/PyFstat_example_standard_directed_MCMC_search_on_1_glitch.py
@@ -7,20 +7,22 @@ presenting a glitch. This is intended to show the impact of
 glitches on vanilla CW searches.
 """
 
+import os
+
 import numpy as np
-import pyfstat
 from PyFstat_example_make_data_for_search_on_1_glitch import (
-    tstart,
-    duration,
-    tref,
     F0,
     F1,
     F2,
     Alpha,
     Delta,
+    duration,
     outdir,
+    tref,
+    tstart,
 )
-import os
+
+import pyfstat
 
 label = "PyFstat_example_standard_directed_MCMC_search_on_1_glitch"
 

--- a/examples/grid_examples/PyFstat_example_grid_search_F0.py
+++ b/examples/grid_examples/PyFstat_example_grid_search_F0.py
@@ -5,10 +5,12 @@ Directed grid search: Monochromatic source
 Search for a monochromatic (no spindown) signal using
 a parameter space grid (i.e. no MCMC).
 """
-import pyfstat
-import numpy as np
-import matplotlib.pyplot as plt
 import os
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import pyfstat
 
 label = "PyFstat_example_grid_search_F0"
 outdir = os.path.join("PyFstat_example_data", label)

--- a/examples/grid_examples/PyFstat_example_grid_search_F0F1.py
+++ b/examples/grid_examples/PyFstat_example_grid_search_F0F1.py
@@ -5,9 +5,11 @@ Directed grid search: Linear spindown
 Search for CW signal including one spindown parameter
 using a parameter space grid (i.e. no MCMC).
 """
-import pyfstat
-import numpy as np
 import os
+
+import numpy as np
+
+import pyfstat
 
 label = "PyFstat_example_grid_search_F0F1"
 outdir = os.path.join("PyFstat_example_data", label)

--- a/examples/grid_examples/PyFstat_example_grid_search_F0F1F2.py
+++ b/examples/grid_examples/PyFstat_example_grid_search_F0F1F2.py
@@ -5,9 +5,11 @@ Directed grid search: Quadratic spindown
 Search for CW signal including two spindown parameters
 using a parameter space grid (i.e. no MCMC).
 """
-import pyfstat
-import numpy as np
 import os
+
+import numpy as np
+
+import pyfstat
 
 label = "PyFstat_example_grid_search_F0F1F2"
 outdir = os.path.join("PyFstat_example_data", label)

--- a/examples/grid_examples/PyFstat_example_grid_search_with_BSGL.py
+++ b/examples/grid_examples/PyFstat_example_grid_search_with_BSGL.py
@@ -8,9 +8,11 @@ and the line-robust BSGL statistic
 to distinguish an astrophysical signal from an artifact in a single detector.
 """
 
-import pyfstat
-import numpy as np
 import os
+
+import numpy as np
+
+import pyfstat
 
 label = "PyFstat_example_grid_search_BSGL"
 outdir = os.path.join("PyFstat_example_data", label)

--- a/examples/mcmc_examples/PyFstat_example_MCMC_search_using_initialisation.py
+++ b/examples/mcmc_examples/PyFstat_example_MCMC_search_using_initialisation.py
@@ -6,9 +6,11 @@ Directed MCMC search for an isolated CW signal using the
 fully-coherent F-statistic. Prior to the burn-in stage, walkers
 are initialized with a certain scattering factor.
 """
-import pyfstat
-import numpy as np
 import os
+
+import numpy as np
+
+import pyfstat
 
 label = "PyFstat_example_MCMC_search_using_initialisation"
 outdir = os.path.join("PyFstat_example_data", label)

--- a/examples/mcmc_examples/PyFstat_example_fully_coherent_MCMC_search.py
+++ b/examples/mcmc_examples/PyFstat_example_fully_coherent_MCMC_search.py
@@ -6,9 +6,11 @@ Directed MCMC search for an isolated CW signal using the
 fully coherent F-statistic.
 """
 
-import pyfstat
-import numpy as np
 import os
+
+import numpy as np
+
+import pyfstat
 from pyfstat.helper_functions import get_predict_fstat_parameters_from_dict
 
 label = "PyFstat_example_fully_coherent_MCMC_search"

--- a/examples/mcmc_examples/PyFstat_example_fully_coherent_MCMC_search_with_BSGL.py
+++ b/examples/mcmc_examples/PyFstat_example_fully_coherent_MCMC_search_with_BSGL.py
@@ -6,9 +6,11 @@ Targeted MCMC search for an isolated CW signal using the
 fully coherent line-robust BSGL-statistic.
 """
 
-import pyfstat
-import numpy as np
 import os
+
+import numpy as np
+
+import pyfstat
 
 label = os.path.splitext(os.path.basename(__file__))[0]
 outdir = os.path.join("PyFstat_example_data", label)

--- a/examples/mcmc_examples/PyFstat_example_semi_coherent_MCMC_search.py
+++ b/examples/mcmc_examples/PyFstat_example_semi_coherent_MCMC_search.py
@@ -5,9 +5,11 @@ MCMC search: Semicoherent F-statistic
 Directed MCMC search for an isolated CW signal using the
 semicoherent F-statistic.
 """
-import pyfstat
-import numpy as np
 import os
+
+import numpy as np
+
+import pyfstat
 
 label = "PyFstat_example_semi_coherent_MCMC_search"
 outdir = os.path.join("PyFstat_example_data", label)

--- a/examples/mcmc_vs_grid_simple_example/PyFstat_example_simple_mcmc_vs_grid_comparison.py
+++ b/examples/mcmc_vs_grid_simple_example/PyFstat_example_simple_mcmc_vs_grid_comparison.py
@@ -5,10 +5,12 @@ MCMC search v.s. grid search
 An example to compare MCMCSearch and GridSearch on the same data.
 """
 
-import pyfstat
 import os
-import numpy as np
+
 import matplotlib.pyplot as plt
+import numpy as np
+
+import pyfstat
 
 # flip this switch for a more expensive 4D (F0,F1,Alpha,Delta) run
 # instead of just (F0,F1)

--- a/examples/other_examples/PyFstat_example_InjectionParametersGenerator.py
+++ b/examples/other_examples/PyFstat_example_InjectionParametersGenerator.py
@@ -6,11 +6,13 @@ Application of dedicated classes to sample software injection
 parameters according to the specified parameter space priors.
 """
 import os
-import numpy as np
+
 import matplotlib.pyplot as plt
+import numpy as np
+
 from pyfstat import (
-    InjectionParametersGenerator,
     AllSkyInjectionParametersGenerator,
+    InjectionParametersGenerator,
     Writer,
 )
 

--- a/examples/other_examples/PyFstat_example_injecting_into_noise_sfts.py
+++ b/examples/other_examples/PyFstat_example_injecting_into_noise_sfts.py
@@ -10,7 +10,9 @@ but the same procedure can be applied to any other set of SFTs
 """
 
 import os
+
 import numpy as np
+
 import pyfstat
 
 label = "PyFstat_example_injection_into_noise_sfts"

--- a/examples/other_examples/PyFstat_example_spectrogram.py
+++ b/examples/other_examples/PyFstat_example_spectrogram.py
@@ -7,6 +7,7 @@ visualizations of the Doppler modulation of a CW signal.
 """
 
 import os
+
 import matplotlib.pyplot as plt
 
 import pyfstat

--- a/examples/other_examples/PyFstat_example_twoF_cumulative.py
+++ b/examples/other_examples/PyFstat_example_twoF_cumulative.py
@@ -7,9 +7,10 @@ Compute the cumulative coherent F-statistic of a signal candidate.
 
 
 import os
-import numpy as np
-import pyfstat
 
+import numpy as np
+
+import pyfstat
 from pyfstat.helper_functions import get_predict_fstat_parameters_from_dict
 
 label = "PyFstat_example_twoF_cumulative"

--- a/examples/run_all_examples.py
+++ b/examples/run_all_examples.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 from glob import glob
+
 from pyfstat.helper_functions import run_commandline
 
 exit_on_first_failure = False

--- a/examples/transient_examples/PyFstat_example_long_transient_MCMC_search.py
+++ b/examples/transient_examples/PyFstat_example_long_transient_MCMC_search.py
@@ -4,10 +4,12 @@ Long transient MCMC search
 
 MCMC search for a long transient CW signal.
 """
-import pyfstat
 import os
+
 import numpy as np
 import PyFstat_example_make_data_for_long_transient_search as data
+
+import pyfstat
 from pyfstat.helper_functions import get_predict_fstat_parameters_from_dict
 
 if not os.path.isdir(data.outdir) or not np.any(

--- a/examples/transient_examples/PyFstat_example_make_data_for_long_transient_search.py
+++ b/examples/transient_examples/PyFstat_example_make_data_for_long_transient_search.py
@@ -9,8 +9,9 @@ or it is also being imported from
 PyFstat_example_long_transient_MCMC_search.py
 """
 
-import pyfstat
 import os
+
+import pyfstat
 
 outdir = os.path.join("PyFstat_example_data", "PyFstat_example_long_transient_search")
 

--- a/examples/transient_examples/PyFstat_example_make_data_for_short_transient_search.py
+++ b/examples/transient_examples/PyFstat_example_make_data_for_short_transient_search.py
@@ -11,8 +11,9 @@ and
 PyFstat_example_short_transient_MCMC_search.py
 """
 
-import pyfstat
 import os
+
+import pyfstat
 
 outdir = os.path.join("PyFstat_example_data", "PyFstat_example_short_transient_search")
 

--- a/examples/transient_examples/PyFstat_example_short_transient_MCMC_search.py
+++ b/examples/transient_examples/PyFstat_example_short_transient_MCMC_search.py
@@ -5,10 +5,12 @@ Short transient MCMC search
 MCMC search for a Short transient CW signal.
 """
 
-import pyfstat
 import os
+
 import numpy as np
 import PyFstat_example_make_data_for_short_transient_search as data
+
+import pyfstat
 from pyfstat.helper_functions import get_predict_fstat_parameters_from_dict
 
 if __name__ == "__main__":

--- a/examples/transient_examples/PyFstat_example_short_transient_grid_search.py
+++ b/examples/transient_examples/PyFstat_example_short_transient_grid_search.py
@@ -5,10 +5,12 @@ Short transient grid search
 An example grid-based search for a short transient signal.
 """
 
-import pyfstat
 import os
+
 import numpy as np
 import PyFstat_example_make_data_for_short_transient_search as data
+
+import pyfstat
 
 if __name__ == "__main__":
 

--- a/pyfstat/__init__.py
+++ b/pyfstat/__init__.py
@@ -1,45 +1,41 @@
+from ._version import get_versions
 from .core import (
     BaseSearchClass,
     ComputeFstat,
     SearchForSignalWithJumps,
-    SemiCoherentSearch,
     SemiCoherentGlitchSearch,
-)
-
-from .injection_parameters import (
-    InjectionParametersGenerator,
-    AllSkyInjectionParametersGenerator,
-)
-
-from .make_sfts import (
-    Writer,
-    BinaryModulatedWriter,
-    GlitchWriter,
-    FrequencyModulatedArtifactWriter,
-    FrequencyAmplitudeModulatedArtifactWriter,
-    LineWriter,
-)
-from .mcmc_based_searches import (
-    MCMCSearch,
-    MCMCGlitchSearch,
-    MCMCSemiCoherentSearch,
-    MCMCFollowUpSearch,
-    MCMCTransientSearch,
+    SemiCoherentSearch,
 )
 from .grid_based_searches import (
+    DMoff_NO_SPIN,
+    FrequencySlidingWindow,
+    GridGlitchSearch,
     GridSearch,
     GridUniformPriorSearch,
-    GridGlitchSearch,
-    FrequencySlidingWindow,
-    DMoff_NO_SPIN,
     SliceGridSearch,
     TransientGridSearch,
 )
 from .gridcorner import gridcorner
-
+from .injection_parameters import (
+    AllSkyInjectionParametersGenerator,
+    InjectionParametersGenerator,
+)
+from .make_sfts import (
+    BinaryModulatedWriter,
+    FrequencyAmplitudeModulatedArtifactWriter,
+    FrequencyModulatedArtifactWriter,
+    GlitchWriter,
+    LineWriter,
+    Writer,
+)
+from .mcmc_based_searches import (
+    MCMCFollowUpSearch,
+    MCMCGlitchSearch,
+    MCMCSearch,
+    MCMCSemiCoherentSearch,
+    MCMCTransientSearch,
+)
 from .snr import DetectorStates, SignalToNoiseRatio
-
-from ._version import get_versions
 
 __version__ = get_versions()["version"]
 del get_versions

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -1,20 +1,20 @@
 """ The core tools used in pyfstat """
 
 
-import os
-import logging
-from pprint import pformat
-
-import glob
-import numpy as np
-import scipy.special
-import scipy.optimize
-from datetime import datetime
 import getpass
+import glob
+import logging
+import os
 import socket
+from datetime import datetime
+from pprint import pformat
 
 import lal
 import lalpulsar
+import numpy as np
+import scipy.optimize
+import scipy.special
+
 import pyfstat.helper_functions as helper_functions
 import pyfstat.tcw_fstat_map_funcs as tcw
 

--- a/pyfstat/grid_based_searches.py
+++ b/pyfstat/grid_based_searches.py
@@ -1,25 +1,25 @@
 """PyFstat search classes using grid-based methods."""
 
 
-import os
-import logging
 import itertools
+import logging
+import os
+import re
 from collections import OrderedDict
 
-import numpy as np
 import matplotlib
 import matplotlib.pyplot as plt
-import re
+import numpy as np
 
 import pyfstat.helper_functions as helper_functions
 from pyfstat.core import (
     BaseSearchClass,
     ComputeFstat,
+    DefunctClass,
     SemiCoherentGlitchSearch,
     SemiCoherentSearch,
-    tqdm,
     args,
-    DefunctClass,
+    tqdm,
 )
 
 

--- a/pyfstat/gridcorner.py
+++ b/pyfstat/gridcorner.py
@@ -40,8 +40,8 @@ of the authors and should not be interpreted as representing official policies,
 either expressed or implied, of the FreeBSD Project.
 """
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 from matplotlib.ticker import MaxNLocator
 
 try:

--- a/pyfstat/helper_functions.py
+++ b/pyfstat/helper_functions.py
@@ -6,18 +6,20 @@ and are of interest mostly only for developers,
 but others can also be helpful for end users.
 """
 
-import os
-import sys
-import subprocess
 import argparse
-import logging
 import inspect
-import peakutils
+import logging
+import os
 import shutil
+import subprocess
+import sys
 from functools import wraps
-import numpy as np
+
 import lal
 import lalpulsar
+import numpy as np
+import peakutils
+
 from ._version import get_versions
 
 # workaround for matplotlib on X-less remote logins

--- a/pyfstat/injection_parameters.py
+++ b/pyfstat/injection_parameters.py
@@ -1,9 +1,10 @@
 """Generate injection parameters drawn from different prior populations"""
-from attrs import define, Factory, field
-import logging
-import numpy as np
 import functools
+import logging
 from typing import Union
+
+import numpy as np
+from attrs import Factory, define, field
 
 isotropic_amplitude_priors = {
     "cosi": {"uniform": {"low": -1.0, "high": 1.0}},

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -1,23 +1,18 @@
 """PyFstat tools to generate and manipulate data in the form of SFTs."""
 
 
-import numpy as np
+import glob
 import logging
 import os
-import glob
 import pkgutil
 
 import lal
 import lalpulsar
+import numpy as np
 
-from pyfstat.core import (
-    BaseSearchClass,
-    SearchForSignalWithJumps,
-    tqdm,
-    args,
-)
 import pyfstat.helper_functions as helper_functions
 from pyfstat import injection_parameters
+from pyfstat.core import BaseSearchClass, SearchForSignalWithJumps, args, tqdm
 
 
 class Writer(BaseSearchClass):

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -43,24 +43,24 @@ and ``scale`` shape parameters). Further priors can be added by modifying ``pyfs
 
 """
 
-import sys
-import os
 import copy
 import logging
+import os
+import sys
 from collections import OrderedDict
 
-import numpy as np
-import matplotlib
-import matplotlib.pyplot as plt
-from ptemcee import Sampler as PTSampler
 import corner
 import dill as pickle
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+from ptemcee import Sampler as PTSampler
 from scipy.stats import lognorm
 
 import pyfstat.core as core
-from pyfstat.core import BaseSearchClass, tqdm, args
-import pyfstat.optimal_setup_functions as optimal_setup_functions
 import pyfstat.helper_functions as helper_functions
+import pyfstat.optimal_setup_functions as optimal_setup_functions
+from pyfstat.core import BaseSearchClass, args, tqdm
 
 
 class MCMCSearch(BaseSearchClass):

--- a/pyfstat/optimal_setup_functions.py
+++ b/pyfstat/optimal_setup_functions.py
@@ -6,10 +6,12 @@ Provides functions to aid in calculating the optimal setup for zoom follow up
 
 
 import logging
-import numpy as np
-import scipy.optimize
+
 import lal
 import lalpulsar
+import numpy as np
+import scipy.optimize
+
 import pyfstat.helper_functions as helper_functions
 
 

--- a/pyfstat/snr.py
+++ b/pyfstat/snr.py
@@ -1,9 +1,10 @@
-from attrs import define, field
+import logging
+from typing import Union
+
 import lal
 import lalpulsar
-import logging
 import numpy as np
-from typing import Union
+from attrs import define, field
 
 from pyfstat.helper_functions import get_ephemeris_files
 

--- a/pyfstat/tcw_fstat_map_funcs.py
+++ b/pyfstat/tcw_fstat_map_funcs.py
@@ -8,13 +8,13 @@ https://arxiv.org/abs/1805.05652
 for a detailed discussion of the GPU implementation.
 """
 
-import numpy as np
-import os
-import logging
-from time import time
-
 # optional imports
 import importlib as imp
+import logging
+import os
+from time import time
+
+import numpy as np
 
 
 def _optional_import(modulename, shorthand=None):

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,9 @@ max-line-length = 80
 select = C,E,F,W,B,B950
 ignore = E501,W503,E203
 
+[isort]
+profile = black
+
 [versioneer]
 VCS = git
 style = pep440

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
-from setuptools import setup, find_packages
-from os import path
 import sys
+from os import path
+
+from setuptools import find_packages, setup
+
 import versioneer
 
 # check python version
@@ -40,6 +42,8 @@ extras_require = {
         "flake8",
         "flake8-docstrings",
         "flake8-executable",
+        "flake8-isort",
+        "isort",
     ],
     "test": ["pytest", "pytest-cov", "flaky"],
     "wheel": ["wheel", "check-wheel-contents"],

--- a/tests/commons_for_tests.py
+++ b/tests/commons_for_tests.py
@@ -2,6 +2,7 @@ import logging
 import os
 import shutil
 import unittest
+
 import pyfstat
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,18 +1,20 @@
 import os
-import pytest
 import unittest
+
 import lalpulsar
 import numpy as np
-from scipy.stats import chi2
-import pyfstat
+import pytest
 
 # FIXME this should be made cleaner with fixtures
 from commons_for_tests import (
     BaseForTestsWithData,
     BaseForTestsWithOutdir,
-    default_Writer_params,
     default_signal_params,
+    default_Writer_params,
 )
+from scipy.stats import chi2
+
+import pyfstat
 
 
 class TestReadParFile(BaseForTestsWithOutdir):

--- a/tests/test_grid_based_searches.py
+++ b/tests/test_grid_based_searches.py
@@ -1,9 +1,11 @@
 import os
+
 import numpy as np
-import pyfstat
 
 # FIXME this should be made cleaner with fixtures
 from commons_for_tests import BaseForTestsWithData
+
+import pyfstat
 
 
 class TestGridSearch(BaseForTestsWithData):

--- a/tests/test_injection_parameters.py
+++ b/tests/test_injection_parameters.py
@@ -1,8 +1,9 @@
 import numpy as np
-import pyfstat
 
 # FIXME this should be made cleaner with fixtures
 from commons_for_tests import BaseForTestsWithOutdir
+
+import pyfstat
 
 
 class TestInjectionParametersGenerator(BaseForTestsWithOutdir):

--- a/tests/test_make_sfts.py
+++ b/tests/test_make_sfts.py
@@ -1,20 +1,22 @@
 import os
-import pytest
 import time
-import numpy as np
+
 import lalpulsar
-import pyfstat
+import numpy as np
+import pytest
 
 # FIXME this should be made cleaner with fixtures
 from commons_for_tests import (
     BaseForTestsWithData,
     BaseForTestsWithOutdir,
-    default_Writer_params,
-    default_signal_params_no_sky,
-    default_signal_params,
     default_binary_params,
+    default_signal_params,
+    default_signal_params_no_sky,
     default_transient_params,
+    default_Writer_params,
 )
+
+import pyfstat
 
 
 class TestWriter(BaseForTestsWithData):

--- a/tests/test_mcmc_based_searches.py
+++ b/tests/test_mcmc_based_searches.py
@@ -1,14 +1,15 @@
-import pytest
 import numpy as np
-import pyfstat
+import pytest
 
 # FIXME this should be made cleaner with fixtures
 from commons_for_tests import (
     BaseForTestsWithData,
-    default_signal_params,
     FlakyError,
+    default_signal_params,
     is_flaky,
 )
+
+import pyfstat
 
 
 @pytest.mark.flaky(max_runs=3, min_passes=1, rerun_filter=is_flaky)

--- a/tests/test_snr.py
+++ b/tests/test_snr.py
@@ -1,7 +1,9 @@
 import os
-import pytest
 import shutil
+
 import numpy as np
+import pytest
+
 import pyfstat
 
 


### PR DESCRIPTION
This adds (and pre-runs) [isort](https://github.com/PyCQA/isort) to have a fixed ordering of package imports.

It comes _before_ `black` in the pre-commit hook order, so that if black were to disagree with it on any formatting choices, it would overrule it. However, there is then also the [flake8-isort](https://pypi.org/project/flake8-isort/) integration, which should (i) do nothing if black agreed with isort, (ii) throw an error if there is disagreement.

I also looked at the alternative [flake8-import-order](https://pypi.org/project/flake8-import-order/) but (at least with the configuration variants I tried) it does not seem to agree entirely with `isort`, and it doesn't come with its own active mode to actually sort things instead of just complaining, so the double `isort` seems the cleanest solution to me.

While at it, I also added a bunch more of trivial hooks.