### PR TITLE
Configure binder to deal with tutorial notebooks

### DIFF
--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -21,7 +21,7 @@ find . -delete
 NOTEBOOKS_SCRIPTS_DIR=.generated-notebooks
 mkdir -p ${NOTEBOOKS_SCRIPTS_DIR}
 cp -r ${TMP_DIR}/* ${NOTEBOOKS_SCRIPTS_DIR}
-find ${NOTEBOOKS_SCRIPTS_DIR} -name '*.py' ! -name '*run_all*' -name '*utils*' -exec sphx_glr_python_to_jupyter.py '{}' +
+find ${NOTEBOOKS_SCRIPTS_DIR} -name '*.py' ! -name '*run_all*' ! -name '*utils*' -exec sphx_glr_python_to_jupyter.py '{}' +
 
 # This symlink is required
 mkdir notebooks

--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -15,6 +15,7 @@ pip install .
 TMP_DIR=/tmp/pyfstat
 mkdir -p ${TMP_DIR}
 cp -r examples/*/*.py .binder ${TMP_DIR}
+cp examples/tutorials/*.ipynb ${TMP_DIR}
 find . -delete
 
 # Generate notebooks from the python scripts
@@ -26,3 +27,4 @@ find ${NOTEBOOKS_SCRIPTS_DIR} -name '*.py' ! -name '*run_all*' ! -name '*utils*'
 # This symlink is required
 mkdir notebooks
 ln -s ../${NOTEBOOKS_SCRIPTS_DIR} notebooks/auto_examples
+


### PR DESCRIPTION
Following #395 & #397, let's make sure tutorials are accessible via Binder.