### PR TITLE
enable context manager mode for ComputeFstat and TransientGridSearch

### DIFF
--- a/examples/transient_examples/PyFstat_example_short_transient_grid_search.py
+++ b/examples/transient_examples/PyFstat_example_short_transient_grid_search.py
@@ -33,6 +33,7 @@ if __name__ == "__main__":
     Deltas = [data.Delta]
 
     BSGL = False
+    BtSG = False
 
     print("Standard CW search:")
     search1 = pyfstat.GridSearch(
@@ -68,6 +69,7 @@ if __name__ == "__main__":
         outputTransientFstatMap=True,
         tCWFstatMapVersion="lal",
         BSGL=BSGL,
+        BtSG=BtSG,
     )
     search2.run()
     search2.print_max_twoF()

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -242,14 +242,14 @@ class ComputeFstat(BaseSearchClass):
     it can also generate simulated data (including noise and/or signals) on the fly.
 
     NOTE: when you want to use this with `tCWFstatMapVersion="pycuda"`,
-    please use context management to ensure proper cleanup of the cuda device context:
-    ```
-    with pyfstat.ComputeFstat(
-        [...],
-        tCWFstatMapVersion="pycuda",
-    ) as search:
-        search.get_fullycoherent_detstat([...])
-    ```
+    please use context management to ensure proper cleanup of the cuda device context,
+    for example::
+
+       with pyfstat.ComputeFstat(
+            [...],
+            tCWFstatMapVersion="pycuda",
+        ) as search:
+            search.get_fullycoherent_detstat([...])
     """
 
     @helper_functions.initializer

--- a/pyfstat/grid_based_searches.py
+++ b/pyfstat/grid_based_searches.py
@@ -876,6 +876,7 @@ class TransientGridSearch(GridSearch):
         minStartTime=None,
         maxStartTime=None,
         BSGL=False,
+        BtSG=False,
         minCoverFreq=None,
         maxCoverFreq=None,
         detectors=None,
@@ -943,8 +944,12 @@ class TransientGridSearch(GridSearch):
         self.search_keys = ["F0", "F1", "F2", "Alpha", "Delta"]
         for k in self.search_keys:
             setattr(self, k, np.atleast_1d(getattr(self, k + "s")))
-        if self.BSGL:
+        if self.BSGL and self.BtSG:
+            raise ValueError("Choose only one of [BSGL,BtSG].")
+        elif self.BSGL:
             self.detstat = "log10BSGL"
+        elif self.BtSG:
+            self.detstat = "logBtSG"
         else:
             self.detstat = "maxTwoF"
         self._initiate_search_object()
@@ -993,6 +998,7 @@ class TransientGridSearch(GridSearch):
             minStartTime=self.minStartTime,
             maxStartTime=self.maxStartTime,
             BSGL=self.BSGL,
+            BtSG=self.BtSG,
             SSBprec=self.SSBprec,
             RngMedWindow=self.RngMedWindow,
             injectSources=self.injectSources,

--- a/pyfstat/grid_based_searches.py
+++ b/pyfstat/grid_based_searches.py
@@ -861,14 +861,14 @@ class TransientGridSearch(GridSearch):
     only the additional ones are documented here.
 
     NOTE: when you want to use this with `tCWFstatMapVersion="pycuda"`,
-    please use context management to ensure proper cleanup of the cuda device context:
-    ```
-    with pyfstat.TransientGridSearch(
-        [...],
-        tCWFstatMapVersion="pycuda",
-    ) as search:
-        search.run()
-    ```
+    please use context management to ensure proper cleanup of the cuda device context,
+    for example::
+
+        with pyfstat.TransientGridSearch(
+            [...],
+            tCWFstatMapVersion="pycuda",
+        ) as search:
+            search.run()
     """
 
     @helper_functions.initializer

--- a/pyfstat/grid_based_searches.py
+++ b/pyfstat/grid_based_searches.py
@@ -858,7 +858,17 @@ class TransientGridSearch(GridSearch):
 
     Most parameters are the same as for `GridSearch`
     and the `core.ComputeFstat` class,
-    only the additional ones are documented here:
+    only the additional ones are documented here.
+
+    NOTE: when you want to use this with `tCWFstatMapVersion="pycuda"`,
+    please use context management to ensure proper cleanup of the cuda device context:
+    ```
+    with pyfstat.TransientGridSearch(
+        [...],
+        tCWFstatMapVersion="pycuda",
+    ) as search:
+        search.run()
+    ```
     """
 
     @helper_functions.initializer
@@ -1146,9 +1156,14 @@ class TransientGridSearch(GridSearch):
         fmt_dict["tau"] = "%d"
         return fmt_dict
 
-    def __del__(self):
-        if hasattr(self, "search"):
-            self.search.__del__()
+    def __enter__(self):
+        logging.debug("Entering the TransientGridSearch context...")
+        self.search.__enter__()
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        logging.debug("Leaving the TransientGridSearch context...")
+        self.search.__exit__(*args, **kwargs)
 
 
 class SliceGridSearch(DefunctClass):
@@ -1195,7 +1210,7 @@ class GridGlitchSearch(GridSearch):
     ):
         """
         Most parameters are the same as for `GridSearch`
-        and the `core.SemiCoherentGlitchSearch` class,
+        and the `core.SemiCoherentGlitchSearch` class;
         only the additional ones are documented here:
 
         Parameters

--- a/pyfstat/tcw_fstat_map_funcs.py
+++ b/pyfstat/tcw_fstat_map_funcs.py
@@ -667,7 +667,7 @@ def pycuda_compute_transient_fstat_map(multiFstatAtoms, windowRange, BtSG=False)
 
     if BtSG:
         # FIXME this should be moved into cuda kernel!
-        FstatMap.logBtSG = FstatMap.get_logBtSG()
+        FstatMap.logBtSG = FstatMap.get_logBtSG(windowRange)
         logging.debug(f"Also computed: logBtSG={FstatMap.logBtSG:.4f}")
 
     return FstatMap

--- a/pyfstat/tcw_fstat_map_funcs.py
+++ b/pyfstat/tcw_fstat_map_funcs.py
@@ -122,6 +122,40 @@ class pyTransientFstatMap:
         """
         return np.unravel_index(np.argmax(self.F_mn), self.F_mn.shape)
 
+    def get_logBtSG(self, windowRange):
+        """Compute (natural log of the) transient-CW Bayes-factor B_tSG = P(x|HyptS)/P(x|HypG).
+
+        Here HypG = Gaussian noise hypothesis, HyptS = transient-CW signal hypothesis.
+
+        B_tSG is marginalized over start-time and timescale of transient CW signal,
+        using given type and parameters of transient window range.
+
+        NOTE: naive python port of the `lalpulsar.ComputeTransientBstat` implementation.
+        Should be optimised by vectorizing the for loops!
+        """
+        # step through F_mn array subtract maxF and sum e^{F_mn - maxF}
+        # The maximum-likelihood Fmax is globally subtracted from F_mn, and stored separatedly in the struct, because in most
+        # expressions it is numerically more robust to compute e^(F_mn - Fmax), which at worst can underflow, while
+        # e^F_mn can overflow (for F>~700). The constant offset e^Fmax is irrelevant for posteriors (normalization constant), or
+        # can be handled separately, eg by computing log(B) = Fmax + log(sum e^(Fmn-Fmax)) for the Bayes-factor.
+        N_t0Range = self.F_mn.shape[0]
+        N_tauRange = self.F_mn.shape[1]
+        sum_eB = 0
+        for m in range(N_t0Range):
+            for n in range(N_tauRange):
+                DeltaF = (
+                    self.maxF - self.F_mn[m, n]
+                )  # always >= 0, exactly ==0 at {m,n}_max
+                sum_eB += np.exp(-DeltaF)
+        # combine this to final log(Bstat) result with proper normalization (assuming rhohMax=1):
+        logBhat = self.maxF + np.log(sum_eB)  # unnormalized Bhat
+        normBh = 70.0 / (
+            N_t0Range * N_tauRange
+        )  # normalization factor assuming rhohMax=1
+        # final normalized Bayes factor, assuming rhohMax=1 */
+        # NOTE: correct this for different rhohMax by adding "- 4 * log(rhohMax)" to logBtSG
+        return np.log(normBh) + logBhat  # - 4.0 * log ( rhohMax )
+
     def write_F_mn_to_file(self, tCWfile, windowRange, header=[]):
         """Format a 2D transient-F-stat matrix over `(t0,tau)` and write as a text file.
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -165,6 +165,27 @@ class TestComputeFstat(BaseForTestsWithData):
         )
         self.assertTrue(FS > 0.0)
 
+    def test_run_computefstatistic_single_point_context(self):
+        # not using any SFTs
+        # same as above but in "context manager" style
+        with pyfstat.ComputeFstat(
+            tref=self.tref,
+            minStartTime=self.tstart,
+            maxStartTime=self.tstart + self.duration,
+            detectors=self.detectors,
+            injectSqrtSX=self.sqrtSX,
+            minCoverFreq=self.F0 - 0.1,
+            maxCoverFreq=self.F0 + 0.1,
+        ) as search:
+            FS = search.get_fullycoherent_twoF(
+                F0=self.F0,
+                F1=self.F1,
+                F2=self.F2,
+                Alpha=self.Alpha,
+                Delta=self.Delta,
+            )
+        self.assertTrue(FS > 0.0)
+
     def test_run_computefstatistic_single_point_with_SFTs(self):
 
         twoF_predicted = self.Writer.predict_fstat()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -407,6 +407,38 @@ class TestComputeFstat(BaseForTestsWithData):
             log10BSGL == lalpulsar.ComputeBSGL(twoF, twoFX, search_H1L1_BSGL.BSGLSetup)
         )
 
+    def test_transient_detstats(self):
+        search = pyfstat.ComputeFstat(
+            tref=self.tref,
+            minStartTime=self.tstart,
+            maxStartTime=self.tstart + self.duration,
+            detectors="H1,L1",
+            injectSqrtSX=np.repeat(self.sqrtSX, 2),
+            minCoverFreq=self.F0 - 0.1,
+            maxCoverFreq=self.F0 + 0.1,
+            transientWindowType="rect",
+            t0Band=2 * default_Writer_params["Tsft"],
+            tauBand=2 * default_Writer_params["Tsft"],
+            tauMin=2 * default_Writer_params["Tsft"],
+            BSGL=True,
+        )
+        twoF = search.get_fullycoherent_twoF(
+            F0=self.F0,
+            F1=self.F1,
+            F2=self.F2,
+            Alpha=self.Alpha,
+            Delta=self.Delta,
+        )
+        print(f"twoF={twoF}")
+        maxTwoF = search.get_transient_maxTwoFstat()
+        print(f"maxTwoF={maxTwoF}")
+        logBtSG = search.get_transient_logBtSG()
+        print(f"logBtSG={logBtSG}")
+        log10BSGL = search.get_transient_log10BSGL()
+        print(f"twoFXatMaxTwoF={search.twoFXatMaxTwoF}")
+        print(f"log10BSGL={log10BSGL}")
+        # FIXME: add quantitative tests
+
     def test_cumulative_twoF(self):
         Nsft = 100
         # not using any SFTs on disk

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -430,10 +430,9 @@ class TestComputeFstat(BaseForTestsWithData):
             Delta=self.Delta,
         )
         print(f"twoF={twoF}")
-        maxTwoF = search.get_transient_maxTwoFstat()
-        print(f"maxTwoF={maxTwoF}")
-        logBtSG = search.get_transient_logBtSG()
-        print(f"logBtSG={logBtSG}")
+        search.get_transient_detstats(BtSG=True)
+        print(f"maxTwoF={search.maxTwoF}")
+        print(f"logBtSG={search.logBtSG}")
         log10BSGL = search.get_transient_log10BSGL()
         print(f"twoFXatMaxTwoF={search.twoFXatMaxTwoF}")
         print(f"log10BSGL={log10BSGL}")

--- a/tests/test_grid_based_searches.py
+++ b/tests/test_grid_based_searches.py
@@ -277,7 +277,7 @@ class TestTransientGridSearch(BaseForTestsWithData):
     F0s = [29.95, 30.05, 0.01]
     Band = 0.2
 
-    def test_transient_grid_search(self):
+    def test_transient_grid_search(self, BtSG=False):
         search = pyfstat.TransientGridSearch(
             "grid_search",
             self.outdir,
@@ -295,6 +295,7 @@ class TestTransientGridSearch(BaseForTestsWithData):
             tauBand=self.Writer.duration,
             outputTransientFstatMap=True,
             tCWFstatMapVersion="lal",
+            BtSG=BtSG,
         )
         search.run()
         self.assertTrue(os.path.isfile(search.out_file))
@@ -310,3 +311,8 @@ class TestTransientGridSearch(BaseForTestsWithData):
         )
         self.assertTrue(max2F_point["t0"] == tCW_out["t0s"][max2Fidx])
         self.assertTrue(max2F_point["tau"] == tCW_out["taus"][max2Fidx])
+        if BtSG:
+            self.assertTrue(hasattr(search.search, "logBtSG"))
+
+    def test_transient_grid_search_BtSG(self):
+        self.test_transient_grid_search(BtSG=True)


### PR DESCRIPTION
 - more robust for GPU usage in different contexts (pun intended)
   than `__del__()`
 - should not affect standard style
 - add test cases
 - include in example
 - fixes #411

Still in testing.

Edit: to be merged AFTER #414.