### PR TITLE
replace lalapps_tconvert with new helper function

### DIFF
--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -511,16 +511,11 @@ class ComputeFstat(BaseSearchClass):
             except ImportError:
                 pass
 
-        cl_tconv1 = "lalapps_tconvert {}".format(int(SFT_timestamps[0]))
-        output = helper_functions.run_commandline(cl_tconv1, log_level=logging.DEBUG)
-        tconvert1 = output.rstrip("\n")
-        cl_tconv2 = "lalapps_tconvert {}".format(int(SFT_timestamps[-1]))
-        output = helper_functions.run_commandline(cl_tconv2, log_level=logging.DEBUG)
-        tconvert2 = output.rstrip("\n")
+        dtstr1 = helper_functions.gps_to_datestr_utc(int(SFT_timestamps[0]))
+        dtstr2 = helper_functions.gps_to_datestr_utc(int(SFT_timestamps[-1]))
         logging.info(
-            "Data contains SFT timestamps from {} ({}) to (including) {} ({})".format(
-                int(SFT_timestamps[0]), tconvert1, int(SFT_timestamps[-1]), tconvert2
-            )
+            f"Data contains SFT timestamps from {SFT_timestamps[0]} ({dtstr1})"
+            f" to (including) {SFT_timestamps[-1]} ({dtstr2})."
         )
 
         if self.minStartTime is None:

--- a/pyfstat/helper_functions.py
+++ b/pyfstat/helper_functions.py
@@ -13,6 +13,7 @@ import os
 import shutil
 import subprocess
 import sys
+from datetime import datetime, timezone
 from functools import wraps
 
 import lal
@@ -1242,3 +1243,37 @@ def generate_loudest_file(
 
     run_commandline(cmd, return_output=False)
     return loudest_file
+
+
+def gps_to_datestr_utc(gps):
+    """Convert an integer count of GPS seconds to a UTC date-time string.
+
+    This uses the locale's default string formatting as per `datetime.strftime()`.
+    It is intended just for informing the user and may not be as reliable
+    in all situations as `lal[apps]_tconvert`.
+    If you want to do any postprocessing of the date-time string,
+    for safety you should probably call that commandline tool.
+
+    Parameters
+    -------
+    gps: int
+        Integer seconds since GPS seconds.
+
+    Returns
+    -------
+    dtstr: str
+        A string representation of date-time in UTC and locale format.
+
+    """
+    utc = lal.GPSToUTC(gps)
+    dt = datetime(
+        year=utc[0],
+        month=utc[1],
+        day=utc[2],
+        hour=utc[3],
+        minute=utc[4],
+        second=utc[5],
+        microsecond=0,
+        tzinfo=timezone.utc,
+    )
+    return dt.strftime("%c %Z")

--- a/tests/test_helper_functions.py
+++ b/tests/test_helper_functions.py
@@ -1,0 +1,12 @@
+import pyfstat
+
+
+def test_gps_to_datestr_utc():
+
+    gps = 1000000000
+    # reference from lalapps_tconvert on en_US.UTF-8 locale
+    # but instead from the "GMT" bit it places in the middle,
+    # we put the timezone info at the end via datetime.strftime()
+    old_str = "Wed Sep 14 01:46:25 GMT 2011"
+    new_str = pyfstat.helper_functions.gps_to_datestr_utc(gps)
+    assert new_str.rstrip(" UTC") == old_str.replace(" GMT ", " ")


### PR DESCRIPTION
See #417 - we actually only used the tool for a single logging output of SFT timestamps, so why not replace it with a pure python/swig solution. As a lal/datetime hybrid, I wouldn't bet though on it being as locale and leap-second robust as the executable solution (which does some custom stuff on a long and winding gps->utc->unix->utc road), so I slapped a notice on the helper function documentation not to trust it for anything beyond simple info output.

- also add test module,
   since so far helper functions were all
   just tested implicitly from via modules