### PR TITLE
Deprecate old MCMCFollowUpSearch and optimal setup functions

### DIFF
--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -2938,7 +2938,7 @@ class MCMCSemiCoherentSearch(MCMCSearch):
         return np.sum(H)
 
 
-class MCMCFollowUpSearch(MCMCSemiCoherentSearch):
+class MCMCFollowUpSearch(MCMCSemiCoherentSearch, core.DeprecatedClass):
     """Hierarchical follow-up procedure
 
     Executes MCMC runs with increasing coherence times in order to follow up a parameter space


### PR DESCRIPTION
First step towards #333 : Make sure there's no confusion and things are not wrongly used by mistake.

- closes #431