### PR TITLE
logging fallback config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *swp
 docs/build/
 docs/source/*_example*/
+*tutorials*

--- a/examples/binary_examples/PyFstat_example_binary_mcmc_vs_grid_comparison.py
+++ b/examples/binary_examples/PyFstat_example_binary_mcmc_vs_grid_comparison.py
@@ -21,6 +21,7 @@ label = "PyFstat_example_binary_mcmc_vs_grid_comparison" + (
     "_circular_orbit" if circular_orbit else ""
 )
 outdir = os.path.join("PyFstat_example_data", label)
+logger = pyfstat.set_up_logger(label=label, outdir=outdir)
 
 # Parameters to generate a data set
 data_parameters = {

--- a/examples/binary_examples/PyFstat_example_binary_mcmc_vs_grid_comparison.py
+++ b/examples/binary_examples/PyFstat_example_binary_mcmc_vs_grid_comparison.py
@@ -54,7 +54,7 @@ signal_parameters = {
 }
 
 
-print("Generating SFTs with injected signal...")
+logger.info("Generating SFTs with injected signal...")
 writer = pyfstat.BinaryModulatedWriter(
     label="simulated_signal",
     outdir=outdir,
@@ -62,9 +62,9 @@ writer = pyfstat.BinaryModulatedWriter(
     **signal_parameters,
 )
 writer.make_data()
-print("")
+logger.info("")
 
-print("Performing Grid Search...")
+logger.info("Performing Grid Search...")
 
 # Create ad-hoc grid and compute Fstatistic around injection point
 # There's no class supporting a binary search in the same way as
@@ -117,9 +117,9 @@ for ind in range(grid_points.shape[0]):
         argp=point[3],
         ecc=point[4],
     )
-print(f"2Fstat computed on {grid_points.shape[0]} points")
-print("")
-print("Plotting results...")
+logger.info(f"2Fstat computed on {grid_points.shape[0]} points")
+logger.info("")
+logger.info("Plotting results...")
 dim = len(search_keys)
 fig, ax = plt.subplots(dim, 1, figsize=(10, 10))
 for ind in range(dim):
@@ -132,7 +132,7 @@ plt.tight_layout()
 fig.savefig(os.path.join(outdir, "grid_twoF_per_dimension.png"))
 
 
-print("Performing MCMCSearch...")
+logger.info("Performing MCMCSearch...")
 # Fixed points in frequency and sky parameters
 theta_prior = {
     "F0": signal_parameters["F0"],
@@ -185,15 +185,15 @@ mcmcsearch.print_summary()
 
 # call some built-in plotting methods
 # these can all highlight the injection parameters, too
-print("Making MCMCSearch {:s} corner plot...".format("-".join(search_keys)))
+logger.info("Making MCMCSearch {:s} corner plot...".format("-".join(search_keys)))
 mcmcsearch.plot_corner(truths=signal_parameters)
-print("Making MCMCSearch prior-posterior comparison plot...")
+logger.info("Making MCMCSearch prior-posterior comparison plot...")
 mcmcsearch.plot_prior_posterior(injection_parameters=signal_parameters)
-print("")
+logger.info("")
 
-print("*" * 20)
-print("Quantitative comparisons:")
-print("*" * 20)
+logger.info("*" * 20)
+logger.info("Quantitative comparisons:")
+logger.info("*" * 20)
 
 # some informative command-line output comparing search results and injection
 # get max twoF and binary Doppler parameters
@@ -203,7 +203,7 @@ max_grid_parameters = grid_points[max_grid_index]
 
 # same for MCMCSearch, here twoF is separate, and non-sampled parameters are not included either
 max_dict_mcmc, max_2F_mcmc = mcmcsearch.get_max_twoF()
-print(
+logger.info(
     "Grid Search:\n\tmax2F={:.4f}\n\tOffsets from injection parameters (relative error): {:s}.".format(
         max_grid_2F,
         ", ".join(
@@ -224,7 +224,7 @@ print(
         ),
     )
 )
-print(
+logger.info(
     "Max 2F candidate from MCMC Search:\n\tmax2F={:.4f}"
     "\n\tOffsets from injection parameters (relative error): {:s}.".format(
         max_2F_mcmc,
@@ -244,7 +244,7 @@ print(
 )
 # get additional point and interval estimators
 stats_dict_mcmc = mcmcsearch.get_summary_stats()
-print(
+logger.info(
     "Mean from MCMCSearch:\n\tOffset from injection parameters (relative error): {:s}"
     "\n\tExpressed as fractions of 2sigma intervals: {:s}.".format(
         ", ".join(
@@ -272,7 +272,7 @@ print(
         ),
     )
 )
-print(
+logger.info(
     "Median from MCMCSearch:\n\tOffset from injection parameters (relative error): {:s},"
     "\n\tExpressed as fractions of 90% confidence intervals: {:s}.".format(
         ", ".join(

--- a/examples/binary_examples/PyFstat_example_semi_coherent_binary_search_using_MCMC.py
+++ b/examples/binary_examples/PyFstat_example_semi_coherent_binary_search_using_MCMC.py
@@ -19,6 +19,7 @@ known_eccentricity = True
 
 label = "PyFstat_example_semi_coherent_binary_search_using_MCMC"
 outdir = os.path.join("PyFstat_example_data", label)
+logger = pyfstat.set_up_logger(label=label, outdir=outdir)
 
 # Properties of the GW data
 data_parameters = {

--- a/examples/followup_examples/PyFstat_example_semi_coherent_directed_follow_up.py
+++ b/examples/followup_examples/PyFstat_example_semi_coherent_directed_follow_up.py
@@ -46,7 +46,7 @@ data.make_data()
 
 # The predicted twoF, given by lalapps_predictFstat can be accessed by
 twoF = data.predict_fstat()
-print("Predicted twoF value: {}\n".format(twoF))
+logger.info("Predicted twoF value: {}\n".format(twoF))
 
 # Search
 VF0 = VF1 = 1e5

--- a/examples/followup_examples/PyFstat_example_semi_coherent_directed_follow_up.py
+++ b/examples/followup_examples/PyFstat_example_semi_coherent_directed_follow_up.py
@@ -14,6 +14,7 @@ import pyfstat
 
 label = "PyFstat_example_semi_coherent_directed_follow_up"
 outdir = os.path.join("PyFstat_example_data", label)
+logger = pyfstat.set_up_logger(label=label, outdir=outdir)
 
 # Properties of the GW data
 data_parameters = {

--- a/examples/glitch_examples/PyFstat_example_glitch_robust_directed_MCMC_search_on_1_glitch.py
+++ b/examples/glitch_examples/PyFstat_example_glitch_robust_directed_MCMC_search_on_1_glitch.py
@@ -90,7 +90,7 @@ mcmc.run(save_loudest=False)  # uses CFSv2 which doesn't support glitch paramete
 dT = time.time() - t1
 mcmc.print_summary()
 
-print("Making corner plot...")
+logger.info("Making corner plot...")
 mcmc.plot_corner(
     label_offset=0.25,
     truths={"F0": F0, "F1": F1, "delta_F0": delta_F0, "tglitch": tstart + dtglitch},
@@ -101,5 +101,5 @@ mcmc.plot_corner(
 
 mcmc.plot_cumulative_max(savefig=True)
 
-print(("Prior widths =", F0_width, F1_width))
-print(("Actual run time = {}".format(dT)))
+logger.info(("Prior widths =", F0_width, F1_width))
+logger.info(("Actual run time = {}".format(dT)))

--- a/examples/glitch_examples/PyFstat_example_glitch_robust_directed_MCMC_search_on_1_glitch.py
+++ b/examples/glitch_examples/PyFstat_example_glitch_robust_directed_MCMC_search_on_1_glitch.py
@@ -28,6 +28,7 @@ from PyFstat_example_make_data_for_search_on_1_glitch import (
 import pyfstat
 
 label = "PyFstat_example_glitch_robust_directed_MCMC_search_on_1_glitch"
+logger = pyfstat.set_up_logger(label=label, outdir=outdir)
 
 Nstar = 1000
 F0_width = np.sqrt(Nstar) * np.sqrt(12) / (np.pi * duration)

--- a/examples/glitch_examples/PyFstat_example_glitch_robust_directed_grid_search_on_1_glitch.py
+++ b/examples/glitch_examples/PyFstat_example_glitch_robust_directed_grid_search_on_1_glitch.py
@@ -72,7 +72,7 @@ delta_F0s_vals = np.unique(search.data["delta_F0"]) - delta_F0
 tglitch_vals = np.unique(search.data["tglitch"])
 tglitch_vals_days = (tglitch_vals - tstart) / 86400.0 - dtglitch / 86400.0
 
-print("Making gridcorner plot...")
+logger.info("Making gridcorner plot...")
 twoF = search.data["twoF"].reshape(
     (len(F0_vals), len(F1_vals), len(delta_F0s_vals), len(tglitch_vals))
 )
@@ -98,6 +98,6 @@ fig, axes = pyfstat.gridcorner(
 fig.savefig("{}/{}_projection_matrix.png".format(outdir, label), bbox_inches="tight")
 
 
-print(("Prior widths =", F0_width, F1_width))
-print(("Actual run time = {}".format(dT)))
-print(("Actual number of grid points = {}".format(search.data.shape[0])))
+logger.info(("Prior widths =", F0_width, F1_width))
+logger.info(("Actual run time = {}".format(dT)))
+logger.info(("Actual number of grid points = {}".format(search.data.shape[0])))

--- a/examples/glitch_examples/PyFstat_example_glitch_robust_directed_grid_search_on_1_glitch.py
+++ b/examples/glitch_examples/PyFstat_example_glitch_robust_directed_grid_search_on_1_glitch.py
@@ -28,6 +28,7 @@ from PyFstat_example_make_data_for_search_on_1_glitch import (
 import pyfstat
 
 label = "PyFstat_example_glitch_robust_directed_grid_search_on_1_glitch"
+logger = pyfstat.set_up_logger(label=label, outdir=outdir)
 
 Nstar = 1000
 F0_width = np.sqrt(Nstar) * np.sqrt(12) / (np.pi * duration)

--- a/examples/glitch_examples/PyFstat_example_standard_directed_MCMC_search_on_1_glitch.py
+++ b/examples/glitch_examples/PyFstat_example_standard_directed_MCMC_search_on_1_glitch.py
@@ -25,6 +25,7 @@ from PyFstat_example_make_data_for_search_on_1_glitch import (
 import pyfstat
 
 label = "PyFstat_example_standard_directed_MCMC_search_on_1_glitch"
+logger = pyfstat.set_up_logger(label=label, outdir=outdir)
 
 Nstar = 10000
 F0_width = np.sqrt(Nstar) * np.sqrt(12) / (np.pi * duration)

--- a/examples/grid_examples/PyFstat_example_grid_search_F0.py
+++ b/examples/grid_examples/PyFstat_example_grid_search_F0.py
@@ -75,7 +75,7 @@ search.run()
 
 # report details of the maximum point
 max_dict = search.get_max_twoF()
-print(
+logger.info(
     "max2F={:.4f} from GridSearch, offsets from injection: {:s}.".format(
         max_dict["twoF"],
         ", ".join(
@@ -89,7 +89,7 @@ print(
 )
 search.generate_loudest()
 
-print("Plotting 2F(F0)...")
+logger.info("Plotting 2F(F0)...")
 fig, ax = plt.subplots()
 frequencies = search.data["F0"]
 twoF = search.data["twoF"]

--- a/examples/grid_examples/PyFstat_example_grid_search_F0.py
+++ b/examples/grid_examples/PyFstat_example_grid_search_F0.py
@@ -5,6 +5,7 @@ Directed grid search: Monochromatic source
 Search for a monochromatic (no spindown) signal using
 a parameter space grid (i.e. no MCMC).
 """
+import logging
 import os
 
 import matplotlib.pyplot as plt
@@ -12,9 +13,13 @@ import numpy as np
 
 import pyfstat
 
+# custom logging config needs to come before import
+# logging.basicConfig(level=logging.INFO, filename="log.log")
+
+
 label = "PyFstat_example_grid_search_F0"
 outdir = os.path.join("PyFstat_example_data", label)
-logger = pyfstat.set_up_logger(label=label, outdir=outdir)
+# logger = pyfstat.set_up_logger(label=label, outdir=outdir)
 
 # Properties of the GW data
 sqrtS = "1e-23"
@@ -75,7 +80,7 @@ search.run()
 
 # report details of the maximum point
 max_dict = search.get_max_twoF()
-logger.info(
+logging.info(
     "max2F={:.4f} from GridSearch, offsets from injection: {:s}.".format(
         max_dict["twoF"],
         ", ".join(
@@ -89,7 +94,7 @@ logger.info(
 )
 search.generate_loudest()
 
-logger.info("Plotting 2F(F0)...")
+logging.info("Plotting 2F(F0)...")
 fig, ax = plt.subplots()
 frequencies = search.data["F0"]
 twoF = search.data["twoF"]

--- a/examples/grid_examples/PyFstat_example_grid_search_F0.py
+++ b/examples/grid_examples/PyFstat_example_grid_search_F0.py
@@ -14,6 +14,7 @@ import pyfstat
 
 label = "PyFstat_example_grid_search_F0"
 outdir = os.path.join("PyFstat_example_data", label)
+logger = pyfstat.set_up_logger(label=label, outdir=outdir)
 
 # Properties of the GW data
 sqrtS = "1e-23"

--- a/examples/grid_examples/PyFstat_example_grid_search_F0F1.py
+++ b/examples/grid_examples/PyFstat_example_grid_search_F0F1.py
@@ -76,7 +76,7 @@ search.run()
 
 # report details of the maximum point
 max_dict = search.get_max_twoF()
-print(
+logger.info(
     "max2F={:.4f} from GridSearch, offsets from injection: {:s}.".format(
         max_dict["twoF"],
         ", ".join(
@@ -90,14 +90,14 @@ print(
 )
 search.generate_loudest()
 
-print("Plotting 2F(F0)...")
+logger.info("Plotting 2F(F0)...")
 search.plot_1D(xkey="F0", xlabel="freq [Hz]", ylabel="$2\\mathcal{F}$")
-print("Plotting 2F(F1)...")
+logger.info("Plotting 2F(F1)...")
 search.plot_1D(xkey="F1")
-print("Plotting 2F(F0,F1)...")
+logger.info("Plotting 2F(F0,F1)...")
 search.plot_2D(xkey="F0", ykey="F1", colorbar=True)
 
-print("Making gridcorner plot...")
+logger.info("Making gridcorner plot...")
 F0_vals = np.unique(search.data["F0"]) - inj["F0"]
 F1_vals = np.unique(search.data["F1"]) - inj["F1"]
 twoF = search.data["twoF"].reshape((len(F0_vals), len(F1_vals)))

--- a/examples/grid_examples/PyFstat_example_grid_search_F0F1.py
+++ b/examples/grid_examples/PyFstat_example_grid_search_F0F1.py
@@ -13,6 +13,7 @@ import pyfstat
 
 label = "PyFstat_example_grid_search_F0F1"
 outdir = os.path.join("PyFstat_example_data", label)
+logger = pyfstat.set_up_logger(label=label, outdir=outdir)
 
 # Properties of the GW data
 sqrtSX = 1e-23

--- a/examples/grid_examples/PyFstat_example_grid_search_F0F1F2.py
+++ b/examples/grid_examples/PyFstat_example_grid_search_F0F1F2.py
@@ -76,7 +76,7 @@ search.run()
 
 # report details of the maximum point
 max_dict = search.get_max_twoF()
-print(
+logger.info(
     "max2F={:.4f} from GridSearch, offsets from injection: {:s}.".format(
         max_dict["twoF"],
         ", ".join(
@@ -93,24 +93,24 @@ search.generate_loudest()
 # FIXME: workaround for matplotlib "Exceeded cell block limit" errors
 agg_chunksize = 10000
 
-print("Plotting 2F(F0)...")
+logger.info("Plotting 2F(F0)...")
 search.plot_1D(
     xkey="F0", xlabel="freq [Hz]", ylabel="$2\\mathcal{F}$", agg_chunksize=agg_chunksize
 )
-print("Plotting 2F(F1)...")
+logger.info("Plotting 2F(F1)...")
 search.plot_1D(xkey="F1", agg_chunksize=agg_chunksize)
-print("Plotting 2F(F2)...")
+logger.info("Plotting 2F(F2)...")
 search.plot_1D(xkey="F2", agg_chunksize=agg_chunksize)
-print("Plotting 2F(Alpha)...")
+logger.info("Plotting 2F(Alpha)...")
 search.plot_1D(xkey="Alpha", agg_chunksize=agg_chunksize)
-print("Plotting 2F(Delta)...")
+logger.info("Plotting 2F(Delta)...")
 search.plot_1D(xkey="Delta", agg_chunksize=agg_chunksize)
 # 2D plots will currently not work for >2 non-trivial (gridded) search dimensions
 # search.plot_2D(xkey="F0",ykey="F1",colorbar=True)
 # search.plot_2D(xkey="F0",ykey="F2",colorbar=True)
 # search.plot_2D(xkey="F1",ykey="F2",colorbar=True)
 
-print("Making gridcorner plot...")
+logger.info("Making gridcorner plot...")
 F0_vals = np.unique(search.data["F0"]) - inj["F0"]
 F1_vals = np.unique(search.data["F1"]) - inj["F1"]
 F2_vals = np.unique(search.data["F2"]) - inj["F2"]

--- a/examples/grid_examples/PyFstat_example_grid_search_F0F1F2.py
+++ b/examples/grid_examples/PyFstat_example_grid_search_F0F1F2.py
@@ -13,6 +13,7 @@ import pyfstat
 
 label = "PyFstat_example_grid_search_F0F1F2"
 outdir = os.path.join("PyFstat_example_data", label)
+logger = pyfstat.set_up_logger(label=label, outdir=outdir)
 
 # Properties of the GW data
 sqrtSX = 1e-23

--- a/examples/grid_examples/PyFstat_example_grid_search_with_BSGL.py
+++ b/examples/grid_examples/PyFstat_example_grid_search_with_BSGL.py
@@ -16,6 +16,7 @@ import pyfstat
 
 label = "PyFstat_example_grid_search_BSGL"
 outdir = os.path.join("PyFstat_example_data", label)
+logger = pyfstat.set_up_logger(label=label, outdir=outdir)
 
 F0 = 30.0
 F1 = 0

--- a/examples/grid_examples/PyFstat_example_grid_search_with_BSGL.py
+++ b/examples/grid_examples/PyFstat_example_grid_search_with_BSGL.py
@@ -107,7 +107,7 @@ searchF = pyfstat.GridSearch(
 )
 searchF.run()
 
-print("Plotting 2F(F0)...")
+logger.info("Plotting 2F(F0)...")
 searchF.plot_1D(xkey="F0")
 
 # second search: line-robust statistic BSGL activated
@@ -130,5 +130,5 @@ searchBSGL.run()
 # The actual output statistic is log10BSGL.
 # The peak at the higher frequency from the "line artifact" should now
 # be massively suppressed.
-print("Plotting log10BSGL(F0)...")
+logger.info("Plotting log10BSGL(F0)...")
 searchBSGL.plot_1D(xkey="F0")

--- a/examples/mcmc_examples/PyFstat_example_MCMC_search_using_initialisation.py
+++ b/examples/mcmc_examples/PyFstat_example_MCMC_search_using_initialisation.py
@@ -46,13 +46,13 @@ data.make_data()
 
 # The predicted twoF, given by lalapps_predictFstat can be accessed by
 twoF = data.predict_fstat()
-print("Predicted twoF value: {}\n".format(twoF))
+logger.info("Predicted twoF value: {}\n".format(twoF))
 
 DeltaF0 = 1e-7
 DeltaF1 = 1e-13
 VF0 = (np.pi * data_parameters["duration"] * DeltaF0) ** 2 / 3.0
 VF1 = (np.pi * data_parameters["duration"] ** 2 * DeltaF1) ** 2 * 4 / 45.0
-print("\nV={:1.2e}, VF0={:1.2e}, VF1={:1.2e}\n".format(VF0 * VF1, VF0, VF1))
+logger.info("\nV={:1.2e}, VF0={:1.2e}, VF1={:1.2e}\n".format(VF0 * VF1, VF0, VF1))
 
 theta_prior = {
     "F0": {

--- a/examples/mcmc_examples/PyFstat_example_MCMC_search_using_initialisation.py
+++ b/examples/mcmc_examples/PyFstat_example_MCMC_search_using_initialisation.py
@@ -14,6 +14,7 @@ import pyfstat
 
 label = "PyFstat_example_MCMC_search_using_initialisation"
 outdir = os.path.join("PyFstat_example_data", label)
+logger = pyfstat.set_up_logger(label=label, outdir=outdir)
 
 # Properties of the GW data
 data_parameters = {

--- a/examples/mcmc_examples/PyFstat_example_fully_coherent_MCMC_search.py
+++ b/examples/mcmc_examples/PyFstat_example_fully_coherent_MCMC_search.py
@@ -47,13 +47,13 @@ data.make_data()
 
 # The predicted twoF, given by lalapps_predictFstat can be accessed by
 twoF = data.predict_fstat()
-print("Predicted twoF value: {}\n".format(twoF))
+logger.info("Predicted twoF value: {}\n".format(twoF))
 
 DeltaF0 = 1e-7
 DeltaF1 = 1e-13
 VF0 = (np.pi * data_parameters["duration"] * DeltaF0) ** 2 / 3.0
 VF1 = (np.pi * data_parameters["duration"] ** 2 * DeltaF1) ** 2 * 4 / 45.0
-print("\nV={:1.2e}, VF0={:1.2e}, VF1={:1.2e}\n".format(VF0 * VF1, VF0, VF1))
+logger.info("\nV={:1.2e}, VF0={:1.2e}, VF1={:1.2e}\n".format(VF0 * VF1, VF0, VF1))
 
 theta_prior = {
     "F0": {

--- a/examples/mcmc_examples/PyFstat_example_fully_coherent_MCMC_search.py
+++ b/examples/mcmc_examples/PyFstat_example_fully_coherent_MCMC_search.py
@@ -15,6 +15,7 @@ from pyfstat.helper_functions import get_predict_fstat_parameters_from_dict
 
 label = "PyFstat_example_fully_coherent_MCMC_search"
 outdir = os.path.join("PyFstat_example_data", label)
+logger = pyfstat.set_up_logger(label=label, outdir=outdir)
 
 # Properties of the GW data
 data_parameters = {

--- a/examples/mcmc_examples/PyFstat_example_fully_coherent_MCMC_search_with_BSGL.py
+++ b/examples/mcmc_examples/PyFstat_example_fully_coherent_MCMC_search_with_BSGL.py
@@ -14,6 +14,7 @@ import pyfstat
 
 label = os.path.splitext(os.path.basename(__file__))[0]
 outdir = os.path.join("PyFstat_example_data", label)
+logger = pyfstat.set_up_logger(label=label, outdir=outdir)
 
 # Properties of the GW data - first we make data for two detectors,
 # both including Gaussian noise and a coherent 'astrophysical' signal.

--- a/examples/mcmc_examples/PyFstat_example_fully_coherent_MCMC_search_with_BSGL.py
+++ b/examples/mcmc_examples/PyFstat_example_fully_coherent_MCMC_search_with_BSGL.py
@@ -68,7 +68,7 @@ extra_writer.make_data()
 
 # The predicted twoF, given by lalapps_predictFstat can be accessed by
 twoF = data.predict_fstat()
-print("Predicted twoF value: {}\n".format(twoF))
+logger.info("Predicted twoF value: {}\n".format(twoF))
 
 # MCMC prior ranges
 DeltaF0 = 1e-5

--- a/examples/mcmc_examples/PyFstat_example_semi_coherent_MCMC_search.py
+++ b/examples/mcmc_examples/PyFstat_example_semi_coherent_MCMC_search.py
@@ -45,13 +45,13 @@ data.make_data()
 
 # The predicted twoF, given by lalapps_predictFstat can be accessed by
 twoF = data.predict_fstat()
-print("Predicted twoF value: {}\n".format(twoF))
+logger.info("Predicted twoF value: {}\n".format(twoF))
 
 DeltaF0 = 1e-7
 DeltaF1 = 1e-13
 VF0 = (np.pi * data_parameters["duration"] * DeltaF0) ** 2 / 3.0
 VF1 = (np.pi * data_parameters["duration"] ** 2 * DeltaF1) ** 2 * 4 / 45.0
-print("\nV={:1.2e}, VF0={:1.2e}, VF1={:1.2e}\n".format(VF0 * VF1, VF0, VF1))
+logger.info("\nV={:1.2e}, VF0={:1.2e}, VF1={:1.2e}\n".format(VF0 * VF1, VF0, VF1))
 
 theta_prior = {
     "F0": {

--- a/examples/mcmc_examples/PyFstat_example_semi_coherent_MCMC_search.py
+++ b/examples/mcmc_examples/PyFstat_example_semi_coherent_MCMC_search.py
@@ -13,6 +13,7 @@ import pyfstat
 
 label = "PyFstat_example_semi_coherent_MCMC_search"
 outdir = os.path.join("PyFstat_example_data", label)
+logger = pyfstat.set_up_logger(label=label, outdir=outdir)
 
 # Properties of the GW data
 data_parameters = {

--- a/examples/mcmc_vs_grid_simple_example/PyFstat_example_simple_mcmc_vs_grid_comparison.py
+++ b/examples/mcmc_vs_grid_simple_example/PyFstat_example_simple_mcmc_vs_grid_comparison.py
@@ -20,6 +20,7 @@ sky = False
 outdir = os.path.join(
     "PyFstat_example_data", "PyFstat_example_simple_mcmc_vs_grid_comparison"
 )
+logger = pyfstat.set_up_logger(label="mcmc_vs_grid", outdir=outdir)
 if sky:
     outdir += "AlphaDelta"
 

--- a/examples/mcmc_vs_grid_simple_example/PyFstat_example_simple_mcmc_vs_grid_comparison.py
+++ b/examples/mcmc_vs_grid_simple_example/PyFstat_example_simple_mcmc_vs_grid_comparison.py
@@ -114,7 +114,7 @@ def plot_2F_scatter(res, label, xkey, ykey):
 
 if __name__ == "__main__":
 
-    print("Generating SFTs with injected signal...")
+    logger.info("Generating SFTs with injected signal...")
     writer = pyfstat.Writer(
         label="simulated_signal",
         outdir=outdir,
@@ -127,7 +127,7 @@ if __name__ == "__main__":
         Band=1,  # default band estimation would be too narrow for a wide grid/prior
     )
     writer.make_data()
-    print("")
+    logger.info("")
 
     # set up square search grid with fixed (F0,F1) mismatch
     # and (optionally) some ad-hoc sky coverage
@@ -155,7 +155,7 @@ if __name__ == "__main__":
         Deltas = [inj["Delta"]]
     search_keys_label = "".join(search_keys)
 
-    print("Performing GridSearch...")
+    logger.info("Performing GridSearch...")
     gridsearch = pyfstat.GridSearch(
         label="grid_search_" + search_keys_label,
         outdir=outdir,
@@ -173,11 +173,11 @@ if __name__ == "__main__":
 
     # do some plots of the GridSearch results
     if not sky:  # this plotter can't currently deal with too large result arrays
-        print("Plotting 1D 2F distributions...")
+        logger.info("Plotting 1D 2F distributions...")
         for key in search_keys:
             gridsearch.plot_1D(xkey=key, xlabel=labels[key], ylabel=labels["2F"])
 
-    print("Making GridSearch {:s} corner plot...".format("-".join(search_keys)))
+    logger.info("Making GridSearch {:s} corner plot...".format("-".join(search_keys)))
     vals = [np.unique(gridsearch.data[key]) - inj[key] for key in search_keys]
     twoF = gridsearch.data["twoF"].reshape([len(kval) for kval in vals])
     corner_labels = [
@@ -193,9 +193,9 @@ if __name__ == "__main__":
     )
     gridcorner_fig.savefig(os.path.join(outdir, gridsearch.label + "_corner.png"))
     plt.close(gridcorner_fig)
-    print("")
+    logger.info("")
 
-    print("Performing MCMCSearch...")
+    logger.info("Performing MCMCSearch...")
     # set up priors in F0 and F1 (over)covering the grid ranges
     if sky:  # MCMC will still be fast in 4D with wider range than grid
         DeltaF0 *= 50
@@ -253,11 +253,11 @@ if __name__ == "__main__":
 
     # call some built-in plotting methods
     # these can all highlight the injection parameters, too
-    print("Making MCMCSearch {:s} corner plot...".format("-".join(search_keys)))
+    logger.info("Making MCMCSearch {:s} corner plot...".format("-".join(search_keys)))
     mcmcsearch.plot_corner(truths=inj)
-    print("Making MCMCSearch prior-posterior comparison plot...")
+    logger.info("Making MCMCSearch prior-posterior comparison plot...")
     mcmcsearch.plot_prior_posterior(injection_parameters=inj)
-    print("")
+    logger.info("")
 
     # NOTE: everything below here is just custom commandline output and plotting
     # for this particular example, which uses the PyFstat outputs,
@@ -268,7 +268,7 @@ if __name__ == "__main__":
     max_dict_grid = gridsearch.get_max_twoF()
     # same for MCMCSearch, here twoF is separate, and non-sampled parameters are not included either
     max_dict_mcmc, max_2F_mcmc = mcmcsearch.get_max_twoF()
-    print(
+    logger.info(
         "max2F={:.4f} from GridSearch, offsets from injection: {:s}.".format(
             max_dict_grid["twoF"],
             ", ".join(
@@ -279,7 +279,7 @@ if __name__ == "__main__":
             ),
         )
     )
-    print(
+    logger.info(
         "max2F={:.4f} from MCMCSearch, offsets from injection: {:s}.".format(
             max_2F_mcmc,
             ", ".join(
@@ -292,7 +292,7 @@ if __name__ == "__main__":
     )
     # get additional point and interval estimators
     stats_dict_mcmc = mcmcsearch.get_summary_stats()
-    print(
+    logger.info(
         "mean   from MCMCSearch: offset from injection by      {:s},"
         " or in fractions of 2sigma intervals: {:s}.".format(
             ", ".join(
@@ -316,7 +316,7 @@ if __name__ == "__main__":
             ),
         )
     )
-    print(
+    logger.info(
         "median from MCMCSearch: offset from injection by      {:s},"
         " or in fractions of 90% confidence intervals: {:s}.".format(
             ", ".join(
@@ -343,10 +343,10 @@ if __name__ == "__main__":
             ),
         )
     )
-    print()
+    logger.info()
 
     # do additional custom plotting
-    print("Loading grid and MCMC search results for custom comparison plots...")
+    logger.info("Loading grid and MCMC search results for custom comparison plots...")
     gridfile = os.path.join(outdir, gridsearch.label + "_NA_GridSearch.txt")
     if not os.path.isfile(gridfile):
         raise RuntimeError(
@@ -369,7 +369,7 @@ if __name__ == "__main__":
 
     # we'll use the two local plotting functions defined above
     # to avoid code duplication in the sky case
-    print("Creating MCMC-grid comparison plots...")
+    logger.info("Creating MCMC-grid comparison plots...")
     plot_grid_vs_samples(grid_res, mcmc_res, "F0", "F1")
     plot_2F_scatter(grid_res, "grid", "F0", "F1")
     plot_2F_scatter(mcmc_res, "mcmc", "F0", "F1")

--- a/examples/other_examples/PyFstat_example_InjectionParametersGenerator.py
+++ b/examples/other_examples/PyFstat_example_InjectionParametersGenerator.py
@@ -14,10 +14,12 @@ from pyfstat import (
     AllSkyInjectionParametersGenerator,
     InjectionParametersGenerator,
     Writer,
+    set_up_logger,
 )
 
 label = "PyFstat_example_InjectionParametersGenerator"
 outdir = os.path.join("PyFstat_example_data", label)
+logger = set_up_logger(label=label, outdir=outdir)
 
 # Properties of the GW data
 gw_data = {

--- a/examples/other_examples/PyFstat_example_InjectionParametersGenerator.py
+++ b/examples/other_examples/PyFstat_example_InjectionParametersGenerator.py
@@ -31,7 +31,7 @@ gw_data = {
     "Tsft": 1800,
 }
 
-print("Drawing random signal parameters...")
+logger.info("Drawing random signal parameters...")
 
 # Draw random signal phase parameters.
 # The AllSkyInjectionParametersGenerator covers [Alpha,Delta] priors automatically.
@@ -76,27 +76,27 @@ phase_parameters = [phase_params_generator.draw() for n in range(Ndraws)]
 Alphas = np.array([p["Alpha"] for p in phase_parameters])
 Deltas = np.array([p["Delta"] for p in phase_parameters])
 plotfile = os.path.join(outdir, label + "_allsky.png")
-print(f"Plotting sky distribution of {Ndraws} points to file: {plotfile}")
+logger.info(f"Plotting sky distribution of {Ndraws} points to file: {plotfile}")
 plt.subplot(111, projection="aitoff")
 plt.plot(Alphas - np.pi, Deltas, ".", markersize=1)
 plt.savefig(plotfile, dpi=300)
 plt.close()
 plotfile = os.path.join(outdir, label + "_alpha_hist.png")
-print(f"Plotting Alpha distribution of {Ndraws} points to file: {plotfile}")
+logger.info(f"Plotting Alpha distribution of {Ndraws} points to file: {plotfile}")
 plt.hist(Alphas, 50)
 plt.xlabel("Alpha")
 plt.ylabel("draws")
 plt.savefig(plotfile, dpi=100)
 plt.close()
 plotfile = os.path.join(outdir, label + "_delta_hist.png")
-print(f"Plotting Delta distribution of {Ndraws} points to file: {plotfile}")
+logger.info(f"Plotting Delta distribution of {Ndraws} points to file: {plotfile}")
 plt.hist(Deltas, 50)
 plt.xlabel("Delta")
 plt.ylabel("draws")
 plt.savefig(plotfile, dpi=100)
 plt.close()
 plotfile = os.path.join(outdir, label + "_sindelta_hist.png")
-print(f"Plotting sin(Delta) distribution of {Ndraws} points to file: {plotfile}")
+logger.info(f"Plotting sin(Delta) distribution of {Ndraws} points to file: {plotfile}")
 plt.hist(np.sin(Deltas), 50)
 plt.xlabel("sin(Delta)")
 plt.ylabel("draws")

--- a/examples/other_examples/PyFstat_example_injecting_into_noise_sfts.py
+++ b/examples/other_examples/PyFstat_example_injecting_into_noise_sfts.py
@@ -17,6 +17,7 @@ import pyfstat
 
 label = "PyFstat_example_injection_into_noise_sfts"
 outdir = os.path.join("PyFstat_example_data", label)
+logger = pyfstat.set_up_logger(label=label, outdir=outdir)
 
 tstart = 1269734418
 duration_Tsft = 100

--- a/examples/other_examples/PyFstat_example_injecting_into_noise_sfts.py
+++ b/examples/other_examples/PyFstat_example_injecting_into_noise_sfts.py
@@ -134,6 +134,6 @@ FS_2 = coherent_search.get_fullycoherent_twoF(
     add_signal_writer.Delta,
 )
 
-print("Base case Fstat: {}".format(FS_1))
-print("Noise + Signal Fstat: {}".format(FS_2))
-print("Relative Difference: {}".format(np.abs(FS_2 - FS_1) / FS_1))
+logger.info("Base case Fstat: {}".format(FS_1))
+logger.info("Noise + Signal Fstat: {}".format(FS_2))
+logger.info("Relative Difference: {}".format(np.abs(FS_2 - FS_1) / FS_1))

--- a/examples/other_examples/PyFstat_example_spectrogram.py
+++ b/examples/other_examples/PyFstat_example_spectrogram.py
@@ -23,6 +23,7 @@ plt.rcParams["axes.grid"] = False
 
 label = "PyFstat_example_spectrogram"
 outdir = os.path.join("PyFstat_example_data", label)
+logger = pyfstat.set_up_logger(label=label, outdir=outdir)
 
 depth = 5
 

--- a/examples/other_examples/PyFstat_example_spectrogram.py
+++ b/examples/other_examples/PyFstat_example_spectrogram.py
@@ -55,7 +55,7 @@ data = pyfstat.BinaryModulatedWriter(
 )
 data.make_data()
 
-print("Loading SFT data and computing normalized power...")
+logger.info("Loading SFT data and computing normalized power...")
 freqs, times, sft_data = pyfstat.helper_functions.get_sft_as_arrays(data.sftfilepath)
 sft_power = sft_data["H1"].real ** 2 + sft_data["H1"].imag ** 2
 normalized_power = (
@@ -63,7 +63,7 @@ normalized_power = (
 )
 
 plotfile = os.path.join(outdir, label + ".png")
-print(f"Plotting to file: {plotfile}")
+logger.info(f"Plotting to file: {plotfile}")
 fig, ax = plt.subplots(figsize=(0.8 * 16, 0.8 * 9))
 ax.set(xlabel="Time [days]", ylabel="Frequency [Hz]", ylim=(99.98, 100.02))
 c = ax.pcolormesh(

--- a/examples/other_examples/PyFstat_example_twoF_cumulative.py
+++ b/examples/other_examples/PyFstat_example_twoF_cumulative.py
@@ -67,7 +67,7 @@ data.make_data()
 
 # The predicted twoF, given by lalapps_predictFstat can be accessed by
 twoF = data.predict_fstat()
-print("Predicted twoF value: {}\n".format(twoF))
+logger.info("Predicted twoF value: {}\n".format(twoF))
 
 # Create a search object for each of the possible SFT combinations
 # (H1 only, L1 only, H1 + L1).

--- a/examples/other_examples/PyFstat_example_twoF_cumulative.py
+++ b/examples/other_examples/PyFstat_example_twoF_cumulative.py
@@ -15,6 +15,7 @@ from pyfstat.helper_functions import get_predict_fstat_parameters_from_dict
 
 label = "PyFstat_example_twoF_cumulative"
 outdir = os.path.join("PyFstat_example_data", label)
+logger = pyfstat.set_up_logger(label=label, outdir=outdir)
 
 # Properties of the GW data
 gw_data = {

--- a/examples/run_all_examples.py
+++ b/examples/run_all_examples.py
@@ -2,18 +2,21 @@ import os
 import shutil
 from glob import glob
 
-from pyfstat.helper_functions import run_commandline
+from pyfstat.helper_functions import run_commandline, set_up_logger
 
 exit_on_first_failure = False
 
 basedir = os.path.abspath(os.path.dirname(__file__))
 
 outdir = "PyFstat_example_data"
+logger = set_up_logger(outdir=outdir, label="run_all_examples")
+
 # make sure we start from a clean output directory
 # and scripts don't just recycle old output
 if os.path.isdir(outdir):
-    print(f"Removing old output directory {outdir}...")
+    logger.info(f"Removing old output directory {outdir}...")
     shutil.rmtree(outdir)
+
 
 # In some examples directories, scripts must be executed in a certain order.
 # Those need to be manually maintained here.
@@ -46,25 +49,27 @@ for case in os.listdir(basedir):
             ]
         else:
             scripts = sorted(glob(os.path.join(exdir, "PyFstat_example_*.py")))
-        print(f"Executing {len(scripts)} script(s) in example directory {exdir}...")
+        logger.info(
+            f"Executing {len(scripts)} script(s) in example directory {exdir}..."
+        )
         for script in scripts:
             Nscripts += 1
             cl = "python " + script
-            print(f"Running: {script}")
+            logger.info(f"Running: {script}")
             try:
                 run_commandline(cl, return_output=False)
             except Exception as e:
-                print(f"FAILED to run {script}")
+                logger.info(f"FAILED to run {script}")
                 failures.append(script)
                 if exit_on_first_failure:
-                    print("Exception was:")
-                    print(e)
+                    logger.info("Exception was:")
+                    logger.info(e)
                     raise RuntimeError("Exiting on first failure as requested.")
                 else:
-                    print("\n")
+                    logger.info("\n")
             else:
-                print(f"Successfully ran: {script}\n")
-        print("")
+                logger.info(f"Successfully ran: {script}\n")
+        logger.info("")
 
 if len(failures) > 0:
     raise RuntimeError(
@@ -72,4 +77,4 @@ if len(failures) > 0:
         + "\n".join(failures)
     )
 else:
-    print(f"Successfully ran {Nscripts} example scripts.")
+    logger.info(f"Successfully ran {Nscripts} example scripts.")

--- a/examples/transient_examples/PyFstat_example_long_transient_MCMC_search.py
+++ b/examples/transient_examples/PyFstat_example_long_transient_MCMC_search.py
@@ -25,6 +25,8 @@ if not os.path.isdir(data.outdir) or not np.any(
         "Please first run PyFstat_example_make_data_for_long_transient_search.py !"
     )
 
+logger = pyfstat.set_up_logger(label="long_transient_mcmc_search", outdir=data.outdir)
+
 tstart = data.tstart
 duration = data.duration
 

--- a/examples/transient_examples/PyFstat_example_make_data_for_long_transient_search.py
+++ b/examples/transient_examples/PyFstat_example_make_data_for_long_transient_search.py
@@ -14,6 +14,7 @@ import os
 import pyfstat
 
 outdir = os.path.join("PyFstat_example_data", "PyFstat_example_long_transient_search")
+logger = pyfstat.set_up_logger(outdir=outdir, label="short_transient_search")
 
 F0 = 30.0
 F1 = -1e-10
@@ -58,4 +59,4 @@ if __name__ == "__main__":
         transientWindowType=transientWindowType,
     )
     transient.make_data()
-    print("Predicted 2F from injection Writer:", transient.predict_fstat())
+    logger.info("Predicted 2F from injection Writer:", transient.predict_fstat())

--- a/examples/transient_examples/PyFstat_example_make_data_for_short_transient_search.py
+++ b/examples/transient_examples/PyFstat_example_make_data_for_short_transient_search.py
@@ -16,6 +16,8 @@ import os
 import pyfstat
 
 outdir = os.path.join("PyFstat_example_data", "PyFstat_example_short_transient_search")
+logger = pyfstat.set_up_logger(outdir=outdir, label="short_transient_search")
+
 
 F0 = 30.0
 F1 = -1e-10
@@ -64,4 +66,4 @@ if __name__ == "__main__":
         Band=0.1,
     )
     transient.make_data()
-    print("Predicted 2F from injection Writer:", transient.predict_fstat())
+    logger.info("Predicted 2F from injection Writer:", transient.predict_fstat())

--- a/examples/transient_examples/PyFstat_example_short_transient_MCMC_search.py
+++ b/examples/transient_examples/PyFstat_example_short_transient_MCMC_search.py
@@ -15,6 +15,10 @@ from pyfstat.helper_functions import get_predict_fstat_parameters_from_dict
 
 if __name__ == "__main__":
 
+    logger = pyfstat.set_up_logger(
+        label="short_transient_mcmc_search", outdir=data.outdir
+    )
+
     if not os.path.isdir(data.outdir) or not np.any(
         [f.endswith(".sft") for f in os.listdir(data.outdir)]
     ):

--- a/examples/transient_examples/PyFstat_example_short_transient_grid_search.py
+++ b/examples/transient_examples/PyFstat_example_short_transient_grid_search.py
@@ -49,7 +49,7 @@ if __name__ == "__main__":
     BSGL = False
     BtSG = False
 
-    print("Standard CW search:")
+    logger.info("Standard CW search:")
     search1 = pyfstat.GridSearch(
         label=f"CW{'_BSGL' if BSGL else ''}",
         outdir=data.outdir,
@@ -68,7 +68,7 @@ if __name__ == "__main__":
         xkey="F0", xlabel="freq [Hz]", ylabel=search1.tex_labels[search1.detstat]
     )
 
-    print("with t0,tau bands:")
+    logger.info("with t0,tau bands:")
     label = f"tCW{'_BSGL' if BSGL else ''}{'_BtSG' if BtSG else ''}_FstatMap_{tCWFstatMapVersion}"
     search2 = pyfstat.TransientGridSearch(
         label=label,

--- a/examples/transient_examples/PyFstat_example_short_transient_grid_search.py
+++ b/examples/transient_examples/PyFstat_example_short_transient_grid_search.py
@@ -25,6 +25,9 @@ tCWFstatMapVersion = "lal"
 
 if __name__ == "__main__":
 
+    logger = pyfstat.set_up_logger(
+        label="short_transient_grid_search", outdir=data.outdir
+    )
     if not os.path.isdir(data.outdir) or not np.any(
         [f.endswith(".sft") for f in os.listdir(data.outdir)]
     ):

--- a/examples/tutorials/0_generating_noise.ipynb
+++ b/examples/tutorials/0_generating_noise.ipynb
@@ -40,6 +40,8 @@
     "# Local module to simplify plotting\n",
     "import utils\n",
     "\n",
+    "logger = pyfstat.set_up_logger(label=\"0_generating_noise\", log_level=\"info\")\n",
+    "\n",
     "%matplotlib inline"
    ]
   },

--- a/examples/tutorials/1_generating_signals.ipynb
+++ b/examples/tutorials/1_generating_signals.ipynb
@@ -34,6 +34,8 @@
     "# Local module to simplify plotting\n",
     "import utils\n",
     "\n",
+    "logger = pyfstat.set_up_logger(label=\"1_generating_signals\", log_level=\"info\")\n",
+    "\n",
     "%matplotlib inline"
    ]
   },

--- a/pyfstat/__init__.py
+++ b/pyfstat/__init__.py
@@ -1,3 +1,5 @@
+import logging
+
 from ._version import get_versions
 from .core import (
     BaseSearchClass,
@@ -41,3 +43,15 @@ from .tcw_fstat_map_funcs import pyTransientFstatMap
 
 __version__ = get_versions()["version"]
 del get_versions
+
+# fallback logging setup
+root_logger = logging.getLogger()
+if len(root_logger.handlers) == 0:
+    logger = set_up_logger()
+    logger.info(f"Running PyFstat version {__version__}")
+    logger.warning(
+        "No logging handler found."
+        " We've set up some nicely formatted stdout logging at INFO level."
+        " Feel free to override from the calling application level if you don't like it,"
+        " and we'll respect that!"
+    )

--- a/pyfstat/__init__.py
+++ b/pyfstat/__init__.py
@@ -16,6 +16,7 @@ from .grid_based_searches import (
     TransientGridSearch,
 )
 from .gridcorner import gridcorner
+from .helper_functions import set_up_logger
 from .injection_parameters import (
     AllSkyInjectionParametersGenerator,
     InjectionParametersGenerator,

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -20,6 +20,8 @@ import pyfstat.helper_functions as helper_functions
 import pyfstat.tcw_fstat_map_funcs as tcw
 
 logger = logging.getLogger(__name__)
+# the following only gets logged if caller pre-configured a logger
+logger.info(f"Running PyFstat version {helper_functions.get_version_string()}")
 
 # workaround for matplotlib on X-less remote logins
 if "DISPLAY" in os.environ:

--- a/pyfstat/grid_based_searches.py
+++ b/pyfstat/grid_based_searches.py
@@ -783,9 +783,9 @@ class GridSearch(BaseSearchClass):
         i.e. the maximum value and its corresponding parameters.
         """
         d = self.get_max_twoF()
-        print("Grid point with max(twoF) for {}:".format(self.label))
+        logger.info("Grid point with max(twoF) for {}:".format(self.label))
         for k, v in d.items():
-            print("  {}={}".format(k, v))
+            logger.info("  {}={}".format(k, v))
 
     def generate_loudest(self):
         """Use ComputeFstatistic_v2 executable to produce a .loudest file"""

--- a/pyfstat/grid_based_searches.py
+++ b/pyfstat/grid_based_searches.py
@@ -21,6 +21,8 @@ from pyfstat.core import (
     SemiCoherentSearch,
 )
 
+logger = logging.getLogger(__name__)
+
 
 class GridSearch(BaseSearchClass):
     """A search evaluating the F-statistic over a regular grid in parameter space.
@@ -148,7 +150,7 @@ class GridSearch(BaseSearchClass):
             return None
 
     def _initiate_search_object(self):
-        logging.info("Setting up search object")
+        logger.info("Setting up search object")
         search_ranges = self._get_search_ranges()
         if self.nsegs == 1:
             self.search = ComputeFstat(
@@ -204,7 +206,7 @@ class GridSearch(BaseSearchClass):
                 x[0], x[1], num=int((x[1] - x[0]) / x[2]) + 1, endpoint=True
             )
         else:
-            logging.info("Using tuple of length {:d} as is.".format(len(x)))
+            logger.info("Using tuple of length {:d} as is.".format(len(x)))
             return np.array(x)
 
     def _get_input_data_array(self):
@@ -214,7 +216,7 @@ class GridSearch(BaseSearchClass):
         and explicit dtype (cannot have named columns without that).
         (Will also ensure safety when reading/saving data from/to .txt files.)
         """
-        logging.info("Generating input data array")
+        logger.info("Generating input data array")
         coord_arrays = []
         for sl in self.search_keys:
             coord_arrays.append(
@@ -258,7 +260,7 @@ class GridSearch(BaseSearchClass):
         if self.clean:
             return False
         if os.path.isfile(self.out_file) is False:
-            logging.info(
+            logger.info(
                 "No old output file '{:s}' found, continuing with grid search.".format(
                     self.out_file
                 )
@@ -269,13 +271,13 @@ class GridSearch(BaseSearchClass):
                 [os.path.getmtime(f) for f in self._get_list_of_matching_sfts()]
             )
             if os.path.getmtime(self.out_file) < oldest_sft:
-                logging.info(
+                logger.info(
                     "Search output data outdates sft files,"
                     + " continuing with grid search."
                 )
                 return False
 
-        logging.info("Checking header of '{:s}'".format(self.out_file))
+        logger.info("Checking header of '{:s}'".format(self.out_file))
         old_params_dict_str_list = (
             helper_functions.read_parameters_dict_lines_from_file_header(self.out_file)
         )
@@ -284,20 +286,20 @@ class GridSearch(BaseSearchClass):
         ]
         unmatched = np.setxor1d(old_params_dict_str_list, new_params_dict_str_list)
         if len(unmatched) > 0:
-            logging.info(
+            logger.info(
                 "Parameters string in file header does not match"
                 + " current search setup, continuing with grid search."
             )
             return False
         else:
-            logging.info(
+            logger.info(
                 "Parameters string in file header matches current search setup."
             )
 
-        logging.info("Loading old data from '{:s}'.".format(self.out_file))
+        logger.info("Loading old data from '{:s}'.".format(self.out_file))
         old_data = helper_functions.read_txt_file_with_header(self.out_file, names=True)
         if len(old_data) != len(self.input_data):
-            logging.info(
+            logger.info(
                 "Old data found in '{:s}', but differs"
                 " in length ({:d} points in file, {:d} points requested);"
                 " continuing with grid search.".format(
@@ -306,7 +308,7 @@ class GridSearch(BaseSearchClass):
             )
             return False
         if len(old_data.dtype) < len(self.input_data.dtype):
-            logging.info(
+            logger.info(
                 "Old data found in '{:s}', but has less columns ({:d})"
                 " than new input parameters grid ({:d});"
                 " continuing with grid search.".format(
@@ -331,7 +333,7 @@ class GridSearch(BaseSearchClass):
             for key in self.search_keys
         ]
         if np.all(column_matches):
-            logging.info(
+            logger.info(
                 "Old data found in '{:s}' with matching input parameters grid,"
                 " no search performed. Data grid size: {:d}x{:d}".format(
                     self.out_file, len(old_data), len(old_data.dtype)
@@ -339,7 +341,7 @@ class GridSearch(BaseSearchClass):
             )
             return old_data
         else:
-            logging.info(
+            logger.info(
                 "Old data found in '{:s}', input parameters grid differs,"
                 "  continuing with grid search.".format(self.out_file)
             )
@@ -376,7 +378,7 @@ class GridSearch(BaseSearchClass):
                 self.data = old_data
                 return
 
-        logging.info(
+        logger.info(
             "Running search over a total of {:d} grid points...".format(
                 np.shape(iterable)[0]
             )
@@ -462,7 +464,7 @@ class GridSearch(BaseSearchClass):
         as long as the `_get_savetxt_fmt_dict() method` is suitably overridden
         to account for any additional parameters.
         """
-        logging.info("Saving data to {}".format(self.out_file))
+        logger.info("Saving data to {}".format(self.out_file))
         header = "\n".join(self.output_file_header)
         header += "\n" + " ".join(self.output_keys)
         outfmt = self._get_savetxt_fmt_list()
@@ -982,18 +984,18 @@ class TransientGridSearch(GridSearch):
         self.output_file_header = self.get_output_file_header()
         if self.outputTransientFstatMap:
             self.tCWfilebase = os.path.splitext(self.out_file)[0] + "_tCW_"
-            logging.info(
+            logger.info(
                 "Will save per-Doppler Fstatmap"
                 " results to {}*.dat".format(self.tCWfilebase)
             )
 
     def __enter__(self):
-        logging.debug("Entering the TransientGridSearch context...")
+        logger.debug("Entering the TransientGridSearch context...")
         self.search.__enter__()
         return self
 
     def __exit__(self, *args, **kwargs):
-        logging.debug("Leaving the TransientGridSearch context...")
+        logger.debug("Leaving the TransientGridSearch context...")
         self.search.__exit__(*args, **kwargs)
 
     def _set_output_keys(self):
@@ -1014,7 +1016,7 @@ class TransientGridSearch(GridSearch):
         self.output_keys += ["t0", "tau"]
 
     def _initiate_search_object(self):
-        logging.info("Setting up search object")
+        logger.info("Setting up search object")
         search_ranges = self._get_search_ranges()
         self.search = ComputeFstat(
             tref=self.tref,
@@ -1085,7 +1087,7 @@ class TransientGridSearch(GridSearch):
         )
         data = np.zeros(len(self.input_data), dtype=output_dtype)
         self.timingFstatMap = 0.0
-        logging.info(
+        logger.info(
             "Running search over a total of {:d} grid points...".format(
                 np.shape(self.input_data)[0]
             )
@@ -1123,7 +1125,7 @@ class TransientGridSearch(GridSearch):
             if self.outputAtoms:
                 self.search.write_atoms_to_file(os.path.splitext(self.out_file)[0])
 
-        logging.info(
+        logger.info(
             "Total time spent computing transient F-stat maps: {:.2f}s".format(
                 self.timingFstatMap
             )
@@ -1268,7 +1270,7 @@ class GridGlitchSearch(GridSearch):
         self.output_file_header = self.get_output_file_header()
 
     def _initiate_search_object(self):
-        logging.info("Setting up search object")
+        logger.info("Setting up search object")
         search_ranges = self._get_search_ranges()
         self.search = SemiCoherentGlitchSearch(
             label=self.label,

--- a/pyfstat/grid_based_searches.py
+++ b/pyfstat/grid_based_searches.py
@@ -11,6 +11,7 @@ import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 from tqdm import tqdm
+from tqdm.contrib.logging import logging_redirect_tqdm
 
 import pyfstat.helper_functions as helper_functions
 from pyfstat.core import (
@@ -390,18 +391,20 @@ class GridSearch(BaseSearchClass):
             }
         )
         data = np.zeros(len(self.input_data), dtype=output_dtype)
-        for n, vals in enumerate(
-            tqdm(iterable, total=getattr(self, "total_iterations", None))
-        ):
-            thisCand = list(vals)
-            detstat = self.search.get_det_stat(*vals)
-            thisCand.append(self.search.twoF)
-            if self.search.singleFstats:
-                thisCand += list(self.search.twoFX[: self.search.numDetectors])
-            if self.detstat != "twoF":
-                thisCand.append(detstat)
-            for k, key in enumerate(self.output_keys):
-                data[key][n] = thisCand[k]
+
+        with logging_redirect_tqdm():
+            for n, vals in enumerate(
+                tqdm(iterable, total=getattr(self, "total_iterations", None))
+            ):
+                thisCand = list(vals)
+                detstat = self.search.get_det_stat(*vals)
+                thisCand.append(self.search.twoF)
+                if self.search.singleFstats:
+                    thisCand += list(self.search.twoFX[: self.search.numDetectors])
+                if self.detstat != "twoF":
+                    thisCand.append(detstat)
+                for k, key in enumerate(self.output_keys):
+                    data[key][n] = thisCand[k]
 
         if return_data:
             return data
@@ -1092,38 +1095,41 @@ class TransientGridSearch(GridSearch):
                 np.shape(self.input_data)[0]
             )
         )
-        for n, vals in enumerate(tqdm(self.input_data)):
-            thisCand = list(vals)
-            detstat = self.search.get_det_stat(*vals)
-            windowRange = getattr(self.search, "windowRange", None)
-            self.timingFstatMap += getattr(self.search, "timingFstatMap", 0.0)
-            thisCand.append(self.search.twoF)
-            if self.search.singleFstats:
-                thisCand += list(self.search.twoFX[: self.search.numDetectors])
-            thisCand.append(self.search.maxTwoF)
-            if hasattr(self.search, "twoFXatMaxTwoF"):
-                thisCand += list(self.search.twoFXatMaxTwoF[: self.search.numDetectors])
-            if self.detstat != "maxTwoF":
-                thisCand.append(detstat)
-            if getattr(self, "transientWindowType", None):
-                if not hasattr(self.search, "FstatMap"):
-                    raise RuntimeError(
-                        "Since transientWindowType!=None, we expected to have a FstatMap."
+        with logging_redirect_tqdm():
+            for n, vals in enumerate(tqdm(self.input_data)):
+                thisCand = list(vals)
+                detstat = self.search.get_det_stat(*vals)
+                windowRange = getattr(self.search, "windowRange", None)
+                self.timingFstatMap += getattr(self.search, "timingFstatMap", 0.0)
+                thisCand.append(self.search.twoF)
+                if self.search.singleFstats:
+                    thisCand += list(self.search.twoFX[: self.search.numDetectors])
+                thisCand.append(self.search.maxTwoF)
+                if hasattr(self.search, "twoFXatMaxTwoF"):
+                    thisCand += list(
+                        self.search.twoFXatMaxTwoF[: self.search.numDetectors]
                     )
-                if self.outputTransientFstatMap:
-                    tCWfile = self.get_transient_fstat_map_filename(thisCand)
-                    self.search.FstatMap.write_F_mn_to_file(
-                        tCWfile, windowRange, self.output_file_header
-                    )
-                maxidx = self.search.FstatMap.get_maxF_idx()
-                thisCand += [
-                    windowRange.t0 + maxidx[0] * windowRange.dt0,
-                    windowRange.tau + maxidx[1] * windowRange.dtau,
-                ]
-            for k, key in enumerate(self.output_keys):
-                data[key][n] = thisCand[k]
-            if self.outputAtoms:
-                self.search.write_atoms_to_file(os.path.splitext(self.out_file)[0])
+                if self.detstat != "maxTwoF":
+                    thisCand.append(detstat)
+                if getattr(self, "transientWindowType", None):
+                    if not hasattr(self.search, "FstatMap"):
+                        raise RuntimeError(
+                            "Since transientWindowType!=None, we expected to have a FstatMap."
+                        )
+                    if self.outputTransientFstatMap:
+                        tCWfile = self.get_transient_fstat_map_filename(thisCand)
+                        self.search.FstatMap.write_F_mn_to_file(
+                            tCWfile, windowRange, self.output_file_header
+                        )
+                    maxidx = self.search.FstatMap.get_maxF_idx()
+                    thisCand += [
+                        windowRange.t0 + maxidx[0] * windowRange.dt0,
+                        windowRange.tau + maxidx[1] * windowRange.dtau,
+                    ]
+                for k, key in enumerate(self.output_keys):
+                    data[key][n] = thisCand[k]
+                if self.outputAtoms:
+                    self.search.write_atoms_to_file(os.path.splitext(self.out_file)[0])
 
         logger.info(
             "Total time spent computing transient F-stat maps: {:.2f}s".format(

--- a/pyfstat/helper_functions.py
+++ b/pyfstat/helper_functions.py
@@ -11,6 +11,7 @@ import logging
 import os
 import shutil
 import subprocess
+import sys
 from datetime import datetime, timezone
 from functools import wraps
 
@@ -83,7 +84,7 @@ def set_up_logger(outdir=None, label="pyfstat", log_level="INFO"):
     )
 
     if any([type(h) == logging.StreamHandler for h in logger.handlers]) is False:
-        stream_handler = logging.StreamHandler()
+        stream_handler = logging.StreamHandler(sys.stdout)
         stream_handler.setFormatter(common_formatter)
         stream_handler.setLevel(level)
         logger.addHandler(stream_handler)

--- a/pyfstat/helper_functions.py
+++ b/pyfstat/helper_functions.py
@@ -51,7 +51,7 @@ def set_up_logger(outdir=None, label="pyfstat", log_level="INFO"):
     Parameters
     ----------
     outdir : str, optional
-        Path of to outdir directory.
+        Path to outdir directory.
     label : str, optional
         Label for this instance of the logger.
         Defaults to `pyfstat`, which is the "root" logger of this package.
@@ -78,8 +78,8 @@ def set_up_logger(outdir=None, label="pyfstat", log_level="INFO"):
     logger.setLevel(level)
 
     common_formatter = logging.Formatter(
-        "%(asctime)s %(name)s %(levelname)-8s: %(message)s",
-        datefmt="%m-%d %H:%M",
+        "%(asctime)s.%(msecs)03d %(name)s %(levelname)-8s: %(message)s",
+        datefmt="%y-%m-%d %H:%M:%S",
     )
 
     if any([type(h) == logging.StreamHandler for h in logger.handlers]) is False:

--- a/pyfstat/helper_functions.py
+++ b/pyfstat/helper_functions.py
@@ -99,9 +99,12 @@ def set_up_logger(outdir=None, label="pyfstat", log_level="INFO"):
             file_handler.setLevel(level)
             logger.addHandler(file_handler)
             # need the following because the file didn't catch any previous version logs yet
-            logger_file_only = logging.Logger("pyfstat")
-            logger_file_only.addHandler(file_handler)
-            logger_file_only.info(f"Running PyFstat version {get_version_string()}")
+            for h in logger.handlers:
+                if not type(h) == logging.FileHandler:
+                    h.setLevel(
+                        logging.WARNING
+                    )  # temporarily, to skip duplicate version info on other handlers
+            logger.info(f"Running PyFstat version {get_version_string()}")
 
     for handler in logger.handlers:
         handler.setLevel(level)

--- a/pyfstat/helper_functions.py
+++ b/pyfstat/helper_functions.py
@@ -43,23 +43,26 @@ def set_up_matplotlib_defaults():
 
 
 def set_up_logger(outdir=None, label="pyfstat", log_level="INFO"):
-    """
-     Setup the logger.
-     Based on the implementation in Nessai:
-     https://github.com/mj-will/nessai/blob/main/nessai/utils/logging.py
-     Parameters
-     ----------
-     outdir : str, optional
-         Path of to outdir directory.
-     label : str, optional
-         Label for this instance of the logger.
-         Defaults to `pyfstat`, which is the "root" logger of this package.
-     log_level : {'ERROR', 'WARNING', 'INFO', 'DEBUG'}, optional
-         Level of logging passed to logger.
-     Returns
-     -------
-    :obj:`logging.Logger`
-         Instance of the Logger class.
+    """Setup the logger.
+
+    Based on the implementation in Nessai:
+    https://github.com/mj-will/nessai/blob/main/nessai/utils/logging.py
+
+    Parameters
+    ----------
+    outdir : str, optional
+        Path of to outdir directory.
+    label : str, optional
+        Label for this instance of the logger.
+        Defaults to `pyfstat`, which is the "root" logger of this package.
+    log_level : {'ERROR', 'WARNING', 'INFO', 'DEBUG'}, optional
+        Level of logging passed to logger.
+
+    Returns
+    -------
+    obj:`logging.Logger`
+        Instance of the Logger class.
+
     """
     from . import __version__ as version
 

--- a/pyfstat/helper_functions.py
+++ b/pyfstat/helper_functions.py
@@ -21,11 +21,13 @@ import peakutils
 
 from ._version import get_versions
 
+logger = logging.getLogger(__name__)
+
 # workaround for matplotlib on X-less remote logins
 if "DISPLAY" in os.environ:
     import matplotlib.pyplot as plt
 else:
-    logging.info(
+    logger.info(
         'No $DISPLAY environment variable found, so importing \
                   matplotlib.pyplot with non-interactive "Agg" backend.'
     )
@@ -152,9 +154,9 @@ def get_ephemeris_files():
             earth_ephem = d["earth_ephem"]
             sun_ephem = d["sun_ephem"]
         except KeyError:
-            logging.warning(f"No [earth/sun]_ephem found in {config_file}. {please}")
+            logger.warning(f"No [earth/sun]_ephem found in {config_file}. {please}")
     else:
-        logging.info(f"No {config_file} file found. {please}")
+        logger.info(f"No {config_file} file found. {please}")
     return earth_ephem, sun_ephem
 
 
@@ -338,7 +340,7 @@ def run_commandline(cl, log_level=20, raise_error=True, return_output=True):
 
     logging.log(log_level, "Now executing: " + cl)
     if "|" in cl:
-        logging.warning(
+        logger.warning(
             "Pipe ('|') found in commandline, errors may not be" " properly caught!"
         )
     try:
@@ -422,11 +424,11 @@ def get_sft_as_arrays(sftfilepattern, fMin=None, fMax=None, constraints=None):
     sft_catalog = lalpulsar.SFTdataFind(sftfilepattern, constraints)
     ifo_labels = lalpulsar.ListIFOsInCatalog(sft_catalog)
 
-    logging.info(
+    logger.info(
         f"Loading {sft_catalog.length} SFTs from {', '.join(ifo_labels.data)}..."
     )
     multi_sfts = lalpulsar.LoadMultiSFTs(sft_catalog, fMin, fMax)
-    logging.info("done!")
+    logger.info("done!")
 
     times = {}
     amplitudes = {}
@@ -441,7 +443,7 @@ def get_sft_as_arrays(sftfilepattern, fMin=None, fMax=None, constraints=None):
 
         nbins, nsfts = amplitudes[ifo].shape
 
-        logging.info(f"{nsfts} retrieved from {ifo}.")
+        logger.info(f"{nsfts} retrieved from {ifo}.")
 
         f0 = sfts.data[0].f0
         df = sfts.data[0].deltaF
@@ -504,7 +506,7 @@ def get_sft_array(sftfilepattern, F0=None, dF0=None):
     MultiSFTs = lalpulsar.LoadMultiSFTs(SFTCatalog, fMin, fMax)
     ndet = MultiSFTs.length
     if ndet > 1:
-        logging.warning(
+        logger.warning(
             "Loaded SFTs from {:d} detectors, only using the first.".format(ndet)
         )
 
@@ -822,7 +824,7 @@ def get_parameters_dict_from_file_header(outfile, comments="#", eval_values=Fals
         (with values either as unparsed strings, or evaluated).
     """
     if eval_values:
-        logging.warning(
+        logger.warning(
             "Will evaluate dictionary values read from file '{:s}'.".format(outfile)
         )
     params_dict = {}
@@ -1190,11 +1192,11 @@ def generate_loudest_file(
     loudest_file: str
         The filename of the CFSv2 output file.
     """
-    logging.info("Running CFSv2 to get .loudest file")
+    logger.info("Running CFSv2 to get .loudest file")
     if np.any([key in max_params for key in ["delta_F0", "delta_F1", "tglitch"]]):
         raise RuntimeError("CFSv2 --outputLoudest cannot deal with glitch parameters.")
     if transientWindowType:
-        logging.warning(
+        logger.warning(
             "CFSv2 --outputLoudest always reports the maximum of the"
             " standard CW 2F-statistic, not the transient max2F."
         )

--- a/pyfstat/helper_functions.py
+++ b/pyfstat/helper_functions.py
@@ -65,7 +65,6 @@ def set_up_logger(outdir=None, label="pyfstat", log_level="INFO"):
         Instance of the Logger class.
 
     """
-    from . import __version__ as version
 
     if type(log_level) is str:
         try:
@@ -90,23 +89,22 @@ def set_up_logger(outdir=None, label="pyfstat", log_level="INFO"):
         logger.addHandler(stream_handler)
 
     if any([type(h) == logging.FileHandler for h in logger.handlers]) is False:
-        if label:
-            if outdir:
-                if not os.path.exists(outdir):
-                    os.makedirs(outdir, exist_ok=True)
-            else:
-                outdir = "."
+        if label and outdir:
+            if not os.path.exists(outdir):
+                os.makedirs(outdir, exist_ok=True)
             log_file = os.path.join(outdir, f"{label}.log")
+            logger.info(f"Additionally logging to file: {log_file}")
             file_handler = logging.FileHandler(log_file)
             file_handler.setFormatter(common_formatter)
-
             file_handler.setLevel(level)
             logger.addHandler(file_handler)
+            # need the following because the file didn't catch any previous version logs yet
+            logger_file_only = logging.Logger("pyfstat")
+            logger_file_only.addHandler(file_handler)
+            logger_file_only.info(f"Running PyFstat version {get_version_string()}")
 
     for handler in logger.handlers:
         handler.setLevel(level)
-
-    logger.info(f"Running PyFstat version {version}")
 
     return logger
 

--- a/pyfstat/helper_functions.py
+++ b/pyfstat/helper_functions.py
@@ -311,7 +311,7 @@ def get_comb_values(F0, frequencies, twoF, period, N=4):
     return comb_frequencies, twoF[comb_idxs], freq_err * np.ones(len(comb_idxs))
 
 
-def run_commandline(cl, log_level=20, raise_error=True, return_output=True):
+def run_commandline(cl, raise_error=True, return_output=True):
     """Run a string cmd as a subprocess, check for errors and return output.
 
     Parameters
@@ -338,7 +338,7 @@ def run_commandline(cl, log_level=20, raise_error=True, return_output=True):
         0 on failed execution if `raise_error=False`.
     """
 
-    logging.log(log_level, "Now executing: " + cl)
+    logger.info("Now executing: " + cl)
     if "|" in cl:
         logger.warning(
             "Pipe ('|') found in commandline, errors may not be" " properly caught!"
@@ -354,9 +354,9 @@ def run_commandline(cl, log_level=20, raise_error=True, return_output=True):
         else:
             subprocess.check_call(cl, shell=True)
     except subprocess.CalledProcessError as e:
-        logging.log(40, "Execution failed: {}".format(e))
+        logger.error("Execution failed: {}".format(e))
         if e.output:
-            logging.log(40, e.output)
+            logger.error(e.output)
         if raise_error:
             raise
         elif return_output:

--- a/pyfstat/helper_functions.py
+++ b/pyfstat/helper_functions.py
@@ -42,22 +42,22 @@ def set_up_matplotlib_defaults():
 
 def set_up_logger(outdir=None, label="pyfstat", log_level="INFO"):
     """
-    Setup the logger.
-    Based on the implementation in Nessai:
-    https://github.com/mj-will/nessai/blob/main/nessai/utils/logging.py
-    Parameters
-    ----------
-    outdir : str, optional
-        Path of to outdir directory.
-    label : str, optional
-        Label for this instance of the logger.
-        Defaults to `pyfstat`, which is the "root" logger of this package.
-    log_level : {'ERROR', 'WARNING', 'INFO', 'DEBUG'}, optional
-        Level of logging passed to logger.
-    Returns
-    -------
+     Setup the logger.
+     Based on the implementation in Nessai:
+     https://github.com/mj-will/nessai/blob/main/nessai/utils/logging.py
+     Parameters
+     ----------
+     outdir : str, optional
+         Path of to outdir directory.
+     label : str, optional
+         Label for this instance of the logger.
+         Defaults to `pyfstat`, which is the "root" logger of this package.
+     log_level : {'ERROR', 'WARNING', 'INFO', 'DEBUG'}, optional
+         Level of logging passed to logger.
+     Returns
+     -------
     :obj:`logging.Logger`
-        Instance of the Logger class.
+         Instance of the Logger class.
     """
     from . import __version__ as version
 
@@ -72,14 +72,14 @@ def set_up_logger(outdir=None, label="pyfstat", log_level="INFO"):
     logger = logging.getLogger("pyfstat")
     logger.setLevel(level)
 
+    common_formatter = logging.Formatter(
+        "%(asctime)s %(name)s %(levelname)-8s: %(message)s",
+        datefmt="%m-%d %H:%M",
+    )
+
     if any([type(h) == logging.StreamHandler for h in logger.handlers]) is False:
         stream_handler = logging.StreamHandler()
-        stream_handler.setFormatter(
-            logging.Formatter(
-                "%(asctime)s %(name)s %(levelname)-8s: %(message)s",
-                datefmt="%m-%d %H:%M",
-            )
-        )
+        stream_handler.setFormatter(common_formatter)
         stream_handler.setLevel(level)
         logger.addHandler(stream_handler)
 
@@ -92,11 +92,7 @@ def set_up_logger(outdir=None, label="pyfstat", log_level="INFO"):
                 outdir = "."
             log_file = os.path.join(outdir, f"{label}.log")
             file_handler = logging.FileHandler(log_file)
-            file_handler.setFormatter(
-                logging.Formatter(
-                    "%(asctime)s %(levelname)-8s: %(message)s", datefmt="%H:%M"
-                )
-            )
+            file_handler.setFormatter(common_formatter)
 
             file_handler.setLevel(level)
             logger.addHandler(file_handler)

--- a/pyfstat/injection_parameters.py
+++ b/pyfstat/injection_parameters.py
@@ -6,6 +6,8 @@ from typing import Union
 import numpy as np
 from attrs import Factory, define, field
 
+logger = logging.getLogger(__name__)
+
 isotropic_amplitude_priors = {
     "cosi": {"uniform": {"low": -1.0, "high": 1.0}},
     "psi": {"uniform": {"low": -0.25 * np.pi, "high": 0.25 * np.pi}},
@@ -110,7 +112,7 @@ class AllSkyInjectionParametersGenerator(InjectionParametersGenerator):
 
         for key in sky_priors:
             if key in priors_input_format:
-                logging.warning(
+                logger.warning(
                     f"Found {key} key in input priors with value {priors_input_format[key]}.\n"
                     "Overwritting to produce uniform samples across the sky."
                 )

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -1663,7 +1663,7 @@ class FrequencyModulatedArtifactWriter(Writer):
         if self.randSeed:
             cl_mfd.append("--randSeed={}".format(self.randSeed))
         cl_mfd = " ".join(cl_mfd)
-        helper_functions.run_commandline(cl_mfd, log_level=10)
+        helper_functions.run_commandline(cl_mfd)
 
 
 class FrequencyAmplitudeModulatedArtifactWriter(FrequencyModulatedArtifactWriter):

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -10,7 +10,7 @@ import lal
 import lalpulsar
 import numpy as np
 from tqdm import tqdm, trange
-from tqdm.contribu.logging import logging_redirect_tqdm
+from tqdm.contrib.logging import logging_redirect_tqdm
 
 import pyfstat.helper_functions as helper_functions
 from pyfstat import injection_parameters

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -57,6 +57,7 @@ import numpy as np
 from ptemcee import Sampler as PTSampler
 from scipy.stats import lognorm
 from tqdm import tqdm
+from tqdm.contrib.logging import logging_redirect_tqdm
 
 import pyfstat.core as core
 import pyfstat.helper_functions as helper_functions
@@ -506,10 +507,11 @@ class MCMCSearch(BaseSearchClass):
         self.scatter_val = scatter_val
 
     def _run_sampler(self, p0, nprod=0, nburn=0, window=50):
-        for result in tqdm(
-            self.sampler.sample(p0, iterations=nburn + nprod), total=nburn + nprod
-        ):
-            pass
+        with logging_redirect_tqdm():
+            for result in tqdm(
+                self.sampler.sample(p0, iterations=nburn + nprod), total=nburn + nprod
+            ):
+                pass
 
         self.mean_acceptance_fraction = np.mean(
             self.sampler.acceptance_fraction, axis=1

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -63,6 +63,8 @@ import pyfstat.helper_functions as helper_functions
 import pyfstat.optimal_setup_functions as optimal_setup_functions
 from pyfstat.core import BaseSearchClass
 
+logger = logging.getLogger(__name__)
+
 
 class MCMCSearch(BaseSearchClass):
     """
@@ -250,14 +252,13 @@ class MCMCSearch(BaseSearchClass):
 
         os.makedirs(outdir, exist_ok=True)
         self.output_file_header = self.get_output_file_header()
-        self._add_log_file(self.output_file_header)
-        logging.info("Set-up MCMC search for model {}".format(self.label))
+        logger.info("Set-up MCMC search for model {}".format(self.label))
         if sftfilepattern:
-            logging.info("Using data {}".format(self.sftfilepattern))
+            logger.info("Using data {}".format(self.sftfilepattern))
         else:
-            logging.info("No sftfilepattern given")
+            logger.info("No sftfilepattern given")
         if injectSources:
-            logging.info("Inject sources: {}".format(injectSources))
+            logger.info("Inject sources: {}".format(injectSources))
         self.pickle_path = os.path.join(self.outdir, self.label + "_saved_data.p")
         self._unpack_input_theta()
         self.ndim = len(self.theta_keys)
@@ -302,11 +303,11 @@ class MCMCSearch(BaseSearchClass):
             self.likelihoodcoef = np.log(70.0 / self.rhohatmax**4)
 
     def _log_input(self):
-        logging.info("theta_prior = {}".format(self.theta_prior))
-        logging.info("nwalkers={}".format(self.nwalkers))
-        logging.info("nsteps = {}".format(self.nsteps))
-        logging.info("ntemps = {}".format(self.ntemps))
-        logging.info("log10beta_min = {}".format(self.log10beta_min))
+        logger.info("theta_prior = {}".format(self.theta_prior))
+        logger.info("nwalkers={}".format(self.nwalkers))
+        logger.info("nsteps = {}".format(self.nsteps))
+        logger.info("ntemps = {}".format(self.ntemps))
+        logger.info("log10beta_min = {}".format(self.log10beta_min))
 
     def _get_search_ranges(self):
         """take prior widths as proxy "search ranges" to allow covering band estimate"""
@@ -314,7 +315,7 @@ class MCMCSearch(BaseSearchClass):
             normal_stds = 3  # this might not always be enough
             prior_bounds, norm_trunc_warn = self._get_prior_bounds(normal_stds)
             if norm_trunc_warn:
-                logging.warning(
+                logger.warning(
                     "Gaussian priors (normal / half-normal) have been truncated"
                     " at {:f} standard deviations for estimating the coverage"
                     " frequency band. If sampling fails at any point, please"
@@ -335,7 +336,7 @@ class MCMCSearch(BaseSearchClass):
             return None
 
     def _initiate_search_object(self):
-        logging.info("Setting up search object")
+        logger.info("Setting up search object")
         search_ranges = self._get_search_ranges()
         self.search = core.ComputeFstat(
             tref=self.tref,
@@ -445,10 +446,10 @@ class MCMCSearch(BaseSearchClass):
 
     def _check_initial_points(self, p0):
         for nt in range(self.ntemps):
-            logging.info("Checking temperature {} chains".format(nt))
+            logger.info("Checking temperature {} chains".format(nt))
             num = sum(self._evaluate_logpost(p0[nt]) == -np.inf)
             if num > 0:
-                logging.warning(
+                logger.warning(
                     "Of {} initial values, {} are -np.inf due to the prior".format(
                         len(p0[0]), num
                     )
@@ -456,7 +457,7 @@ class MCMCSearch(BaseSearchClass):
                 p0 = self._generate_new_p0_to_fix_initial_points(p0, nt)
 
     def _generate_new_p0_to_fix_initial_points(self, p0, nt):
-        logging.info("Attempting to correct intial values")
+        logger.info("Attempting to correct intial values")
         init_logpost = self._evaluate_logpost(p0[nt])
         idxs = np.arange(self.nwalkers)[init_logpost == -np.inf]
         count = 0
@@ -469,9 +470,9 @@ class MCMCSearch(BaseSearchClass):
             count += 1
 
         if sum(init_logpost == -np.inf) > 0:
-            logging.info("Failed to fix initial priors")
+            logger.info("Failed to fix initial priors")
         else:
-            logging.info("Suceeded to fix initial priors")
+            logger.info("Suceeded to fix initial priors")
 
         return p0
 
@@ -496,7 +497,7 @@ class MCMCSearch(BaseSearchClass):
             deviation `diag(scatter_val * p)`.
         """
 
-        logging.info(
+        logger.info(
             "Setting up initialisation with nburn0={}, scatter_val={}".format(
                 nburn0, scatter_val
             )
@@ -513,12 +514,12 @@ class MCMCSearch(BaseSearchClass):
         self.mean_acceptance_fraction = np.mean(
             self.sampler.acceptance_fraction, axis=1
         )
-        logging.info(
+        logger.info(
             "Mean acceptance fraction: {}".format(self.mean_acceptance_fraction)
         )
         if self.ntemps > 1:
             self.tswap_acceptance_fraction = self.sampler.tswap_acceptance_fraction
-            logging.info(
+            logger.info(
                 "Tswap acceptance fraction: {}".format(
                     self.sampler.tswap_acceptance_fraction
                 )
@@ -526,7 +527,7 @@ class MCMCSearch(BaseSearchClass):
         self.autocorr_time = self._get_autocorr_time(
             sampler=self.sampler, window=window
         )
-        logging.info("Autocorrelation length: {}".format(self.autocorr_time))
+        logger.info("Autocorrelation length: {}".format(self.autocorr_time))
 
     def _get_autocorr_time(self, sampler, window=50):
         """
@@ -677,7 +678,7 @@ class MCMCSearch(BaseSearchClass):
             if getattr(self, "nsegs", 1) > 1:
                 time += (tau0C + tau0T * Nsfts) * self.nsegs * numb_evals
 
-        logging.info(
+        logger.info(
             "Estimated run-time = {} s = {:1.0f}:{:1.0f} m".format(
                 time, *divmod(time, 60)
             )
@@ -732,7 +733,7 @@ class MCMCSearch(BaseSearchClass):
 
         self.old_data_is_okay_to_use = self._check_old_data_is_okay_to_use()
         if self.old_data_is_okay_to_use is True:
-            logging.warning("Using saved data from {}".format(self.pickle_path))
+            logger.warning("Using saved data from {}".format(self.pickle_path))
             d = self.get_saved_data_dictionary()
             self.samples = d["samples"]
             self.lnprobs = d["lnprobs"]
@@ -764,7 +765,7 @@ class MCMCSearch(BaseSearchClass):
         # Run initialisation steps if required
         ninit_steps = len(self.nsteps) - 2
         for j, n in enumerate(self.nsteps[:-2]):
-            logging.info(
+            logger.info(
                 "Running {}/{} initialisation with {} steps".format(j, ninit_steps, n)
             )
             self._run_sampler(p0, nburn=n, window=window)
@@ -779,7 +780,7 @@ class MCMCSearch(BaseSearchClass):
                     )
                     plt.close(walker_fig)
                 except Exception as e:
-                    logging.warning(
+                    logger.warning(
                         "Failed to plot initialisation walkers due to Error {}".format(
                             e
                         )
@@ -795,7 +796,7 @@ class MCMCSearch(BaseSearchClass):
         else:
             nburn = 0
         nprod = self.nsteps[-1]
-        logging.info("Running final burn and prod with {} steps".format(nburn + nprod))
+        logger.info("Running final burn and prod with {} steps".format(nburn + nprod))
         self._run_sampler(p0, nburn=nburn, nprod=nprod)
 
         samples = self.sampler.chain[0, :, nburn:, :].reshape((-1, self.ndim))
@@ -821,7 +822,7 @@ class MCMCSearch(BaseSearchClass):
                 )
                 walkers_fig.tight_layout()
             except Exception as e:
-                logging.warning("Failed to plot walkers due to Error {}".format(e))
+                logger.warning("Failed to plot walkers due to Error {}".format(e))
             if (walker_plot_args.get("fig") is not None) and (
                 walker_plot_args.get("axes") is not None
             ):
@@ -834,7 +835,7 @@ class MCMCSearch(BaseSearchClass):
                     )
                     plt.close(walkers_fig)
                 except Exception as e:
-                    logging.warning(
+                    logger.warning(
                         "Failed to save walker plots due to Error {}".format(e)
                     )
 
@@ -990,7 +991,7 @@ class MCMCSearch(BaseSearchClass):
 
             missing_keys = set(self.theta_keys) - kwargs["truths"].keys()
             if missing_keys:
-                logging.warning(
+                logger.warning(
                     f"plot_corner(): Missing keys {missing_keys} in 'truths' dictionary,"
                     " argument will be ignored."
                 )
@@ -1121,7 +1122,7 @@ class MCMCSearch(BaseSearchClass):
         try:
             import chainconsumer
         except ImportError:
-            logging.warning(
+            logger.warning(
                 "Could not import 'chainconsumer' package, please install it to use this method."
             )
             return
@@ -1135,7 +1136,7 @@ class MCMCSearch(BaseSearchClass):
                 raise ValueError("'truth' must be a dictionary.")
             missing_keys = np.setdiff1d(self.theta_keys, list(kwargs["truth"].keys()))
             if len(missing_keys) > 0:
-                logging.warning(
+                logger.warning(
                     "plot_chainconsumer(): Missing keys {} in 'truth' dictionary,"
                     " argument will be ignored.".format(missing_keys)
                 )
@@ -1298,7 +1299,7 @@ class MCMCSearch(BaseSearchClass):
         injection_parameters = injection_parameters or {}
         missing_keys = set(self.theta_keys) - injection_parameters.keys()
         if missing_keys:
-            logging.warning(
+            logger.warning(
                 f"plot_prior_posterior(): Missing keys {missing_keys} in 'injection_parameters',"
                 " no injection parameters will be highlighted."
             )
@@ -1372,7 +1373,7 @@ class MCMCSearch(BaseSearchClass):
         Unlike the core function, here savefig=True is the default,
         for consistency with other MCMC plotting functions.
         """
-        logging.info("Getting cumulative 2F")
+        logger.info("Getting cumulative 2F")
         d, maxtwoF = self.get_max_twoF()
         for key, val in self.theta_prior.items():
             if key not in d:
@@ -1463,7 +1464,7 @@ class MCMCSearch(BaseSearchClass):
                 x, s=kwargs["scale"], scale=np.exp(kwargs["loc"])
             )
         else:
-            logging.info("kwargs:", kwargs)
+            logger.info("kwargs:", kwargs)
             raise ValueError("Prior pdf type {:s} unknown.".format(kwargs["type"]))
 
     def _generate_rv(self, **kwargs):
@@ -1511,7 +1512,7 @@ class MCMCSearch(BaseSearchClass):
 
             missing_keys = set(self.theta_keys) - injection_parameters.keys()
             if missing_keys:
-                logging.warning(
+                logger.warning(
                     f"plot_walkers(): Missing keys {missing_keys} in 'injection_parameters',"
                     " argument will be ignored."
                 )
@@ -1546,7 +1547,7 @@ class MCMCSearch(BaseSearchClass):
         if len(shape) == 4:
             ntemps, nwalkers, nsteps, ndim = shape
             if temp < ntemps:
-                logging.info("Plotting temperature {} chains".format(temp))
+                logger.info("Plotting temperature {} chains".format(temp))
             else:
                 raise ValueError(
                     ("Requested temperature {} outside of" "available range").format(
@@ -1646,7 +1647,7 @@ class MCMCSearch(BaseSearchClass):
                             detstat_burnin, bins=50, histtype="step", color="C3"
                         )
                     except ValueError:
-                        logging.info(
+                        logger.info(
                             "Histogram of detection statistic failed, "
                             "most likely all values were the same."
                         )
@@ -1660,7 +1661,7 @@ class MCMCSearch(BaseSearchClass):
                     ) / self.likelihooddetstatmultiplier
                     axes[-1].hist(detstat, bins=50, histtype="step", color="k")
                 except ValueError:
-                    logging.info(
+                    logger.info(
                         "Histogram of detection statistic failed, "
                         "most likely all values were the same."
                     )
@@ -1702,7 +1703,7 @@ class MCMCSearch(BaseSearchClass):
         """Generate a set of init vals for the walkers"""
 
         if type(self.theta_initial) == dict:
-            logging.info("Generate initial values from initial dictionary")
+            logger.info("Generate initial values from initial dictionary")
             if hasattr(self, "nglitch") and self.nglitch > 1:
                 raise ValueError("Initial dict not implemented for nglitch>1")
             p0 = [
@@ -1716,7 +1717,7 @@ class MCMCSearch(BaseSearchClass):
                 for j in range(self.ntemps)
             ]
         elif self.theta_initial is None:
-            logging.info("Generate initial values from prior dictionary")
+            logger.info("Generate initial values from prior dictionary")
             p0 = [
                 [
                     [
@@ -1746,17 +1747,17 @@ class MCMCSearch(BaseSearchClass):
 
         # General warnings about the state of lnp
         if np.any(np.isnan(lnp)):
-            logging.warning(
+            logger.warning(
                 "Of {} lnprobs {} are nan".format(np.shape(lnp), np.sum(np.isnan(lnp)))
             )
         if np.any(np.isposinf(lnp)):
-            logging.warning(
+            logger.warning(
                 "Of {} lnprobs {} are +np.inf".format(
                     np.shape(lnp), np.sum(np.isposinf(lnp))
                 )
             )
         if np.any(np.isneginf(lnp)):
-            logging.warning(
+            logger.warning(
                 "Of {} lnprobs {} are -np.inf".format(
                     np.shape(lnp), np.sum(np.isneginf(lnp))
                 )
@@ -1768,7 +1769,7 @@ class MCMCSearch(BaseSearchClass):
         p = pF[idx]
         p0 = self._generate_scattered_p0(p)
 
-        logging.info(
+        logger.info(
             (
                 "Gen. new p0 from pos {} which had det. stat.={:2.1f}"
                 " and lnp={:2.1f}"
@@ -1800,7 +1801,7 @@ class MCMCSearch(BaseSearchClass):
         d["all_lnlikelihood"] = all_lnlikelihood
 
         if os.path.isfile(self.pickle_path):
-            logging.info(
+            logger.info(
                 "Saving backup of {} as {}.old".format(
                     self.pickle_path, self.pickle_path
                 )
@@ -1823,7 +1824,7 @@ class MCMCSearch(BaseSearchClass):
 
     def _check_old_data_is_okay_to_use(self):
         if os.path.isfile(self.pickle_path) is False:
-            logging.info("No pickled data found")
+            logger.info("No pickled data found")
             return False
 
         if self.sftfilepattern is not None:
@@ -1831,7 +1832,7 @@ class MCMCSearch(BaseSearchClass):
                 [os.path.getmtime(f) for f in self._get_list_of_matching_sfts()]
             )
             if os.path.getmtime(self.pickle_path) < oldest_sft:
-                logging.info("Pickled data outdates sft files")
+                logger.info("Pickled data outdates sft files")
                 return False
 
         old_d = self.get_saved_data_dictionary().copy()
@@ -1859,16 +1860,16 @@ class MCMCSearch(BaseSearchClass):
         if len(mod_keys) == 0:
             return True
         else:
-            logging.warning("Saved data differs from requested")
-            logging.info("Differences found in following keys:")
+            logger.warning("Saved data differs from requested")
+            logger.info("Differences found in following keys:")
             for key in mod_keys:
                 if len(key) == 3:
                     if np.isscalar(key[1]) or key[0] == "nsteps":
-                        logging.info("    {} : {} -> {}".format(*key))
+                        logger.info("    {} : {} -> {}".format(*key))
                     else:
-                        logging.info("    " + key[0])
+                        logger.info("    " + key[0])
                 else:
-                    logging.info(key)
+                    logger.info(key)
             return False
 
     def _get_savetxt_fmt_dict(self):
@@ -1893,7 +1894,7 @@ class MCMCSearch(BaseSearchClass):
         Export MCMC samples into a text file using `numpy.savetxt`.
         """
         self.samples_file = os.path.join(self.outdir, self.label + "_samples.dat")
-        logging.info("Exporting samples to {}".format(self.samples_file))
+        logger.info("Exporting samples to {}".format(self.samples_file))
         header = "\n".join(self.output_file_header)
         header += "\n" + " ".join(self.output_keys)
         outfmt = self._get_savetxt_gmt_list()
@@ -1959,11 +1960,11 @@ class MCMCSearch(BaseSearchClass):
                 "Object has no self.lnlikes attribute, please execute .run() first."
             )
         if any(np.isposinf(self.lnlikes)):
-            logging.info("lnlike values contain positive infinite values")
+            logger.info("lnlike values contain positive infinite values")
         if any(np.isneginf(self.lnlikes)):
-            logging.info("lnlike values contain negative infinite values")
+            logger.info("lnlike values contain negative infinite values")
         if any(np.isnan(self.lnlikes)):
-            logging.info("lnlike values contain nan")
+            logger.info("lnlike values contain nan")
         idxs = np.isfinite(self.lnlikes)
         jmax = np.nanargmax(self.lnlikes[idxs])
         d = OrderedDict()
@@ -2066,7 +2067,7 @@ class MCMCSearch(BaseSearchClass):
                         edges.append(bound)
                         fracs.append(str(100 * float(np.sum(bools)) / len(bools)))
                 if len(edges) > 0:
-                    logging.warning(
+                    logger.warning(
                         "{}% of the {} posterior is railing on the {} edges".format(
                             "% & ".join(fracs), k, " & ".join(edges)
                         )
@@ -2088,11 +2089,11 @@ class MCMCSearch(BaseSearchClass):
         if method in ["median", "mean"]:
             summary_stats = self.get_summary_stats()
             filename = os.path.join(self.outdir, self.label + "_" + method + ".par")
-            logging.info("Writing {} using {} parameters.".format(filename, method))
+            logger.info("Writing {} using {} parameters.".format(filename, method))
         elif method == "twoFmax":
             max_twoF_d, max_twoF = self.get_max_twoF()
             filename = os.path.join(self.outdir, self.label + "_max2F.par")
-            logging.info("Writing {} at max twoF = {}.".format(filename, max_twoF))
+            logger.info("Writing {} at max twoF = {}.".format(filename, max_twoF))
         else:
             raise ValueError("Method '{}' not supported.".format(method))
 
@@ -2126,7 +2127,7 @@ class MCMCSearch(BaseSearchClass):
         for key in ["transient-t0Epoch", "transient-t0Offset", "transient-tau"]:
             if key in max_params and not int(max_params[key]) == max_params[key]:
                 rounded = int(round(max_params[key]))
-                logging.warning(
+                logger.warning(
                     "Rounding {:s}={:f} to {:d} for CFSv2 call.".format(
                         key, max_params[key], rounded
                     )
@@ -2194,22 +2195,22 @@ class MCMCSearch(BaseSearchClass):
         """Prints a summary of the max twoF found to the terminal"""
         max_twoFd, max_twoF = self.get_max_twoF()
         summary_stats = self.get_summary_stats()
-        logging.info("Summary:")
+        logger.info("Summary:")
         if hasattr(self, "theta0_idx"):
-            logging.info("theta0 index: {}".format(self.theta0_idx))
-        logging.info("Max twoF: {} with parameters:".format(max_twoF))
+            logger.info("theta0 index: {}".format(self.theta0_idx))
+        logger.info("Max twoF: {} with parameters:".format(max_twoF))
         for k in np.sort(list(max_twoFd.keys())):
-            logging.info("  {:10s} = {:1.9e}".format(k, max_twoFd[k]))
-        logging.info("Mean +- std for production values:")
+            logger.info("  {:10s} = {:1.9e}".format(k, max_twoFd[k]))
+        logger.info("Mean +- std for production values:")
         for k in np.sort(list(summary_stats.keys())):
-            logging.info(
+            logger.info(
                 "  {:10s} = {:1.9e} +/- {:1.9e}".format(
                     k, summary_stats[k]["mean"], summary_stats[k]["std"]
                 )
             )
-        logging.info("Median and 90% quantiles for production values:")
+        logger.info("Median and 90% quantiles for production values:")
         for k in np.sort(list(summary_stats.keys())):
-            logging.info(
+            logger.info(
                 "  {:10s} = {:1.9e} - {:1.9e} + {:1.9e}".format(
                     k,
                     summary_stats[k]["median"],
@@ -2217,7 +2218,7 @@ class MCMCSearch(BaseSearchClass):
                     summary_stats[k]["upper90"] - summary_stats[k]["median"],
                 )
             )
-        logging.info("\n")
+        logger.info("\n")
 
     def _CF_twoFmax(self, theta, twoFmax, ntrials):
         Fmax = twoFmax / 2.0
@@ -2288,7 +2289,7 @@ class MCMCSearch(BaseSearchClass):
         deltaTs = np.diff(tboundaries)
         ntrials = [time_trials + delta_F0 * dT for dT in deltaTs]
         p_val = self._p_val_twoFhat(max_twoF, ntrials)
-        logging.info("p-value = {}".format(p_val))
+        logger.info("p-value = {}".format(p_val))
         return p_val
 
     def compute_evidence(self, make_plots=False, write_to_file=None):
@@ -2315,7 +2316,7 @@ class MCMCSearch(BaseSearchClass):
         betas = betas[::-1]
 
         if any(np.isinf(mean_lnlikes)):
-            logging.warning(
+            logger.warning(
                 "mean_lnlikes contains inf: recalculating without"
                 " the {} infs".format(len(betas[np.isinf(mean_lnlikes)]))
             )
@@ -2328,7 +2329,7 @@ class MCMCSearch(BaseSearchClass):
         z2 = np.trapz(mean_lnlikes[::-1][::2][::-1], betas[::-1][::2][::-1])
         log10evidence_err = np.abs(z1 - z2) / np.log(10)
 
-        logging.info(
+        logger.info(
             "log10 evidence for {} = {} +/- {}".format(
                 self.label, log10evidence, log10evidence_err
             )
@@ -2509,8 +2510,7 @@ class MCMCGlitchSearch(MCMCSearch):
         self._set_init_params_dict(locals())
         os.makedirs(outdir, exist_ok=True)
         self.output_file_header = self.get_output_file_header()
-        self._add_log_file(self.output_file_header)
-        logging.info(
+        logger.info(
             (
                 "Set-up MCMC glitch search with {} glitches for model {}" " on data {}"
             ).format(self.nglitch, self.label, self.sftfilepattern)
@@ -2542,7 +2542,7 @@ class MCMCGlitchSearch(MCMCSearch):
         self.likelihoodcoef *= self.nglitch + 1
 
     def _initiate_search_object(self):
-        logging.info("Setting up search object")
+        logger.info("Setting up search object")
         search_ranges = self._get_search_ranges()
         self.search = core.SemiCoherentGlitchSearch(
             label=self.label,
@@ -2710,7 +2710,7 @@ class MCMCGlitchSearch(MCMCSearch):
             If false, return an axis object.
         """
 
-        logging.info("Getting cumulative 2F")
+        logger.info("Getting cumulative 2F")
         fig, ax = plt.subplots()
         d, maxtwoF = self.get_max_twoF()
         for key, val in self.theta_prior.items():
@@ -2736,7 +2736,7 @@ class MCMCGlitchSearch(MCMCSearch):
             ts = tboundaries[j]
             te = tboundaries[j + 1]
             if (te - ts) / 86400 < 5:
-                logging.info("Period too short to perform cumulative search")
+                logger.info("Period too short to perform cumulative search")
                 continue
             if j < self.theta0_idx:
                 summed_deltaF0 = np.sum(delta_F0s[j : self.theta0_idx])
@@ -2862,8 +2862,7 @@ class MCMCSemiCoherentSearch(MCMCSearch):
 
         os.makedirs(outdir, exist_ok=True)
         self.output_file_header = self.get_output_file_header()
-        self._add_log_file(self.output_file_header)
-        logging.info(
+        logger.info(
             ("Set-up MCMC semi-coherent search for model {} on data" "{}").format(
                 self.label, self.sftfilepattern
             )
@@ -2883,7 +2882,7 @@ class MCMCSemiCoherentSearch(MCMCSearch):
         if self.nsegs:
             self._set_likelihoodcoef()
         else:
-            logging.info("Value `nsegs` not yet provided")
+            logger.info("Value `nsegs` not yet provided")
 
     def _set_likelihoodcoef(self):
         """Additional constant terms to turn a detection statistic into a likelihood.
@@ -2911,7 +2910,7 @@ class MCMCSemiCoherentSearch(MCMCSearch):
         return d
 
     def _initiate_search_object(self):
-        logging.info("Setting up search object")
+        logger.info("Setting up search object")
         search_ranges = self._get_search_ranges()
         self.search = core.SemiCoherentSearch(
             label=self.label,
@@ -3018,8 +3017,7 @@ class MCMCFollowUpSearch(MCMCSemiCoherentSearch, core.DeprecatedClass):
 
         os.makedirs(outdir, exist_ok=True)
         self.output_file_header = self.get_output_file_header()
-        self._add_log_file(self.output_file_header)
-        logging.info(
+        logger.info(
             ("Set-up MCMC semi-coherent search for model {} on data" "{}").format(
                 self.label, self.sftfilepattern
             )
@@ -3039,7 +3037,7 @@ class MCMCFollowUpSearch(MCMCSemiCoherentSearch, core.DeprecatedClass):
         if self.nsegs:
             self._set_likelihoodcoef()
         else:
-            logging.info("Value `nsegs` not yet provided")
+            logger.info("Value `nsegs` not yet provided")
 
     def _get_data_dictionary_to_save(self):
         d = dict(
@@ -3099,7 +3097,7 @@ class MCMCFollowUpSearch(MCMCSemiCoherentSearch, core.DeprecatedClass):
 
         self.old_data_is_okay_to_use = self._check_old_data_is_okay_to_use()
         if self.old_data_is_okay_to_use is True:
-            logging.warning("Using saved data from {}".format(self.pickle_path))
+            logger.warning("Using saved data from {}".format(self.pickle_path))
             d = self.get_saved_data_dictionary()
             self.samples = d["samples"]
             self.lnprobs = d["lnprobs"]
@@ -3131,13 +3129,13 @@ class MCMCFollowUpSearch(MCMCSemiCoherentSearch, core.DeprecatedClass):
             )
 
             Tcoh = (self.maxStartTime - self.minStartTime) / nseg / 86400.0
-            logging.info(
+            logger.info(
                 (
                     "Running {}/{} with {} steps and {} nsegs " "(Tcoh={:1.2f} days)"
                 ).format(j + 1, len(run_setup), (nburn, nprod), nseg, Tcoh)
             )
             self._run_sampler(p0, nburn=nburn, nprod=nprod, window=window)
-            logging.info(
+            logger.info(
                 "Max detection statistic of run was {}".format(
                     np.max(self.sampler.loglikelihood)
                 )
@@ -3151,7 +3149,7 @@ class MCMCFollowUpSearch(MCMCSemiCoherentSearch, core.DeprecatedClass):
                     for ax in walkers_axes[: self.ndim]:
                         ax.axvline(nsteps_total, color="k", ls="--", lw=0.25)
                 except Exception as e:
-                    logging.warning("Failed to plot walkers due to Error {}".format(e))
+                    logger.warning("Failed to plot walkers due to Error {}".format(e))
 
             nsteps_total += nburn + nprod
 
@@ -3189,7 +3187,7 @@ class MCMCFollowUpSearch(MCMCSemiCoherentSearch, core.DeprecatedClass):
             try:
                 walkers_fig.tight_layout()
             except Exception as e:
-                logging.warning(
+                logger.warning(
                     "Failed to set tight layout for walkers plot due to Error {}".format(
                         e
                     )
@@ -3206,12 +3204,12 @@ class MCMCFollowUpSearch(MCMCSemiCoherentSearch, core.DeprecatedClass):
                     )
                     plt.close(walkers_fig)
                 except Exception as e:
-                    logging.warning(
+                    logger.warning(
                         "Failed to save walker plots due to Error {}".format(e)
                     )
 
     def _update_search_object(self):
-        logging.info("Update search object")
+        logger.info("Update search object")
         self.search.init_computefstatistic()
 
     def init_run_setup(
@@ -3238,7 +3236,7 @@ class MCMCFollowUpSearch(MCMCSemiCoherentSearch, core.DeprecatedClass):
             Use `MCMCFollowUpSearch.read_setup_input_file` to read a previous
             setup file.
         log_table: bool
-            Log follow-up setup using `logging.info` as a table.
+            Log follow-up setup using `logger.info` as a table.
         gen_tex_table: bool
             Dump follow-up setup into a text file as a tex table.
             File is constructed as `os.path.join(self.outdir, self.label + "_run_setup.tex")`.
@@ -3254,14 +3252,14 @@ class MCMCFollowUpSearch(MCMCSemiCoherentSearch, core.DeprecatedClass):
                 " from which the optimal run_setup can be estimated"
             )
         if run_setup is None:
-            logging.info("No run_setup provided")
+            logger.info("No run_setup provided")
 
             run_setup_input_file = os.path.join(
                 self.outdir, self.label + "_run_setup.p"
             )
 
             if os.path.isfile(run_setup_input_file):
-                logging.info(
+                logger.info(
                     "Checking old setup input file {}".format(run_setup_input_file)
                 )
                 old_setup = self.read_setup_input_file(run_setup_input_file)
@@ -3271,7 +3269,7 @@ class MCMCFollowUpSearch(MCMCSemiCoherentSearch, core.DeprecatedClass):
                     Nsegs0=Nsegs0,
                     theta_prior=self.theta_prior,
                 ):
-                    logging.info(
+                    logger.info(
                         "Using old setup with NstarMax={}, Nsegs0={}".format(
                             NstarMax, Nsegs0
                         )
@@ -3309,7 +3307,7 @@ class MCMCFollowUpSearch(MCMCSemiCoherentSearch, core.DeprecatedClass):
             run_setup.append(((self.nsteps[0], self.nsteps[1]), nsegs_vals[-1], False))
 
         else:
-            logging.info("Calculating the number of templates for this setup")
+            logger.info("Calculating the number of templates for this setup")
             Nstar_vals = []
             for i, rs in enumerate(run_setup):
                 rs = list(rs)
@@ -3333,15 +3331,15 @@ class MCMCFollowUpSearch(MCMCSemiCoherentSearch, core.DeprecatedClass):
                     Nstar_vals.append(Nstar)
 
         if log_table:
-            logging.info("Using run-setup as follows:")
-            logging.info("Stage | nburn | nprod | nsegs | Tcoh d | resetp0 | Nstar")
+            logger.info("Using run-setup as follows:")
+            logger.info("Stage | nburn | nprod | nsegs | Tcoh d | resetp0 | Nstar")
             for i, rs in enumerate(run_setup):
                 Tcoh = (self.maxStartTime - self.minStartTime) / rs[1] / 86400
                 if Nstar_vals[i] is None:
                     vtext = "N/A"
                 else:
                     vtext = "{:0.3e}".format(int(Nstar_vals[i]))
-                logging.info(
+                logger.info(
                     "{} | {} | {} | {} | {} | {} | {}".format(
                         str(i).ljust(5),
                         str(rs[0][0]).ljust(5),
@@ -3380,7 +3378,7 @@ class MCMCFollowUpSearch(MCMCSemiCoherentSearch, core.DeprecatedClass):
                 f.write(r"\end{tabular}" + "\n")
 
         if setup_only:
-            logging.info("Exit as requested by setup_only flag")
+            logger.info("Exit as requested by setup_only flag")
             sys.exit()
         else:
             return run_setup
@@ -3415,9 +3413,9 @@ class MCMCFollowUpSearch(MCMCSemiCoherentSearch, core.DeprecatedClass):
             if all(truths):
                 return True
             else:
-                logging.info("Old setup doesn't match one of NstarMax, Nsegs0 or prior")
+                logger.info("Old setup doesn't match one of NstarMax, Nsegs0 or prior")
         except KeyError as e:
-            logging.info("Error found when comparing with old setup: {}".format(e))
+            logger.info("Error found when comparing with old setup: {}".format(e))
             return False
 
     def _get_p0_per_stage(self, reset_p0=False):
@@ -3483,7 +3481,7 @@ class MCMCTransientSearch(MCMCSearch):
     """
 
     def _initiate_search_object(self):
-        logging.info("Setting up search object")
+        logger.info("Setting up search object")
         if not self.transientWindowType:
             self.transientWindowType = "rect"
         search_ranges = self._get_search_ranges()

--- a/pyfstat/optimal_setup_functions.py
+++ b/pyfstat/optimal_setup_functions.py
@@ -14,6 +14,8 @@ import scipy.optimize
 
 import pyfstat.helper_functions as helper_functions
 
+logger = logging.getLogger(__name__)
+
 
 def get_optimal_setup(
     NstarMax, Nsegs0, tref, minStartTime, maxStartTime, prior, detector_names
@@ -50,14 +52,14 @@ def get_optimal_setup(
 
     """
 
-    logging.info(
+    logger.info(
         "Calculating optimal setup for NstarMax={}, Nsegs0={}".format(NstarMax, Nsegs0)
     )
 
     Nstar_0 = get_Nstar_estimate(
         Nsegs0, tref, minStartTime, maxStartTime, prior, detector_names
     )
-    logging.info("Stage {}, nsegs={}, Nstar={}".format(0, Nsegs0, int(Nstar_0)))
+    logger.info("Stage {}, nsegs={}, Nstar={}".format(0, Nsegs0, int(Nstar_0)))
 
     nsegs_vals = [Nsegs0]
     Nstar_vals = [Nstar_0]
@@ -71,7 +73,7 @@ def get_optimal_setup(
         nsegs_vals.append(nsegs_i)
         Nstar_vals.append(Nstar_i)
         i += 1
-        logging.info("Stage {}, nsegs={}, Nstar={}".format(i, nsegs_i, int(Nstar_i)))
+        logger.info("Stage {}, nsegs={}, Nstar={}".format(i, nsegs_i, int(Nstar_i)))
 
     return nsegs_vals, Nstar_vals
 
@@ -130,7 +132,7 @@ def _get_nsegs_ip1(
     res = scipy.optimize.minimize(
         f, 0.4 * nsegs_i, method="Powell", tol=1, options={"maxiter": 10}
     )
-    logging.info("{} with {} evaluations".format(res["message"], res["nfev"]))
+    logger.info("{} with {} evaluations".format(res["message"], res["nfev"]))
     nsegs_ip1 = int(res.x)
     if nsegs_ip1 == 0:
         nsegs_ip1 = 1
@@ -259,7 +261,7 @@ def get_Nstar_estimate(nsegs, tref, minStartTime, maxStartTime, prior, detector_
             ephemeris,
         )
     except RuntimeError as e:
-        logging.warning("Encountered run-time error {}".format(e))
+        logger.warning("Encountered run-time error {}".format(e))
         raise RuntimeError("Calculation of the SSkyMetric failed")
 
     if sky:
@@ -283,7 +285,7 @@ def get_Nstar_estimate(nsegs, tref, minStartTime, maxStartTime, prior, detector_
         dV = np.abs(np.linalg.det(parallelepiped[:j, :j]))
         sqrtdetG = np.sqrt(np.abs(np.linalg.det(g[:j, :j])))
         Nstars.append(sqrtdetG * dV)
-    logging.debug(
+    logger.debug(
         "Nstar for each dimension = {}".format(
             ", ".join(["{:1.1e}".format(n) for n in Nstars])
         )

--- a/pyfstat/snr.py
+++ b/pyfstat/snr.py
@@ -8,6 +8,8 @@ from attrs import define, field
 
 from pyfstat.helper_functions import get_ephemeris_files
 
+logger = logging.getLogger(__name__)
+
 
 @define(kw_only=True, slots=False)
 class SignalToNoiseRatio:
@@ -440,16 +442,16 @@ class DetectorStates:
                         "no comma-separated strings allowed."
                     )
 
-            logging.debug("Retrieving detectors from timestamps dictionary.")
+            logger.debug("Retrieving detectors from timestamps dictionary.")
             detectors = list(timestamps.keys())
             timestamps = timestamps.values()
 
         elif detectors is not None:
             if isinstance(detectors, str):
-                logging.debug("Converting `detectors` string to list")
+                logger.debug("Converting `detectors` string to list")
                 detectors = detectors.replace(" ", "").split(",")
 
-            logging.debug("Checking integrity of `timestamps`")
+            logger.debug("Checking integrity of `timestamps`")
             ts = np.array(timestamps)
             if ts.dtype == np.dtype("O") or ts.ndim > 1:
                 raise ValueError("`timestamps` is not a 1D list of numerical values")


### PR DESCRIPTION
This seems rather hacky but implements the following behaviour, which seems most user-friendly to me. But this is very much up for dicussion.

1. user does no logging config at all -> we do everything at info level on stdout with our preferred formatting, but tell them they can override it
2. user calls `pyfstat.set_up_logger()` -> behaviour as on the parent branch
3. user does their own config before importing pyfstat -> we respect it

The 3 cases can be tested with commenting in/out the relevant lines in `PyFstat_example_grid_search_F0.py`.

The main caveat (besides hackiness) is that 3 cares about order, the setup really needs to happen before `import pyfstat`.