### PR TITLE
implement transient BtSG statistic

### DIFF
--- a/examples/transient_examples/PyFstat_example_long_transient_MCMC_search.py
+++ b/examples/transient_examples/PyFstat_example_long_transient_MCMC_search.py
@@ -3,6 +3,12 @@ Long transient MCMC search
 ==========================
 
 MCMC search for a long transient CW signal.
+
+By default, the standard persistent-CW 2F-statistic
+and the transient max2F statistic are compared.
+
+You can turn on either `BSGL = True` or `BtSG = True` (not both!)
+to test alternative statistics.
 """
 import os
 
@@ -66,9 +72,11 @@ nwalkers = 100
 nsteps = [100, 100]
 
 transientWindowType = "rect"
+BSGL = False
+BtSG = False
 
 mcmc = pyfstat.MCMCTransientSearch(
-    label="transient_search",
+    label="transient_search" + ("_BSGL" if BSGL else "") + ("_BtSG" if BtSG else ""),
     outdir=data.outdir,
     sftfilepattern=os.path.join(data.outdir, "*simulated_transient_signal*sft"),
     theta_prior=theta_prior,
@@ -78,6 +86,8 @@ mcmc = pyfstat.MCMCTransientSearch(
     ntemps=ntemps,
     log10beta_min=log10beta_min,
     transientWindowType=transientWindowType,
+    BSGL=BSGL,
+    BtSG=BtSG,
 )
 mcmc.run(walker_plot_args={"plot_det_stat": True, "injection_parameters": inj})
 mcmc.print_summary()

--- a/examples/transient_examples/PyFstat_example_short_transient_grid_search.py
+++ b/examples/transient_examples/PyFstat_example_short_transient_grid_search.py
@@ -3,6 +3,12 @@ Short transient grid search
 ===========================
 
 An example grid-based search for a short transient signal.
+
+By default, the standard persistent-CW 2F-statistic
+and the transient max2F statistic are compared.
+
+You can turn on either `BSGL = True` or `BtSG = True` (not both!)
+to test alternative statistics.
 """
 
 import os
@@ -33,10 +39,11 @@ if __name__ == "__main__":
     Deltas = [data.Delta]
 
     BSGL = False
+    BtSG = False
 
     print("Standard CW search:")
     search1 = pyfstat.GridSearch(
-        label="CW" + ("_BSGL" if BSGL else ""),
+        label="CW" + ("_BSGL" if BSGL else "") + ("_BtSG" if BtSG else ""),
         outdir=data.outdir,
         sftfilepattern=os.path.join(data.outdir, "*simulated_transient_signal*sft"),
         F0s=F0s,
@@ -49,7 +56,9 @@ if __name__ == "__main__":
     )
     search1.run()
     search1.print_max_twoF()
-    search1.plot_1D(xkey="F0", xlabel="freq [Hz]", ylabel="$2\\mathcal{F}$")
+    search1.plot_1D(
+        xkey="F0", xlabel="freq [Hz]", ylabel=search1.tex_labels[search1.detstat]
+    )
 
     print("with t0,tau bands:")
     search2 = pyfstat.TransientGridSearch(
@@ -68,7 +77,10 @@ if __name__ == "__main__":
         outputTransientFstatMap=True,
         tCWFstatMapVersion="lal",
         BSGL=BSGL,
+        BtSG=BtSG,
     )
     search2.run()
     search2.print_max_twoF()
-    search2.plot_1D(xkey="F0", xlabel="freq [Hz]", ylabel="$2\\mathcal{F}$")
+    search2.plot_1D(
+        xkey="F0", xlabel="freq [Hz]", ylabel=search2.tex_labels[search2.detstat]
+    )

--- a/pyfstat/__init__.py
+++ b/pyfstat/__init__.py
@@ -36,6 +36,7 @@ from .mcmc_based_searches import (
     MCMCTransientSearch,
 )
 from .snr import DetectorStates, SignalToNoiseRatio
+from .tcw_fstat_map_funcs import pyTransientFstatMap
 
 __version__ = get_versions()["version"]
 del get_versions

--- a/pyfstat/grid_based_searches.py
+++ b/pyfstat/grid_based_searches.py
@@ -50,7 +50,9 @@ class GridSearch(BaseSearchClass):
         "Alpha": r"$\alpha$",
         "Delta": r"$\delta$",
         "twoF": r"$\widetilde{2\mathcal{F}}$",
-        "log10BSGL": r"$\log_{10}\mathcal{B}_{\mathrm{SGL}}$",
+        "maxTwoF": r"$\max\widetilde{2\mathcal{F}}$",
+        "log10BSGL": r"$\log_{10}\mathcal{B}_{\mathrm{S/GL}}$",
+        "lnBtSG": r"$\ln\mathcal{B}_{\mathrm{tS/G}}$",
     }
     """Formatted labels used for plot annotations."""
 
@@ -876,6 +878,7 @@ class TransientGridSearch(GridSearch):
         minStartTime=None,
         maxStartTime=None,
         BSGL=False,
+        BtSG=False,
         minCoverFreq=None,
         maxCoverFreq=None,
         detectors=None,
@@ -943,8 +946,12 @@ class TransientGridSearch(GridSearch):
         self.search_keys = ["F0", "F1", "F2", "Alpha", "Delta"]
         for k in self.search_keys:
             setattr(self, k, np.atleast_1d(getattr(self, k + "s")))
-        if self.BSGL:
+        if self.BSGL and self.BtSG:  # pragma: no cover
+            raise ValueError("Please choose only one of [BSGL,BtSG].")
+        elif self.BSGL:
             self.detstat = "log10BSGL"
+        elif self.BtSG:
+            self.detstat = "lnBtSG"
         else:
             self.detstat = "maxTwoF"
         self._initiate_search_object()
@@ -993,6 +1000,7 @@ class TransientGridSearch(GridSearch):
             minStartTime=self.minStartTime,
             maxStartTime=self.maxStartTime,
             BSGL=self.BSGL,
+            BtSG=self.BtSG,
             SSBprec=self.SSBprec,
             RngMedWindow=self.RngMedWindow,
             injectSources=self.injectSources,

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -128,6 +128,7 @@ class MCMCSearch(BaseSearchClass):
         rhohatmax=1000,
         binary=False,
         BSGL=False,
+        BtSG=False,
         SSBprec=None,
         RngMedWindow=None,
         minCoverFreq=None,
@@ -183,6 +184,9 @@ class MCMCSearch(BaseSearchClass):
             If true, search over binary orbital parameters.
         BSGL: bool, optional
             If true, use the BSGL statistic.
+        BtSG: bool, optional
+            If true, use the transient lnBtSG statistic.
+            (Only for transient searches.)
         SSBPrec: int, optional
             SSBPrec (SSB precision) to use when calling ComputeFstat. See `core.ComputeFstat`.
         RngMedWindow: int, optional
@@ -226,6 +230,7 @@ class MCMCSearch(BaseSearchClass):
         self.rhohatmax = rhohatmax
         self.binary = binary
         self.BSGL = BSGL
+        self.BtSG = BtSG
         self.SSBprec = SSBprec
         self.RngMedWindow = RngMedWindow
         self.minCoverFreq = minCoverFreq
@@ -3480,6 +3485,7 @@ class MCMCTransientSearch(MCMCSearch):
             minStartTime=self.minStartTime,
             maxStartTime=self.maxStartTime,
             BSGL=self.BSGL,
+            BtSG=self.BtSG,
             binary=self.binary,
             injectSources=self.injectSources,
             tCWFstatMapVersion=self.tCWFstatMapVersion,

--- a/pyfstat/tcw_fstat_map_funcs.py
+++ b/pyfstat/tcw_fstat_map_funcs.py
@@ -15,7 +15,6 @@ import os
 from time import time
 
 import numpy as np
-from scipy.special import logsumexp
 
 
 def _optional_import(modulename, shorthand=None):
@@ -196,26 +195,6 @@ class pyTransientFstatMap:
         # doing the manual version of the same stable summation trick is slightly faster.
         sum_eB = np.sum(np.exp(-(self.maxF - self.F_mn)))
         logBhat = self.maxF + np.log(sum_eB)  # unnormalized Bhat
-        normBh = 70.0 / np.prod(
-            self.F_mn.shape
-        )  # normalization factor assuming rhohMax=1
-        # NOTE: correct this for different rhohMax by adding "- 4 * log(rhohMax)" to lnBtSG
-        self.lnBtSG = np.log(normBh) + logBhat  # - 4.0 * log ( rhohMax )
-        return self.lnBtSG
-
-    def get_lnBtSG_logsumexp(self):
-        """Compute (natural log of the) transient-CW Bayes-factor B_tSG = P(x|HyptS)/P(x|HypG).
-
-        Here HypG = Gaussian noise hypothesis, HyptS = transient-CW signal hypothesis.
-
-        B_tSG is marginalized over start-time and timescale of transient CW signal,
-        using given type and parameters of transient window range.
-
-        This is a python port of the `lalpulsar.ComputeTransientBstat` implementation,
-        replacing for loops by numpy operations.
-        """
-        # step through F_mn array and sum e^{-maxF} via stable "logsumexp" summation
-        logBhat = logsumexp(self.F_mn)
         normBh = 70.0 / np.prod(
             self.F_mn.shape
         )  # normalization factor assuming rhohMax=1

--- a/pyfstat/tcw_fstat_map_funcs.py
+++ b/pyfstat/tcw_fstat_map_funcs.py
@@ -15,6 +15,7 @@ import os
 from time import time
 
 import numpy as np
+from scipy.special import logsumexp
 
 
 def _optional_import(modulename, shorthand=None):
@@ -195,6 +196,26 @@ class pyTransientFstatMap:
         # doing the manual version of the same stable summation trick is slightly faster.
         sum_eB = np.sum(np.exp(-(self.maxF - self.F_mn)))
         logBhat = self.maxF + np.log(sum_eB)  # unnormalized Bhat
+        normBh = 70.0 / np.prod(
+            self.F_mn.shape
+        )  # normalization factor assuming rhohMax=1
+        # NOTE: correct this for different rhohMax by adding "- 4 * log(rhohMax)" to lnBtSG
+        self.lnBtSG = np.log(normBh) + logBhat  # - 4.0 * log ( rhohMax )
+        return self.lnBtSG
+
+    def get_lnBtSG_logsumexp(self):
+        """Compute (natural log of the) transient-CW Bayes-factor B_tSG = P(x|HyptS)/P(x|HypG).
+
+        Here HypG = Gaussian noise hypothesis, HyptS = transient-CW signal hypothesis.
+
+        B_tSG is marginalized over start-time and timescale of transient CW signal,
+        using given type and parameters of transient window range.
+
+        This is a python port of the `lalpulsar.ComputeTransientBstat` implementation,
+        replacing for loops by numpy operations.
+        """
+        # step through F_mn array and sum e^{-maxF} via stable "logsumexp" summation
+        logBhat = logsumexp(self.F_mn)
         normBh = 70.0 / np.prod(
             self.F_mn.shape
         )  # normalization factor assuming rhohMax=1

--- a/tests/test_grid_based_searches.py
+++ b/tests/test_grid_based_searches.py
@@ -277,7 +277,7 @@ class TestTransientGridSearch(BaseForTestsWithData):
     F0s = [29.95, 30.05, 0.01]
     Band = 0.2
 
-    def test_transient_grid_search(self):
+    def test_transient_grid_search(self, BtSG=False):
         search = pyfstat.TransientGridSearch(
             "grid_search",
             self.outdir,
@@ -295,6 +295,7 @@ class TestTransientGridSearch(BaseForTestsWithData):
             tauBand=self.Writer.duration,
             outputTransientFstatMap=True,
             tCWFstatMapVersion="lal",
+            BtSG=BtSG,
         )
         search.run()
         self.assertTrue(os.path.isfile(search.out_file))
@@ -310,3 +311,8 @@ class TestTransientGridSearch(BaseForTestsWithData):
         )
         self.assertTrue(max2F_point["t0"] == tCW_out["t0s"][max2Fidx])
         self.assertTrue(max2F_point["tau"] == tCW_out["taus"][max2Fidx])
+        if BtSG:
+            self.assertTrue(hasattr(search.search, "lnBtSG"))
+
+    def test_transient_grid_search_BtSG(self):
+        self.test_transient_grid_search(BtSG=True)

--- a/tests/test_mcmc_based_searches.py
+++ b/tests/test_mcmc_based_searches.py
@@ -494,7 +494,7 @@ class TestMCMCTransientSearch(BaseForMCMCSearchTests):
         self._check_mcmc_quantiles(transient=True)
         self._test_plots()
 
-    def test_transient_MCMC_t0_tau(self):
+    def test_transient_MCMC_t0_tau(self, BtSG=False):
 
         theta = {
             **self.basic_theta,
@@ -517,9 +517,13 @@ class TestMCMCTransientSearch(BaseForMCMCSearchTests):
             sftfilepattern=self.Writer.sftfilepath,
             **self.MCMC_params,
             transientWindowType=self.transientWindowType,
+            BtSG=BtSG,
         )
         self.search.run(plot_walkers=False)
         self.search.print_summary()
         self._check_twoF_predicted()
         self._check_mcmc_quantiles(transient=True)
         self._test_plots()
+
+    def test_transient_MCMC_t0_tau_BtSG(self, BtSG=False):
+        self.test_transient_MCMC_t0_tau(BtSG=True)


### PR DESCRIPTION
- implemented in `ComputeFstat` and `TransientGridSearch` classes
- based on [XLALComputeTransientBstat](https://lscsoft.docs.ligo.org/lalsuite/lalpulsar/group___transient_c_w__utils__h.html#gaf66cf2ffa017a6b1dffd266139b52fad) and Prix, Giampanis & Messenger 2011
- introduces a `ComputeFstat.get_transient_detstats()` method and makes `get_transient_detstats.get_transient_maxTwoFstat()` a legacy wrapper around it
- refs #260

Currently with `tCWFstatMapVersion="lal"`, the original lalpulsar function is called for BtSG as well. With `tCWFstatMapVersion="pycuda"`, the python version of BtSG is called after the pycuda computation of the FstatMap. A naive python port of that function (with double for loop) was very slow (BtSG took up to factor 10 longer than FstatMap), but a simple change to `np.sum()` was enough to make the extra cost negligible, and so it seems porting BtSG to cuda is not necessary.

TODO:

- [x] add to `TransientMCMCSearch`
- [x] add meaningful quantitative tests
- [x] fix pipeline
- [x] squash