### PR TITLE
finish lalapps->lalpulsar migration

### DIFF
--- a/etc/pyfstat-dev.yml
+++ b/etc/pyfstat-dev.yml
@@ -15,8 +15,8 @@ dependencies:
   - peakutils
   - pathos
   - python-lal >=7.1.5
-  - python-lalpulsar >=3.1.1
-  - lalapps >=7.4.0
+  - python-lalpulsar >=5.0.0
+  - lalpulsar >=5.0.0
   - pip
   - pip:
     - -e ../[dev]

--- a/pyfstat/helper_functions.py
+++ b/pyfstat/helper_functions.py
@@ -980,7 +980,7 @@ def predict_fstat(
     Parameters
     ----------
     h0, cosi, psi, Alpha, Delta : float
-        Signal parameters, see `lalapps_PredictFstat --help` for more info.
+        Signal parameters, see `lalpulsar_PredictFstat --help` for more info.
     F0: float or None
         Signal frequency.
         Only needed for noise floor estimation when given `sftfilepattern`
@@ -1015,11 +1015,11 @@ def predict_fstat(
         Ephemerides files, defaults will be used if `None`.
     transientWindowType: str
         Optional parameter for transient signals,
-        see `lalapps_PredictFstat --help`.
+        see `lalpulsar_PredictFstat --help`.
         Default of `none` means a classical Continuous Wave signal.
     transientStartTime, transientTau: int or None
         Optional parameters for transient signals,
-        see `lalapps_PredictFstat --help`.
+        see `lalpulsar_PredictFstat --help`.
 
     Returns
     -------

--- a/pyfstat/helper_functions.py
+++ b/pyfstat/helper_functions.py
@@ -692,6 +692,10 @@ def get_commandline_from_SFTDescriptor(descriptor):
     Most LALSuite SFT creation tools save their commandline into that entry,
     so we can extract it and reuse it to reproduce that data.
 
+    Since lalapps 9.0.0 / lalpulsar 5.0.0
+    the relevant executables have been moved to lalpulsar,
+    but we allow for lalapps backwards compatibility here,
+
     Parameters
     ----------
     descriptor: SFTDescriptor
@@ -1230,9 +1234,11 @@ def gps_to_datestr_utc(gps):
 def get_lal_exec(cmd):
     """Get a lalpulsar/lalapps executable name with the right prefix.
 
-    This is purely to allow for backwards compatibility while
-    https://git.ligo.org/lscsoft/lalsuite/-/merge_requests/1904/
-    has been merged to LALSuite master but not yet released.
+    This is purely to allow for backwards compatibility
+    if, for whatever reason,
+    someone needs to run with old releases
+    (lalapps<9.0.0 and lalpulsar<5.0.0)
+    from before the executables were moved.
 
     Parameters
     -------

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -29,7 +29,7 @@ class Writer(BaseSearchClass):
 
     This class currently relies on the `Makefakedata_v5` executable
     which will be run in a subprocess.
-    See `lalapps_Makefakedata_v5 --help`
+    See `lalpulsar_Makefakedata_v5 --help`
     for more detailed help with some of the parameters.
     """
 
@@ -1308,7 +1308,7 @@ class FrequencyModulatedArtifactWriter(Writer):
 
     Contrary to the main `Writer` class, this calls the older
     `Makefakedata_v4` executable which supports the special `--lineFeature` option.
-    See `lalapps_Makefakedata_v4 --help`
+    See `lalpulsar_Makefakedata_v4 --help`
     for more detailed help with some of the parameters.
     """
 


### PR DESCRIPTION
- [x]  pyfstat-dev,yml: require lalpulsar instead of lalapps, now that 5.0.0 with the actual executables is out
- [x] remove remaining lalapps references from comments
- [x] but keeping `get_lal_exec()` and `get_commandline_from_SFTDescriptor()` backwards compatible

- refs #417