### PR TITLE
add (h0,cosi)<->(aplus,across) functions to utils.converting

### DIFF
--- a/pyfstat/snr.py
+++ b/pyfstat/snr.py
@@ -6,7 +6,7 @@ import lalpulsar
 import numpy as np
 from attrs import define, field
 
-from pyfstat.utils import get_ephemeris_files
+from pyfstat.utils import convert_h0_cosi_to_aCross_aPlus, get_ephemeris_files
 
 logger = logging.getLogger(__name__)
 
@@ -300,9 +300,7 @@ class SignalToNoiseRatio:
             raise ValueError("Need either (h0, cosi) or (aPlus, aCross), but not both")
 
         if h0_cosi:
-            aPlus = 0.5 * h0 * (1 + cosi**2)
-            aCross = h0 * cosi
-            return aPlus, aCross
+            aPlus, aCross = convert_h0_cosi_to_aCross_aPlus(h0, cosi)
 
         return aPlus, aCross
 

--- a/pyfstat/snr.py
+++ b/pyfstat/snr.py
@@ -6,7 +6,7 @@ import lalpulsar
 import numpy as np
 from attrs import define, field
 
-from pyfstat.utils import convert_h0_cosi_to_aCross_aPlus, get_ephemeris_files
+from pyfstat.utils import convert_h0_cosi_to_aPlus_aCross, get_ephemeris_files
 
 logger = logging.getLogger(__name__)
 
@@ -300,7 +300,7 @@ class SignalToNoiseRatio:
             raise ValueError("Need either (h0, cosi) or (aPlus, aCross), but not both")
 
         if h0_cosi:
-            aPlus, aCross = convert_h0_cosi_to_aCross_aPlus(h0, cosi)
+            aPlus, aCross = convert_h0_cosi_to_aPlus_aCross(h0, cosi)
 
         return aPlus, aCross
 

--- a/pyfstat/utils/__init__.py
+++ b/pyfstat/utils/__init__.py
@@ -8,6 +8,8 @@ but others can also be helpful for end users.
 
 from .cli import match_commandlines, run_commandline
 from .converting import (
+    convert_aCross_aPlus_to_h0_cosi,
+    convert_h0_cosi_to_aCross_aPlus,
     get_dictionary_from_lines,
     gps_to_datestr_utc,
     parse_list_of_numbers,

--- a/pyfstat/utils/__init__.py
+++ b/pyfstat/utils/__init__.py
@@ -8,8 +8,8 @@ but others can also be helpful for end users.
 
 from .cli import match_commandlines, run_commandline
 from .converting import (
-    convert_aCross_aPlus_to_h0_cosi,
-    convert_h0_cosi_to_aCross_aPlus,
+    convert_aPlus_aCross_to_h0_cosi,
+    convert_h0_cosi_to_aPlus_aCross,
     get_dictionary_from_lines,
     gps_to_datestr_utc,
     parse_list_of_numbers,

--- a/pyfstat/utils/converting.py
+++ b/pyfstat/utils/converting.py
@@ -113,6 +113,8 @@ def convert_h0_cosi_to_aPlus_aCross(h0, cosi):
     """
     Converts amplitude parameters from a pair of `(h0,cosi)` to a pair of `(aPlus,aCross)`.
 
+    See e.g. Eq. (30) of https://dcc.ligo.org/T0900149-v6/public .
+
     If both inputs are single numbers,
     both outputs will be as well.
     If at least one input is a list or np.array,
@@ -160,6 +162,7 @@ def convert_aPlus_aCross_to_h0_cosi(aPlus, aCross):
     Conversion in this direction is only well-defined if `aPlus >= abs(aCross) >= 0`,
     as expected for GWs from neutron stars at twice the spin frequency,
     but not necessarily in all other CW emission scenarios.
+    See e.g. Eq. (32) of https://dcc.ligo.org/T0900149-v6/public .
 
     If both inputs are single numbers,
     both outputs will be as well.

--- a/pyfstat/utils/converting.py
+++ b/pyfstat/utils/converting.py
@@ -107,3 +107,62 @@ def gps_to_datestr_utc(gps):
         tzinfo=timezone.utc,
     )
     return dt.strftime("%c %Z")
+
+
+def convert_h0_cosi_to_aCross_aPlus(h0, cosi):
+    """
+    Converts amplitude parameters from a pair of `(h0,cosi)` to a pair of `(aPlus,aCross)`.
+
+    Parameters
+    -------
+    h0: float
+        Nominal GW amplitude.
+    cosi: float
+        Cosine of the source inclination w.r.t. line of sight.
+
+    Returns
+    -------
+    aPlus: float
+        Plus polarization amplitude.
+    aCross: float
+        Cross polarization amplitude.
+    """
+    aPlus = 0.5 * h0 * (1 + cosi**2)
+    aCross = h0 * cosi
+    return aPlus, aCross
+
+
+def convert_aCross_aPlus_to_h0_cosi(aPlus, aCross):
+    """
+    Converts amplitude parameters from a pair of `(aPlus,aCross)` to a pair of `(h0,cosi)`.
+
+    Inverse to ``convert_h0_cosi_to_aCross_aPlus()``.
+
+    Conversion in this direction is only well-defined if `abs(aCross) > abs(aPlus)`,
+    as expected for GWs from neutron stars at twice the spin frequency,
+    but not necessarily in all other CW emission scenarios.
+
+    Parameters
+    -------
+    aPlus: float
+        Plus polarization amplitude.
+    aCross: float
+        Cross polarization amplitude.
+
+    Returns
+    -------
+    h0: float
+        Nominal GW amplitude.
+    cosi: float
+        Cosine of the source inclination w.r.t. line of sight.
+    """
+
+    if np.abs(aCross) > np.abs(aPlus):
+        raise ValueError("not valid for abs(aCross)>abs(aPlus)")
+
+    h0 = aPlus + np.sqrt(aPlus**2 - aCross**2)
+    if h0 > 0:
+        cosi = aCross / h0
+    else:
+        cosi = 0
+    return h0, cosi

--- a/pyfstat/utils/converting.py
+++ b/pyfstat/utils/converting.py
@@ -113,30 +113,40 @@ def convert_h0_cosi_to_aPlus_aCross(h0, cosi):
     """
     Converts amplitude parameters from a pair of `(h0,cosi)` to a pair of `(aPlus,aCross)`.
 
+    If both inputs are single numbers,
+    both outputs will be as well.
+    If at least one input is a list or np.array,
+    both outputs will be np.arrays.
+
     Parameters
     -------
-    h0: float
+    h0: float, list or np.array
         Nominal GW amplitude.
-    cosi: float
+    cosi: float, list or np.array
         Cosine of the source inclination w.r.t. line of sight.
 
     Returns
     -------
-    aPlus: float
+    aPlus: float or np.array
         Plus polarization amplitude.
-    aCross: float
+    aCross: float or np.array
         Cross polarization amplitude.
     """
 
     h0 = np.atleast_1d(h0)
     cosi = np.atleast_1d(cosi)
 
+    if np.any(h0 < 0):
+        raise ValueError("not valid for h0<0")
+    if np.any(np.abs(cosi) > 1):
+        raise ValueError("not valid for abs(cosi)>1")
+
     aPlus = 0.5 * h0 * (1.0 + cosi**2)
     aCross = h0 * cosi
 
-    if len(aPlus) == 1:
+    if aPlus.size == 1:
         aPlus = aPlus[0]
-    if len(cosi) == 1:
+    if cosi.size == 1:
         aCross = aCross[0]
     return aPlus, aCross
 
@@ -151,44 +161,42 @@ def convert_aPlus_aCross_to_h0_cosi(aPlus, aCross):
     as expected for GWs from neutron stars at twice the spin frequency,
     but not necessarily in all other CW emission scenarios.
 
+    If both inputs are single numbers,
+    both outputs will be as well.
+    If at least one input is a list or np.array,
+    both outputs will be np.arrays.
+
     Parameters
     -------
-    aPlus: float
+    aPlus: float, list or np.array
         Plus polarization amplitude
         (must be `>= abs(aCross)` and `>= 0`).
-    aCross: float
+    aCross: float, list or np.array
         Cross polarization amplitude.
 
     Returns
     -------
-    h0: float
+    h0: float or np.array
         Nominal GW amplitude.
-    cosi: float
+    cosi: float or np.array
         Cosine of the source inclination w.r.t. line of sight.
     """
 
     aPlus = np.atleast_1d(aPlus)
     aCross = np.atleast_1d(aCross)
 
-    if np.any(np.abs(aCross) > np.abs(aPlus)):
-        raise ValueError("not valid for abs(aCross)>abs(aPlus)")
     if np.any(aPlus < 0):
         raise ValueError("not valid for aPlus<0")
+    if np.any(np.abs(aCross) > aPlus):
+        raise ValueError("not valid for abs(aCross)>aPlus")
 
     h0 = aPlus + np.sqrt(aPlus**2 - aCross**2)
 
-    # next: vectorized version of if-else on h0>0?
-    # if h0 > 0:
-    # cosi = aCross / h0
-    # else:
-    # cosi = 0
-    mask = np.ma.array(h0, mask=(h0 == 0))
-    cosi = aCross / mask
-    cosi[cosi.mask] = 0
-    cosi = np.asarray(cosi)
+    # vectorized version of if-else on h0>0
+    cosi = np.divide(aCross, h0, out=np.zeros_like(aCross), where=(h0 > 0))
 
-    if len(h0) == 1:
+    if h0.size == 1:
         h0 = h0[0]
-    if len(cosi) == 1:
+    if cosi.size == 1:
         cosi = cosi[0]
     return h0, cosi

--- a/tests/test_utils/test_converting.py
+++ b/tests/test_utils/test_converting.py
@@ -1,3 +1,5 @@
+import pytest
+
 import pyfstat
 
 
@@ -10,3 +12,15 @@ def test_gps_to_datestr_utc():
     old_str = "Wed Sep 14 01:46:25 GMT 2011"
     new_str = pyfstat.utils.gps_to_datestr_utc(gps)
     assert new_str.rstrip(" UTC") == old_str.replace(" GMT ", " ")
+
+
+def test_convert_aCross_aPlus_to_h0_cosi():
+    h0, cosi = pyfstat.utils.convert_aCross_aPlus_to_h0_cosi(1.0, 0.0)
+    assert h0 == pytest.approx(2.0, 1e-9)
+    assert cosi == pytest.approx(0.0, 1e-9)
+    h0, cosi = pyfstat.utils.convert_aCross_aPlus_to_h0_cosi(1.0, 1.0)
+    assert h0 == pytest.approx(1.0, 1e-9)
+    assert cosi == pytest.approx(1.0, 1e-9)
+    h0, cosi = pyfstat.utils.convert_aCross_aPlus_to_h0_cosi(-1.0, 0.0)
+    assert h0 == pytest.approx(0.0, 1e-9)
+    assert cosi == pytest.approx(0.0, 1e-9)

--- a/tests/test_utils/test_converting.py
+++ b/tests/test_utils/test_converting.py
@@ -1,3 +1,6 @@
+import itertools
+
+import numpy as np
 import pytest
 
 import pyfstat
@@ -14,13 +17,66 @@ def test_gps_to_datestr_utc():
     assert new_str.rstrip(" UTC") == old_str.replace(" GMT ", " ")
 
 
-def test_convert_aCross_aPlus_to_h0_cosi():
-    h0, cosi = pyfstat.utils.convert_aCross_aPlus_to_h0_cosi(1.0, 0.0)
-    assert h0 == pytest.approx(2.0, 1e-9)
-    assert cosi == pytest.approx(0.0, 1e-9)
-    h0, cosi = pyfstat.utils.convert_aCross_aPlus_to_h0_cosi(1.0, 1.0)
-    assert h0 == pytest.approx(1.0, 1e-9)
-    assert cosi == pytest.approx(1.0, 1e-9)
-    h0, cosi = pyfstat.utils.convert_aCross_aPlus_to_h0_cosi(-1.0, 0.0)
-    assert h0 == pytest.approx(0.0, 1e-9)
-    assert cosi == pytest.approx(0.0, 1e-9)
+# known correct conversions from literature and lalpulsar
+amp_params_test = [
+    {
+        "aPlus": 0.0,
+        "aCross": 0.0,
+        "h0": 0.0,
+        "cosi": 0.0,
+    },
+    {
+        "aPlus": 1.0,
+        "aCross": 0.0,
+        "h0": 2.0,
+        "cosi": 0.0,
+    },
+    {
+        "aPlus": 1.0,
+        "aCross": 1.0,
+        "h0": 1.0,
+        "cosi": 1.0,
+    },
+    {
+        "aPlus": 1.0,
+        "aCross": -1.0,
+        "h0": 1.0,
+        "cosi": -1.0,
+    },
+]
+
+
+def test_convert_h0_cosi_to_aPlus_aCross():
+    for params in amp_params_test:
+        print(params)
+        aPlus, aCross = pyfstat.utils.convert_h0_cosi_to_aPlus_aCross(
+            params["h0"], params["cosi"]
+        )
+        assert aPlus == pytest.approx(params["aPlus"], 1e-9)
+        assert aCross == pytest.approx(params["aCross"], 1e-9)
+
+
+def test_convert_aPlus_aCross_to_h0_cosi():
+    for params in amp_params_test:
+        h0, cosi = pyfstat.utils.convert_aPlus_aCross_to_h0_cosi(
+            params["aPlus"], params["aCross"]
+        )
+        assert h0 == pytest.approx(params["h0"], 1e-9)
+        assert cosi == pytest.approx(params["cosi"], 1e-9)
+
+
+def test_convert_between_h0_cosi_and_aPlus_aCross():
+    h0s = np.logspace(-26, -24, 3)
+    cosis = np.linspace(-1, 1, 5)
+    h0s_in = np.zeros(len(h0s) * len(cosis))
+    cosis_in = np.zeros(len(h0s) * len(cosis))
+    h0s_out = np.zeros(len(h0s) * len(cosis))
+    cosis_out = np.zeros(len(h0s) * len(cosis))
+    for n, pair in enumerate(itertools.product(h0s, cosis)):
+        h0s_in[n], cosis_in[n] = pair
+        # h0s_out[n], cosis_out[n] = pyfstat.utils.convert_aPlus_aCross_to_h0_cosi(*pyfstat.utils.convert_h0_cosi_to_aPlus_aCross(*pair))
+    h0s_out, cosis_out = pyfstat.utils.convert_aPlus_aCross_to_h0_cosi(
+        *pyfstat.utils.convert_h0_cosi_to_aPlus_aCross(h0s_in, cosis_in)
+    )
+    np.testing.assert_allclose(h0s_in, h0s_out, rtol=1e-9)
+    np.testing.assert_allclose(cosis_in, cosis_out, rtol=1e-9)

--- a/tests/test_utils/test_converting.py
+++ b/tests/test_utils/test_converting.py
@@ -1,5 +1,3 @@
-import itertools
-
 import numpy as np
 import pytest
 
@@ -66,17 +64,14 @@ def test_convert_aPlus_aCross_to_h0_cosi():
 
 
 def test_convert_between_h0_cosi_and_aPlus_aCross():
-    h0s = np.logspace(-26, -24, 3)
-    cosis = np.linspace(-1, 1, 5)
-    h0s_in = np.zeros(len(h0s) * len(cosis))
-    cosis_in = np.zeros(len(h0s) * len(cosis))
-    h0s_out = np.zeros(len(h0s) * len(cosis))
-    cosis_out = np.zeros(len(h0s) * len(cosis))
-    for n, pair in enumerate(itertools.product(h0s, cosis)):
-        h0s_in[n], cosis_in[n] = pair
-        # h0s_out[n], cosis_out[n] = pyfstat.utils.convert_aPlus_aCross_to_h0_cosi(*pyfstat.utils.convert_h0_cosi_to_aPlus_aCross(*pair))
+    h0s_in = np.logspace(-26, -24, 3)
+    cosis_in = np.linspace(-1, 1, 5)
     h0s_out, cosis_out = pyfstat.utils.convert_aPlus_aCross_to_h0_cosi(
-        *pyfstat.utils.convert_h0_cosi_to_aPlus_aCross(h0s_in, cosis_in)
+        *pyfstat.utils.convert_h0_cosi_to_aPlus_aCross(
+            h0s_in[:, None], cosis_in[None, :]
+        )
     )
-    np.testing.assert_allclose(h0s_in, h0s_out, rtol=1e-9)
-    np.testing.assert_allclose(cosis_in, cosis_out, rtol=1e-9)
+    for h0col in h0s_out.transpose():
+        np.testing.assert_allclose(h0col, h0s_in, rtol=1e-9)
+    for cosirow in cosis_out:
+        np.testing.assert_allclose(cosirow, cosis_in, rtol=1e-9)


### PR DESCRIPTION
Extracts the existing one from an `snr` internal method to `utils.converting`, and adds the inverse, so they can be reused by other modules too.

Inverse should match https://lscsoft.docs.ligo.org/lalsuite/lalpulsar/_compute_fstatistic__v2_8c_source.html#l02045