### PR TITLE
Refurbish logging pytestconfig

### DIFF
--- a/pyfstat/__init__.py
+++ b/pyfstat/__init__.py
@@ -47,6 +47,6 @@ try:
     logger.info(f"Running PyFstat version {__version__}")
 except Exception as e:  # pragma: no cover
     print(
-        "Logging setup failed with exception: {e}\n"
+        f"Logging setup failed with exception: {e}\n"
         "Proceeding without default logging."
     )

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+log_cli = 1
+log_cli_level = WARNING
+# Dirty trick, we add the log_file_level without an actual log_file attached:
+# the overall pytest logger will be set to the more inclusive of the two levels,
+# and that way the capture after failed tests will include INFO.
+log_file_level = INFO


### PR DESCRIPTION
add pytest.ini to configure log level
    
     - default will be to report >=WARNING for passing
       and >=INFO for failing tests
     - can still be overridden by e.g.
       pytest --log-cli-level INFO
     - no actual log_file set for now

Also added missing `f` to exception printing.