### PR TITLE
DetectorStates ts nparray

### DIFF
--- a/pyfstat/snr.py
+++ b/pyfstat/snr.py
@@ -444,7 +444,7 @@ class DetectorStates:
 
             logger.debug("Retrieving detectors from timestamps dictionary.")
             detectors = list(timestamps.keys())
-            timestamps = timestamps.values()
+            timestamps = (np.array(ts) for ts in timestamps.values())
 
         elif detectors is not None:
             if isinstance(detectors, str):

--- a/tests/test_snr.py
+++ b/tests/test_snr.py
@@ -121,7 +121,7 @@ def test_DetectorStates(data_parameters, writer):
     mds2 = pyfstat.DetectorStates().get_multi_detector_states(
         Tsft=writer.Tsft, timestamps={key: list(common_ts) for key in ("H1", "L1")}
     )
-    assert compare_multi_detector_states_series(*[mds[0], mds2])
+    assert compare_multi_detector_states_series(mds[0], mds2)
 
     # test a wrong input that shouldn't work
     with pytest.raises(Exception):

--- a/tests/test_snr.py
+++ b/tests/test_snr.py
@@ -117,6 +117,13 @@ def test_DetectorStates(data_parameters, writer):
     ]
     assert compare_multi_detector_states_series(*mds)
 
+    # test again with plain list instead of np.array
+    mds2 = pyfstat.DetectorStates().get_multi_detector_states(
+        Tsft=writer.Tsft, timestamps={key: list(common_ts) for key in ("H1", "L1")}
+    )
+    assert compare_multi_detector_states_series(*[mds[0], mds2])
+
+    # test a wrong input that shouldn't work
     with pytest.raises(Exception):
         pyfstat.DetectorStates().get_multi_detector_states(
             Tsft=writer.Tsft, timestamps={"H1,L1": [0]}


### PR DESCRIPTION
@Rodrigo-Tenorio exposes and fixes a missing list->np.array conversion in DetectorStates

For reference, error from running with the first commit only is
```
FAILED tests/test_snr.py::test_DetectorStates - AttributeError: 'list' object has no attribute 'ndim'
```