### PR TITLE
fix pycuda detaching with weakref and contex manager

### DIFF
--- a/examples/transient_examples/PyFstat_example_short_transient_grid_search.py
+++ b/examples/transient_examples/PyFstat_example_short_transient_grid_search.py
@@ -3,12 +3,15 @@ Short transient grid search
 ===========================
 
 An example grid-based search for a short transient signal.
-
 By default, the standard persistent-CW 2F-statistic
 and the transient max2F statistic are compared.
 
 You can turn on either `BSGL = True` or `BtSG = True` (not both!)
 to test alternative statistics.
+
+This is also ready to use on a GPU,
+if you have one available and `pycuda` installed.
+Just change to `tCWFstatMapVersion = "pycuda"`.
 """
 
 import os
@@ -17,6 +20,8 @@ import numpy as np
 import PyFstat_example_make_data_for_short_transient_search as data
 
 import pyfstat
+
+tCWFstatMapVersion = "lal"
 
 if __name__ == "__main__":
 
@@ -43,7 +48,7 @@ if __name__ == "__main__":
 
     print("Standard CW search:")
     search1 = pyfstat.GridSearch(
-        label="CW" + ("_BSGL" if BSGL else "") + ("_BtSG" if BtSG else ""),
+        label=f"CW{'_BSGL' if BSGL else ''}",
         outdir=data.outdir,
         sftfilepattern=os.path.join(data.outdir, "*simulated_transient_signal*sft"),
         F0s=F0s,
@@ -61,8 +66,9 @@ if __name__ == "__main__":
     )
 
     print("with t0,tau bands:")
+    label = f"tCW{'_BSGL' if BSGL else ''}{'_BtSG' if BtSG else ''}_FstatMap_{tCWFstatMapVersion}"
     search2 = pyfstat.TransientGridSearch(
-        label="tCW" + ("_BSGL" if BSGL else ""),
+        label=label,
         outdir=data.outdir,
         sftfilepattern=os.path.join(data.outdir, "*simulated_transient_signal*sft"),
         F0s=F0s,
@@ -75,7 +81,7 @@ if __name__ == "__main__":
         t0Band=data.duration - 2 * data.Tsft,
         tauBand=data.duration,
         outputTransientFstatMap=True,
-        tCWFstatMapVersion="lal",
+        tCWFstatMapVersion=tCWFstatMapVersion,
         BSGL=BSGL,
         BtSG=BtSG,
     )

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -426,11 +426,20 @@ class ComputeFstat(BaseSearchClass):
         self.allowedMismatchFromSFTLength = allowedMismatchFromSFTLength
 
     def _setup_finalizer(self):
+        """
+        Setup for proper cleanup at end of context in pycuda case.
+
+        Users should normally *not* have to call self._finalizer() manually:
+        the `finalize` call is enough to set up python garbage collection,
+        and we only store it as an attribute for debugging/testing purposes.
+        """
         if "cuda" in self.tCWFstatMapVersion:
             logging.debug(
                 f"Setting up GPU context finalizer for {self.tCWFstatMapVersion} transient maps."
             )
-            finalize(self, self._finalize_gpu_context)
+            self._finalizer = finalize(self, self._finalize_gpu_context)
+        else:
+            self._finalizer = None
 
     def _finalize_gpu_context(self):
         """Clean up at the end of context manager style usage."""

--- a/pyfstat/grid_based_searches.py
+++ b/pyfstat/grid_based_searches.py
@@ -1148,10 +1148,6 @@ class TransientGridSearch(GridSearch):
         fmt_dict["tau"] = "%d"
         return fmt_dict
 
-    def __del__(self):
-        if hasattr(self, "search"):
-            self.search.__del__()
-
 
 class SliceGridSearch(DefunctClass):
     last_supported_version = "1.9.0"

--- a/pyfstat/tcw_fstat_map_funcs.py
+++ b/pyfstat/tcw_fstat_map_funcs.py
@@ -248,6 +248,22 @@ being available.
 """
 
 
+def _optional_imports_pycuda():
+    """Helper function to check for all all modules we need."""
+    have_pycuda = _optional_import("pycuda")
+    have_pycuda_drv = _optional_import("pycuda.driver", "drv")
+    have_pycuda_gpuarray = _optional_import("pycuda.gpuarray", "gpuarray")
+    have_pycuda_tools = _optional_import("pycuda.tools", "cudatools")
+    have_pycuda_compiler = _optional_import("pycuda.compiler", "cudacomp")
+    return (
+        have_pycuda
+        and have_pycuda_drv
+        and have_pycuda_gpuarray
+        and have_pycuda_tools
+        and have_pycuda_compiler
+    )
+
+
 def init_transient_fstat_map_features(feature="lal", cudaDeviceName=None):
     """Initialization of available modules (or 'features') for computing transient F-stat maps.
 
@@ -279,25 +295,10 @@ def init_transient_fstat_map_features(feature="lal", cudaDeviceName=None):
     """
 
     features = {}
-
     have_lal = _optional_import("lal")
     have_lalpulsar = _optional_import("lalpulsar")
     features["lal"] = have_lal and have_lalpulsar
-
-    # import GPU features
-    have_pycuda = _optional_import("pycuda")
-    have_pycuda_drv = _optional_import("pycuda.driver", "drv")
-    have_pycuda_gpuarray = _optional_import("pycuda.gpuarray", "gpuarray")
-    have_pycuda_tools = _optional_import("pycuda.tools", "cudatools")
-    have_pycuda_compiler = _optional_import("pycuda.compiler", "cudacomp")
-    features["pycuda"] = (
-        have_pycuda
-        and have_pycuda_drv
-        and have_pycuda_gpuarray
-        and have_pycuda_tools
-        and have_pycuda_compiler
-    )
-
+    features["pycuda"] = _optional_imports_pycuda()
     logging.debug("Got the following features for transient F-stat maps:")
     logging.debug(features)
 


### PR DESCRIPTION
Changes in #413 , although very useful, introduce a completely different coding style depending on which arguments are being given into a function.

This PR solves that by substituting `weakref.finalize` by context managers.

Must be merged after #413