### PR TITLE
Ignore setup.py dependencies to test conda environment 

### DIFF
--- a/.github/workflows/conda-test.yml
+++ b/.github/workflows/conda-test.yml
@@ -28,6 +28,7 @@ jobs:
           conda config --show-sources
           conda config --show
           printenv | sort
+          pip install --no-dependencies .
       - name: test with pytest
         shell: bash -l {0}
         run: |

--- a/etc/pyfstat-dev.yml
+++ b/etc/pyfstat-dev.yml
@@ -19,4 +19,4 @@ dependencies:
   - python-lalpulsar >=3.1.1
   - lalapps >=7.4.0
   - pytest
-  
+  - flaky


### PR DESCRIPTION
@dbkeitel 

Not sure if it's going to be a long term solution , but will do the trick for now if it works.

Edit: Falling back to the "install using pip" route, including a specific flag to avoid installing anything with pip.