### PR TITLE
test examples with --clean

### DIFF
--- a/examples/run_all_examples.py
+++ b/examples/run_all_examples.py
@@ -49,7 +49,7 @@ for case in os.listdir(basedir):
         print(f"Executing {len(scripts)} script(s) in example directory {exdir}...")
         for script in scripts:
             Nscripts += 1
-            cl = "python " + script
+            cl = "python " + script + " --clean"
             print(f"Running: {script}")
             try:
                 run_commandline(cl, return_output=False)


### PR DESCRIPTION
While we still have the global `--clean` option, let me use the opportunity to run the all-examples action and see where it fails: https://github.com/PyFstat/PyFstat/actions/runs/2912512784

(I already know it's broken for at least some grid classes)