### PR TITLE
Update recipes v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ plotting methods and some of the [example scripts](./examples).
 * `test`: For running the test suite locally using [pytest](https://docs.pytest.org) and some of its addons
   (`python -m pytest tests/`).
 * `wheel`: Includes `wheel` and `check-wheel-contents`.
-* `dev`: Collects `style`, `test` and `wheel`.
+* `dev`: Collects `docs`, `style`, `test` and `wheel`.
 * `docs`: Required dependencies to build the documentation.
 
 Installation can be done by adding one or more of the aforementioned tags to the installation command.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ pip install --upgrade pip setuptools
 See [this wiki page](https://github.com/PyFstat/PyFstat/wiki/conda-environments)
 for further instructions on installing conda itself,
 installing PyFstat into an existing environment,
-or for a minimal .yml recipe to set up a PyFstat-specific environment.
+or for .yml recipes to set up a PyFstat-specific environment
+both for normal users and for developers.
 
 If getting PyFstat from conda-forge, it already includes the required ephemerides files.
 
@@ -194,17 +195,27 @@ pip install pyfstat[chainconsumer,pycuda,style]
 ```
 This command accepts the "development mode" tag `-e`.
 
+Note that LALSuite is a default requirement, not an optional one,
+but its installation from PyPI can be disabled
+by setting the `NO_LALSUITE_FROM_PYPI` environment variable,
+e.g. for a development install from a local git clone:
+```
+NO_LALSUITE_FROM_PYPI=1 pip install -e .
+```
+This can be useful to avoid duplication when in a conda environment
+or installing LALSuite from source.
+
 ### Using LALSuite built from source
 
 If you prefer to make your own LALSuite installation
 [from source](https://git.ligo.org/lscsoft/lalsuite/),
-make sure it is **swig-enabled** and contains at least the `lalpulsar` and `lalapps` packages.
+make sure it is **swig-enabled** and contains at least the `lal` and `lalpulsar` packages.
 
 Following the instructions from their README,
 at the step where it tells you to run `./configure`,
 an example minimal line would be e.g.:
 ```
-./configure --prefix=${HOME}/lalsuite-install --disable-all-lal --enable-lalpulsar --enable-lalapps --enable-swig-python
+./configure --prefix=${HOME}/lalsuite-install --disable-all-lal --enable-lalpulsar --enable-swig-python
 ```
 
 Then after the `make && make install` step,

--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ Available sets of optional dependencies are:
 
 * `chainconsumer` ([Samreay/Chainconsumer](https://github.com/Samreay/ChainConsumer)): Required to run some optional
 plotting methods and some of the [example scripts](./examples).
+* `dev`: Collects `docs`, `style`, `test` and `wheel`.
+* `docs`: Required dependencies to build the documentation.
 * `pycuda` ([PyPI](https://pypi.org/project/pycuda/)): Required for the `tCWFstatMapVersion=pycuda`
   option of the `TransientGridSearch` class. (Note: Installing `pycuda` requires a working
   `nvcc` compiler in your path.)
@@ -182,8 +184,6 @@ plotting methods and some of the [example scripts](./examples).
 * `test`: For running the test suite locally using [pytest](https://docs.pytest.org) and some of its addons
   (`python -m pytest tests/`).
 * `wheel`: Includes `wheel` and `check-wheel-contents`.
-* `dev`: Collects `docs`, `style`, `test` and `wheel`.
-* `docs`: Required dependencies to build the documentation.
 
 Installation can be done by adding one or more of the aforementioned tags to the installation command.
 

--- a/etc/pyfstat-dev.yml
+++ b/etc/pyfstat-dev.yml
@@ -28,4 +28,4 @@ dependencies:
   - scipy
   - tqdm
   - pip:
-    - -e ../[dev]
+    - -e ../[dev]  # the ".." is needed because pip seems to get called from within "etc"

--- a/etc/pyfstat-dev.yml
+++ b/etc/pyfstat-dev.yml
@@ -1,3 +1,11 @@
+# important notes:
+# 1. to ensure correct relative path for the editable mode installation,
+# always create your environment while at the root directory of your pyfstat git clone.
+#
+# 2. to avoid having duplicate lalsuite packages from both conda and pip,
+# please always run as
+# NO_LALSUITE_FROM_PYPI=1 mamba env create -f etc/pyfstat-dev.yml
+
 name: pyfstat-dev
 
 channels:

--- a/etc/pyfstat-dev.yml
+++ b/etc/pyfstat-dev.yml
@@ -4,19 +4,20 @@ channels:
   - conda-forge
 
 dependencies:
-  - python >=3.8
-  - numpy
-  - matplotlib-base >=2.1
-  - scipy
-  - ptemcee
+  - attrs
   - corner
   - dill
-  - tqdm
+  - lalpulsar >=5.0.0
+  - matplotlib-base >=2.1
+  - numpy
   - peakutils
   - pathos
+  - pip
+  - ptemcee
+  - python >=3.8
   - python-lal >=7.1.5
   - python-lalpulsar >=5.0.0
-  - lalpulsar >=5.0.0
-  - pip
+  - scipy
+  - tqdm
   - pip:
     - -e ../[dev]

--- a/etc/pyfstat.yml
+++ b/etc/pyfstat.yml
@@ -2,5 +2,5 @@ name: pyfstat
 channels:
     - conda-forge
 dependencies:
-    - python >=3.7
+    - python >=3.8
     - pyfstat

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 # Extra dependencies
 extras_require = {
+    "chainconsumer": ["chainconsumer"],
     "dev": [
         "pre-commit",
     ],
@@ -36,7 +37,6 @@ extras_require = {
         "mistune==0.8.4",
         "Pillow==9.2.0",
     ],
-    "chainconsumer": ["chainconsumer"],
     "pycuda": ["pycuda"],
     "style": [
         "black",

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ extras_require = {
     "test": ["pytest", "pytest-cov", "flaky"],
     "wheel": ["wheel", "check-wheel-contents"],
 }
-for key in ["style", "test", "wheel"]:
+for key in ["docs", "style", "test", "wheel"]:
     extras_require["dev"] += extras_require[key]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
+import os
 import sys
-from os import path
 
 from setuptools import find_packages, setup
 
@@ -17,12 +17,26 @@ else:
     print("Confirmed Python version %s.%s.%s or above" % min_python_version[:3])
 
 
-here = path.abspath(path.dirname(__file__))
+here = os.path.abspath(os.path.dirname(__file__))
 # Get the long description from the README file
-with open(path.join(here, "README.md"), encoding="utf-8") as f:
+with open(os.path.join(here, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
-# Extra dependencies
+# dependencies
+requires = [
+    "attrs",
+    "corner",
+    "dill",
+    "matplotlib>=2.1",
+    "numpy",
+    "pathos",
+    "peakutils",
+    "ptemcee",
+    "scipy",
+    "tqdm",
+    "versioneer",
+]
+lalsuite = "lalsuite>=7.7"
 extras_require = {
     "chainconsumer": ["chainconsumer"],
     "dev": [
@@ -88,19 +102,7 @@ setup(
         "Topic :: Scientific/Engineering :: Physics",
     ],
     python_requires=">=%s.%s.%s" % min_python_version[:3],
-    install_requires=[
-        "attrs",
-        "corner",
-        "dill",
-        "lalsuite>=7.7",
-        "matplotlib>=2.1",
-        "numpy",
-        "pathos",
-        "peakutils",
-        "ptemcee",
-        "scipy",
-        "tqdm",
-        "versioneer",
-    ],
+    install_requires=requires
+    + ([] if os.environ.get("NO_LALSUITE_FROM_PYPI", False) else [lalsuite]),
     extras_require=extras_require,
 )


### PR DESCRIPTION
- supersedes #442 
- pyfstat-dev.yml
  - sort dependencies
  - add missing attrs
- pyfstat.yml
  - bump to python >= 3.8
- setup: skip lalsuite if NO_LALSUITE_FROM_PYPI set
     - use this in pyfstat-dev.yml
       to avoid duplicate packages from conda and pip
- plus some misc README updates

Wiki will be updated to match.