### PR TITLE
Drop peakutils

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,16 +150,15 @@ and recent lalsuite dependencies will include ephemerides files too.
 PyFstat uses the following external python modules,
 which should all be pulled in automatically if you use `pip`:
 
-* [numpy](https://www.numpy.org/)
-* [matplotlib](https://matplotlib.org/)
-* [scipy](https://www.scipy.org/)
-* [ptemcee](https://github.com/willvousden/ptemcee)
 * [corner](https://pypi.python.org/pypi/corner/)
 * [dill](https://pypi.python.org/pypi/dill)
-* [tqdm](https://pypi.python.org/pypi/tqdm)
-* [peakutils](https://pypi.python.org/pypi/PeakUtils)
-* [pathos](https://pypi.python.org/pypi/pathos)
 * [lalsuite](https://pypi.org/project/lalsuite/)
+* [matplotlib](https://matplotlib.org/)
+* [numpy](https://www.numpy.org/)
+* [pathos](https://pypi.python.org/pypi/pathos)
+* [ptemcee](https://github.com/willvousden/ptemcee)
+* [scipy](https://www.scipy.org/)
+* [tqdm](https://pypi.python.org/pypi/tqdm)
 * [versioneer](https://pypi.org/project/versioneer/)
 
 For a general introduction to installing modules, see

--- a/etc/pyfstat-dev.yml
+++ b/etc/pyfstat-dev.yml
@@ -18,7 +18,6 @@ dependencies:
   - lalpulsar >=5.0.0
   - matplotlib-base >=2.1
   - numpy
-  - peakutils
   - pathos
   - pip
   - ptemcee

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ requires = [
     "matplotlib>=2.1",
     "numpy",
     "pathos",
-    "peakutils",
     "ptemcee",
     "scipy",
     "tqdm",


### PR DESCRIPTION
 - no longer needed since #453
 - also sort dependencies in README alphabetically