### PR TITLE
fix ptemcee incompatibility with numpy 1.23.0 via local copies of autocorr functions

### DIFF
--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -524,7 +524,7 @@ class MCMCSearch(BaseSearchClass):
 
         This is copied from sampler.py of ptemcee-1.0.0
         [(c) Daniel Foreman-Mackey & contributors],
-        and only modified to be a class method.
+        to allow us to call the locally fixed _autocorr_function().
 
         :param window: (optional)
             The size of the windowing function. This is equivalent to the
@@ -547,7 +547,7 @@ class MCMCSearch(BaseSearchClass):
 
         This version of this function is copied from util.py of ptemcee-1.0.0
         [(c) Daniel Foreman-Mackey & contributors],
-        and only modified to be a class method.
+        and fixed up to be compatible with numpy>=1.23.0.
 
         :param x:
             The time series. If multidimensional, set the time axis using the
@@ -577,7 +577,7 @@ class MCMCSearch(BaseSearchClass):
             slice(None),
         ] * len(f.shape)
         m[axis] = slice(1, window)
-        m[axis] = slice(1, window)
+        m = tuple(m)  # fix for numpy>=1.23.0
         tau = 1 + 2 * np.sum(f[m], axis=axis)
 
         return tau
@@ -588,7 +588,7 @@ class MCMCSearch(BaseSearchClass):
 
         This version of this function is copied from util.py of ptemcee-1.0.0
         [(c) Daniel Foreman-Mackey & contributors],
-        and only modified to be a class method.
+        and fixed up to be compatible with numpy>=1.23.0.
 
         :param x:
             The time series. If multidimensional, set the time axis using the
@@ -620,9 +620,11 @@ class MCMCSearch(BaseSearchClass):
         # Compute the FFT and then (from that) the auto-correlation function.
         f = np.fft.fft(x - np.mean(x, axis=axis), n=2 * n, axis=axis)
         m[axis] = slice(0, n)
-        acf = np.fft.ifft(f * np.conjugate(f), axis=axis)[m].real
+        m_tuple = tuple(m)  # fix for numpy>=1.23.0
+        acf = np.fft.ifft(f * np.conjugate(f), axis=axis)[m_tuple].real
         m[axis] = 0
-        return acf / acf[m]
+        m_tuple = tuple(m)  # fix for numpy>=1.23.0
+        return acf / acf[m_tuple]
 
     def _estimate_run_time(self):
         """Print the estimated run time

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
         "dill",
         "lalsuite>=7.2",
         "matplotlib>=2.1",
-        "numpy<1.23.0",
+        "numpy",
         "pathos",
         "peakutils",
         "ptemcee",


### PR DESCRIPTION
This first adds local copies of the ptemcee-1.0.0 autocorr functions (taken from [the PyPI release tarball](https://files.pythonhosted.org/packages/81/1d/2b3f09f0eb3ce8530e59b03e1aab4bc260cc14ddbc7dad761f9107d944e6/ptemcee-1.0.0.tar.gz)). Then it does a simple cast of lists of slices to tuples to fix the incompatibility. Numpy pin can now be removed.

Comparison run of `examples/transient_examples/PyFstat_example_short_transient_MCMC_search.py` with PyFstat 1.15.0 from conda:
```
17:20 INFO    : Running final burn and prod with 400 steps
100%|███████████████████████████████████████████████████████████| 400/400 [00:06<00:00, 58.57it/s]
17:20 INFO    : Mean acceptance fraction: [0.131275 0.338375]
17:20 INFO    : Tswap acceptance fraction: [0.096075 0.096075]
/home/dkeitel/.conda/envs/pyfstat/lib/python3.10/site-packages/ptemcee/util.py:43: FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different result.
  acf = np.fft.ifft(f * np.conjugate(f), axis=axis)[m].real
/home/dkeitel/.conda/envs/pyfstat/lib/python3.10/site-packages/ptemcee/util.py:45: FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different result.
  return acf / acf[m]
/home/dkeitel/.conda/envs/pyfstat/lib/python3.10/site-packages/ptemcee/util.py:80: FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different result.
  tau = 1 + 2*np.sum(f[m], axis=axis)
17:20 INFO    : Autocorrelation length: [[34.53833898 50.89847907 33.90042491 81.02920398]
 [21.63292614 33.71851189 40.06070022 35.64498086]]
```

and with these patches:
```
17:19 INFO    : Running final burn and prod with 400 steps
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 400/400 [00:06<00:00, 59.51it/s]
17:19 INFO    : Mean acceptance fraction: [0.124625 0.33125 ]
17:19 INFO    : Tswap acceptance fraction: [0.044975 0.044975]
17:19 INFO    : Autocorrelation length: [[38.40494641 77.60574929 56.96806642 82.25742395]
 [36.20718978 48.71374996 55.61313057 64.86090856]]
```

@Rodrigo-Tenorio looking at the commits separately will be more useful than the overall diff view here.