### PR TITLE
lalapps->lalpulsar migration with compatibility helper function

### DIFF
--- a/pyfstat/grid_based_searches.py
+++ b/pyfstat/grid_based_searches.py
@@ -783,7 +783,7 @@ class GridSearch(BaseSearchClass):
             print("  {}={}".format(k, v))
 
     def generate_loudest(self):
-        """Use lalapps_ComputeFstatistic_v2 to produce a .loudest file"""
+        """Use ComputeFstatistic_v2 executable to produce a .loudest file"""
         max_params = self.get_max_twoF()
         max_params.pop("twoF")
         max_params = self.translate_keys_to_lal(max_params)

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -652,8 +652,11 @@ class Writer(BaseSearchClass):
             if not helper_functions.match_commandlines(cl_old, cl_mfd):
                 logging.info(
                     "......commandlines unmatched for first SFT in old"
-                    " file '{}'. {}".format(sftfile, need_new)
+                    " file '{}':".format(sftfile)
                 )
+                logging.info(cl_old)
+                logging.info(cl_mfd)
+                logging.info(need_new)
                 return False
         logging.info("......OK: Commandline matched with old SFT header(s).")
         logging.info(

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -2111,7 +2111,7 @@ class MCMCSearch(BaseSearchClass):
                     f.write("{} = {:1.16e}\n".format(key, val))
 
     def generate_loudest(self):
-        """Use lalapps_ComputeFstatistic_v2 to produce a .loudest file"""
+        """Use ComputeFstatistic_v2 executable to produce a .loudest file"""
         max_params, max_twoF = self.get_max_twoF()
         for key in self.theta_prior:
             if key not in max_params:

--- a/pyfstat/snr.py
+++ b/pyfstat/snr.py
@@ -99,7 +99,7 @@ class SignalToNoiseRatio:
             Defaults to LALSuite's default of using the central time of an STF (SFT's timestamp + Tsft/2).
         running_median_window: int
             Window used to compute the running-median noise floor estimation.
-            Default value is consistent with that used in lalapps_PredictFstat.
+            Default value is consistent with that used in PredictFstat executable.
         sft_constraint: lalpulsar.SFTConstraint
             Optional argument to specify further constraints in XLALSFTdataFind.
         """

--- a/tests/test_grid_based_searches.py
+++ b/tests/test_grid_based_searches.py
@@ -102,7 +102,7 @@ class TestGridSearch(BaseForTestsWithData):
         CFSv2_out_file = os.path.join(self.outdir, "CFSv2_Fstat_out.txt")
         CFSv2_loudest_file = os.path.join(self.outdir, "CFSv2_Fstat_loudest.txt")
         cl_CFSv2 = []
-        cl_CFSv2.append("lalapps_ComputeFstatistic_v2")
+        cl_CFSv2.append(pyfstat.helper_functions.get_lal_exec("ComputeFstatistic_v2"))
         cl_CFSv2.append("--Alpha {} --AlphaBand 0".format(self.Alpha))
         cl_CFSv2.append("--Delta {} --DeltaBand 0".format(self.Delta))
         cl_CFSv2.append("--Freq {}".format(self.F0s[0]))
@@ -114,7 +114,7 @@ class TestGridSearch(BaseForTestsWithData):
         cl_CFSv2.append("--outputFstat " + CFSv2_out_file)
         cl_CFSv2.append("--outputLoudest " + CFSv2_loudest_file)
         # to match ComputeFstat default (and hence PyFstat) defaults on older
-        # lalapps_CFSv2 versions, set the RngMedWindow manually:
+        # CFSv2 versions, set the RngMedWindow manually:
         cl_CFSv2.append("--RngMedWindow=101")
         cl_CFSv2 = " ".join(cl_CFSv2)
         pyfstat.helper_functions.run_commandline(cl_CFSv2)

--- a/tests/test_helper_functions.py
+++ b/tests/test_helper_functions.py
@@ -4,7 +4,7 @@ import pyfstat
 def test_gps_to_datestr_utc():
 
     gps = 1000000000
-    # reference from lalapps_tconvert on en_US.UTF-8 locale
+    # reference from lal_tconvert on en_US.UTF-8 locale
     # but instead from the "GMT" bit it places in the middle,
     # we put the timezone info at the end via datetime.strftime()
     old_str = "Wed Sep 14 01:46:25 GMT 2011"

--- a/tests/test_make_sfts.py
+++ b/tests/test_make_sfts.py
@@ -307,7 +307,8 @@ class TestWriter(BaseForTestsWithData):
         )
         writer.make_data(verbose=True)
         # split them by frequency
-        cl_split = "lalapps_splitSFTs --frequency-bandwidth 1"
+        cl_split = pyfstat.helper_functions.get_lal_exec("splitSFTs")
+        cl_split += " --frequency-bandwidth 1"
         cl_split += f" --start-frequency {writer.fmin}"
         cl_split += f" --end-frequency {writer.fmin+writer.Band}"
         cl_split += f" --output-directory {self.outdir}"


### PR DESCRIPTION
fixes #425 and makes progress on #417 by adding a transitional helper function `get_lal_exec()` for dynamically selecting `lalpulsar_` if available and falling back to `lalapps_` else.