### PR TITLE
485 refurbish injection parameters

### DIFF
--- a/examples/other_examples/PyFstat_example_InjectionParametersGenerator.py
+++ b/examples/other_examples/PyFstat_example_InjectionParametersGenerator.py
@@ -71,9 +71,9 @@ data.make_data()
 
 # Now we draw many phase parameters and check the sky distribution
 Ndraws = 10000
-phase_parameters = [phase_params_generator.draw() for n in range(Ndraws)]
-Alphas = np.array([p["Alpha"] for p in phase_parameters])
-Deltas = np.array([p["Delta"] for p in phase_parameters])
+phase_parameters = phase_params_generator.draw(size=Ndraws)
+Alphas = phase_parameters["Alpha"]
+Deltas = phase_parameters["Delta"]
 plotfile = os.path.join(outdir, label + "_allsky.png")
 logger.info(f"Plotting sky distribution of {Ndraws} points to file: {plotfile}")
 plt.subplot(111, projection="aitoff")

--- a/examples/other_examples/PyFstat_example_InjectionParametersGenerator.py
+++ b/examples/other_examples/PyFstat_example_InjectionParametersGenerator.py
@@ -71,7 +71,7 @@ data.make_data()
 
 # Now we draw many phase parameters and check the sky distribution
 Ndraws = 10000
-phase_parameters = phase_params_generator.draw(size=Ndraws)
+phase_parameters = phase_params_generator.draw_many(size=Ndraws)
 Alphas = phase_parameters["Alpha"]
 Deltas = phase_parameters["Delta"]
 plotfile = os.path.join(outdir, label + "_allsky.png")

--- a/examples/other_examples/PyFstat_example_InjectionParametersGenerator.py
+++ b/examples/other_examples/PyFstat_example_InjectionParametersGenerator.py
@@ -14,6 +14,7 @@ from pyfstat import (
     AllSkyInjectionParametersGenerator,
     InjectionParametersGenerator,
     Writer,
+    isotropic_amplitude_priors,
     set_up_logger,
 )
 
@@ -38,7 +39,7 @@ logger.info("Drawing random signal parameters...")
 # The rest can be a mix of nontrivial prior distributions and fixed values.
 phase_params_generator = AllSkyInjectionParametersGenerator(
     priors={
-        "F0": {"uniform": {"low": 29.0, "high": 31.0}},
+        "F0": {"stats.uniform": {"loc": 29.0, "scale": 2.0}},
         "F1": -1e-10,
         "F2": 0,
     },
@@ -51,10 +52,8 @@ phase_parameters["tref"] = gw_data["tstart"]
 # Here we use the plain InjectionParametersGenerator class.
 amplitude_params_generator = InjectionParametersGenerator(
     priors={
-        "h0": {"normal": {"loc": 1e-24, "scale": 1e-24}},
-        "cosi": {"uniform": {"low": 0.0, "high": 1.0}},
-        "phi": {"uniform": {"low": 0.0, "high": 2 * np.pi}},
-        "psi": {"uniform": {"low": 0.0, "high": np.pi}},
+        "h0": {"stats.norm": {"loc": 1e-24, "scale": 1e-26}},
+        **isotropic_amplitude_priors,
     },
     seed=42,
 )

--- a/examples/tutorials/1_generating_signals.ipynb
+++ b/examples/tutorials/1_generating_signals.ipynb
@@ -323,7 +323,7 @@
     "\n",
     "signal_parameters_generator = pyfstat.AllSkyInjectionParametersGenerator(\n",
     "    priors={\n",
-    "        \"F0\": {\"uniform\": {\"low\": 100.0, \"high\": 100.1}},\n",
+    "        \"F0\": {\"stats.uniform\": {\"loc\": 100.0, \"scale\": 0.1}},\n",
     "        \"F1\": -1e-10,\n",
     "        \"F2\": 0,\n",
     "        \"h0\": writer_kwargs[\"sqrtSX\"] / 10,  # Fix amplitude at depth 10.\n",

--- a/pyfstat/__init__.py
+++ b/pyfstat/__init__.py
@@ -33,6 +33,8 @@ from .gridcorner import gridcorner
 from .injection_parameters import (
     AllSkyInjectionParametersGenerator,
     InjectionParametersGenerator,
+    custom_prior,
+    isotropic_amplitude_priors,
 )
 from .make_sfts import (
     BinaryModulatedWriter,

--- a/pyfstat/__init__.py
+++ b/pyfstat/__init__.py
@@ -33,8 +33,6 @@ from .gridcorner import gridcorner
 from .injection_parameters import (
     AllSkyInjectionParametersGenerator,
     InjectionParametersGenerator,
-    custom_prior,
-    isotropic_amplitude_priors,
 )
 from .make_sfts import (
     BinaryModulatedWriter,

--- a/pyfstat/injection_parameters.py
+++ b/pyfstat/injection_parameters.py
@@ -16,12 +16,12 @@ def custom_prior(prior_function: Callable) -> Callable:
     Intended to be used as a decorator to add custom functions to
     the list of available priors for `InjectionParametersGenerator`.
 
-    For example:
-    ```
-    @pyfstat.custom_prior
-    def negative_log_uniform(generator):
-        return -10**(generator.uniform())
-    ```
+    For example,::
+
+        @pyfstat.custom_prior
+        def negative_log_uniform(generator):
+            return -10**(generator.uniform())
+
     will add the key `negative_log_uniform` to `_pyfstat_custom_priors`
     with said function as the corresponding value.
 
@@ -35,7 +35,6 @@ def custom_prior(prior_function: Callable) -> Callable:
     -------
     prior_function:
         Same function as the input function.
-
     """
 
     function_name = "{prior_function.__name__}"
@@ -90,21 +89,22 @@ class InjectionParametersGenerator:
         Each parameter's prior should be given as a dictionary entry as follows:
         `{"parameter": {"<function>": {**kwargs}}}`
         where <function> may be (exclusively) either a user-defined function decorated
-        with `@custom_prior` or the name of a `scipy.stats` `rv_continuous`.
+        with `@custom_prior` or the name of a `scipy.stats` random variable.
 
-        - | If a user-defined function is used, such a function *must* take
+        * | If a user-defined function is used, such a function *must* take
           | a `generator` kwarg as one of its arguments and use such a generator
           | to generate any required random number within the function.
           | The `generator` kwarg is *required* regardless of whether this is a
           | deterministic or random function.
           | For example, a negative log-distributed random number could be constructed as
-        ```
-        @pyfstat.custom_prior
-        def negative_log_uniform(generator):
-            return -10**(generator.uniform())
-        ```
 
-        - | If a `scipy.stats` function is used, it *must* be given as `stats.*`
+        ::
+
+            @pyfstat.custom_prior
+            def negative_log_uniform(generator):
+                return -10**(generator.uniform())
+
+        * | If a `scipy.stats` function is used, it *must* be given as `stats.*`
           | (i.e. the `stats` namespace should be explicitly included).
           |  For example, a uniform prior between 3 and 5 would be written as
           | `{"parameter": {"stats.uniform": {"loc": 3, "scale": 5}}}`.

--- a/pyfstat/injection_parameters.py
+++ b/pyfstat/injection_parameters.py
@@ -26,6 +26,9 @@ def custom_prior(prior_function: Callable) -> Callable:
     will add the key `negative_log_uniform` to `_pyfstat_custom_priors`
     with said function as the corresponding value.
 
+    See docstring of :func:`~pyfstat.injection_parameters.InjectionParametersGenerator`
+    for an example on how to draw samples from a custom prior.
+
     Parameters
     ----------
     prior_function:
@@ -102,14 +105,28 @@ class InjectionParametersGenerator:
 
         ::
 
-            @pyfstat.custom_prior
+            import pyfstat
+
+            @pyfstat.injection_parameters.custom_prior
             def negative_log_uniform(generator):
                 return -10**(generator.uniform())
+
+            priors = {"my_parameter": "negative_log_uniform": {}}
+            ipg = pyfstat.InjectionParametersGenerator(priors=priors, seed=42)
+            ipg.draw()
 
         * | If a `scipy.stats` function is used, it *must* be given as `stats.*`
           | (i.e. the `stats` namespace should be explicitly included).
           |  For example, a uniform prior between 3 and 5 would be written as
           | `{"parameter": {"stats.uniform": {"loc": 3, "scale": 5}}}`.
+
+        ::
+
+            import pyfstat
+
+            priors = {"my_parameter": "stats.uniform": {"loc": 3, "scale": 5}}
+            ipg = pyfstat.InjectionParametersGenerator(priors=priors, seed=42)
+            ipg.draw()
 
         Delta-priors (i.e. priors for a determinisitic output) can also be specified by
         giving the fixed value to be returned as-is. For example, specifying a fixed

--- a/pyfstat/injection_parameters.py
+++ b/pyfstat/injection_parameters.py
@@ -140,8 +140,9 @@ class InjectionParametersGenerator:
             1. Callable without required arguments:
             `{"ParameterA": np.random.uniform}`.
 
-            2. Dict containing numpy.random distribution as key and kwargs
-            in a dict as value:
+            2. Dictionary with a numpy.random distribution as key and its corresponding
+            kwargs in a dict as value (mind that this is formally the same dict structure
+            as when using a `"stats.*"` distribution with the new syntax):
             `{"ParameterA": {"uniform": {"low": 0, "high":1}}}`.
 
         Note, however, that these options are deprecated and will be removed

--- a/pyfstat/injection_parameters.py
+++ b/pyfstat/injection_parameters.py
@@ -16,7 +16,7 @@ _pyfstat_custom_priors = {}
 def custom_prior(prior_function: Callable) -> Callable:
     """
     Intended to be used as a decorator to add custom functions to
-    the list of available priors for `InjectionParametersGenerator`.
+    the list of available priors for ``InjectionParametersGenerator``.
 
     For example,::
 
@@ -24,19 +24,19 @@ def custom_prior(prior_function: Callable) -> Callable:
         def negative_log_uniform(generator, size):
             return -10**(generator.uniform(size=size))
 
-    will add the key `negative_log_uniform` to `_pyfstat_custom_priors`
+    will add the key ``negative_log_uniform`` to ``_pyfstat_custom_priors``
     with said function as the corresponding value.
 
-    A function decorated with `custom_prior` *must* take `generator` and `size` as
-    keyword arguments; otherwise, a `TypeException` will be raised.
+    A function decorated with ``custom_prior`` *must* take ``generator`` and ``size`` as
+    keyword arguments; otherwise, a ``TypeException`` will be raised.
 
-    See docstring of :func:`~pyfstat.injection_parameters.InjectionParametersGenerator`
+    See docstring of :func:``~pyfstat.injection_parameters.InjectionParametersGenerator``
     for an example on how to draw samples from a custom prior.
 
     Parameters
     ----------
     prior_function:
-        Function to be added into `_pyfstat_custom_priors` with a key
+        Function to be added into ``_pyfstat_custom_priors`` with a key
         corresponding *exactly* to the name it was given at definition time.
 
     Returns
@@ -90,7 +90,7 @@ def uniform_sky_declination(generator: np.random.Generator, size: int) -> np.arr
         As required by InjectionParametersGenerator.
     size:
         As required by InjectionParameterGenerator. Gets passed directly
-        as a kwargs to `generator`'s methods.
+        as a kwargs to ``generator``'s methods.
 
     Returns
     -------
@@ -111,14 +111,14 @@ class InjectionParametersGenerator:
         (following the PyFstat convention).
 
         Each parameter's prior should be given as a dictionary entry as follows:
-        `{"parameter": {"<function>": {**kwargs}}}`
+        ``{"parameter": {"<function>": {**kwargs}}}``
         where <function> may be (exclusively) either a user-defined function decorated
-        with `@custom_prior` or the name of a `scipy.stats` random variable.
+        with ``@custom_prior`` or the name of a ``scipy.stats`` random variable.
 
         * | If a user-defined function is used, such a function *must* take
-          | a `generator` kwarg as one of its arguments and use such a generator
+          | a ``generator`` kwarg as one of its arguments and use such a generator
           | to generate any required random number within the function.
-          | The `generator` kwarg is *required* regardless of whether this is a
+          | The ``generator`` kwarg is *required* regardless of whether this is a
           | deterministic or random function.
           | For example, a negative log-distributed random number could be constructed as
 
@@ -134,10 +134,10 @@ class InjectionParametersGenerator:
             ipg = pyfstat.InjectionParametersGenerator(priors=priors, seed=42)
             ipg.draw()
 
-        * | If a `scipy.stats` function is used, it *must* be given as `stats.*`
-          | (i.e. the `stats` namespace should be explicitly included).
+        * | If a ``scipy.stats`` function is used, it *must* be given as ``stats.*``
+          | (i.e. the ``stats`` namespace should be explicitly included).
           |  For example, a uniform prior between 3 and 5 would be written as
-          | `{"parameter": {"stats.uniform": {"loc": 3, "scale": 5}}}`.
+          | ``{"parameter": {"stats.uniform": {"loc": 3, "scale": 5}}}``.
 
         ::
 
@@ -149,7 +149,7 @@ class InjectionParametersGenerator:
 
         Delta-priors (i.e. priors for a determinisitic output) can also be specified by
         giving the fixed value to be returned as-is. For example, specifying a fixed
-        value of 1 for the parameter `A` would be `{"A": 1}`.
+        value of 1 for the parameter ``A`` would be ``{"A": 1}``.
 
         Alternatively, the following three options, which were recommended
         on a previous release, are still a valid input. They will be used as a fall-back
@@ -157,12 +157,12 @@ class InjectionParametersGenerator:
         but their use is highly discouraged for newly produced code.
 
             1. Callable without required arguments:
-            `{"ParameterA": np.random.uniform}`.
+            ``{"ParameterA": np.random.uniform}``.
 
             2. Dictionary with a numpy.random distribution as key and its corresponding
             kwargs in a dict as value (mind that this is formally the same dict structure
-            as when using a `"stats.*"` distribution with the new syntax):
-            `{"ParameterA": {"uniform": {"low": 0, "high":1}}}`.
+            as when using a ``"stats.*"`` distribution with the new syntax):
+            ``{"ParameterA": {"uniform": {"low": 0, "high":1}}}``.
 
         Note, however, that these options are deprecated and will be removed
         in a future PyFstat release.
@@ -170,13 +170,13 @@ class InjectionParametersGenerator:
         specifying seeds in this class.
 
     generator:
-        Numpy random number generator (e.g. `np.random.default_rng`)
-        which will be used to draw random numbers from. Conflicts with `seed`.
+        Numpy random number generator (e.g. ``np.random.default_rng``)
+        which will be used to draw random numbers from. Conflicts with ``seed``.
 
     seed:
-        Random seed to create instantiate `np.random.default_rng` from scratch.
-        Conflicts with `generator`. If neither `seed` nor `generator` are given,
-        a random number generator will be instantiated using `seed=None`
+        Random seed to create instantiate ``np.random.default_rng`` from scratch.
+        Conflicts with ``generator``. If neither ``seed`` nor ``generator`` are given,
+        a random number generator will be instantiated using ``seed=None``
         and a warning will be thrown.
     """
 
@@ -306,7 +306,7 @@ class InjectionParametersGenerator:
         Returns
         -------
         injection_parameters:
-            Dictionary of arrays. Each key corresponds to that found in `self.priors`.
+            Dictionary of arrays. Each key corresponds to that found in ``self.priors``.
         """
 
         return {
@@ -315,7 +315,7 @@ class InjectionParametersGenerator:
         }
 
     def draw_many(self, size) -> dict:
-        """Draw a `size` multi-dimensional parameter space point from the given priors.
+        """Draw a ``size`` multi-dimensional parameter space point from the given priors.
 
         Parameters
         ----------
@@ -325,7 +325,7 @@ class InjectionParametersGenerator:
         Returns
         -------
         injection_parameters:
-            Dictionary of arrays. Each key corresponds to that found in `self.priors`.
+            Dictionary of arrays. Each key corresponds to that found in ``self.priors``.
             Values are numpy arrays as returned by their corresponding method.
         """
         return {
@@ -337,13 +337,13 @@ class InjectionParametersGenerator:
 class AllSkyInjectionParametersGenerator(InjectionParametersGenerator):
     """
     Draw injection parameter samples from priors and return in dictionary format.
-    This class works in exactly the same way as `InjectionParametersGenerator`,
-    but including by default two extra keys, `Alpha` and `Delta` (sky position's
+    This class works in exactly the same way as ``InjectionParametersGenerator``,
+    but including by default two extra keys, ``Alpha`` and ``Delta`` (sky position's
     right ascension and declination in radians), which are sample isotropically
     across the celestial sphere.
 
-    `Alpha`'s distribution is Uniform(0, 2 pi), and
-    `sin(Delta)`'s distribution is Uniform(-1, 1).
+    ``Alpha``'s distribution is Uniform(0, 2 pi), and
+    ``sin(Delta)``'s distribution is Uniform(-1, 1).
 
     The only reason this class exists is because, using the notation we specified
     in the base class, there is no way to generate arcsine distributed numbers using
@@ -368,7 +368,7 @@ class AllSkyInjectionParametersGenerator(InjectionParametersGenerator):
         for key in sky_priors:
             if key in priors:
                 logger.warning(
-                    f"Found input key {key} with value {priors[key]}.\n"
+                    f"Found input key `{key}` with value {priors[key]}.\n"
                     "Overwritting to produce uniform samples across the sky."
                 )
 

--- a/pyfstat/injection_parameters.py
+++ b/pyfstat/injection_parameters.py
@@ -37,14 +37,14 @@ def custom_prior(prior_function: Callable) -> Callable:
         Same function as the input function.
     """
 
-    function_name = "{prior_function.__name__}"
+    function_name = f"{prior_function.__name__}"
     if function_name in _pyfstat_custom_priors:
         raise ValueError(
             f"Custom prior `{function_name}` already defined in `pyfstat._pyfstat_custom_priors.` "
             f"Please, use a different function name"
         )
 
-    _pyfstat_custom_priors[prior_function.__name__] = prior_function
+    _pyfstat_custom_priors[function_name] = prior_function
 
     return prior_function
 

--- a/pyfstat/injection_parameters.py
+++ b/pyfstat/injection_parameters.py
@@ -116,6 +116,5 @@ class AllSkyInjectionParametersGenerator(InjectionParametersGenerator):
                     f"Found {key} key in input priors with value {priors_input_format[key]}.\n"
                     "Overwritting to produce uniform samples across the sky."
                 )
-            priors_input_format[key] = sky_priors[key]
 
-        return super()._parse_priors(priors_input_format)
+        return super()._parse_priors({**priors_input_format, **sky_priors})

--- a/pyfstat/injection_parameters.py
+++ b/pyfstat/injection_parameters.py
@@ -41,8 +41,9 @@ def custom_prior(prior_function: Callable) -> Callable:
     function_name = f"{prior_function.__name__}"
     if function_name in _pyfstat_custom_priors:
         raise ValueError(
-            f"Custom prior `{function_name}` already defined in `pyfstat._pyfstat_custom_priors.` "
-            f"Please, use a different function name"
+            f"Custom prior `{function_name}` already defined in "
+            "`pyfstat._pyfstat_custom_priors.` "
+            "Please, use a different function name"
         )
 
     _pyfstat_custom_priors[function_name] = prior_function
@@ -112,8 +113,8 @@ class InjectionParametersGenerator:
 
         Alternatively, the following three options, which were recommended
         on a previous release, are still a valid input. They will be used as a fall-back
-        if none of the two previous options are matched, but their use is highly discouraged
-        for newly produced code.
+        if none of the two previous options are matched,
+        but their use is highly discouraged for newly produced code.
 
             1. Callable without required arguments:
             `{"ParameterA": np.random.uniform}`.

--- a/pyfstat/injection_parameters.py
+++ b/pyfstat/injection_parameters.py
@@ -228,6 +228,10 @@ class InjectionParametersGenerator:
                 )
 
             distribution = next(iter(parameter_prior))
+            if not isinstance(distribution, str):
+                raise ValueError(
+                    "Prior distribution's key should be a string. Got {{type(distribution)}`"
+                )
 
             if distribution in _pyfstat_custom_priors:
                 logger.debug(

--- a/pyfstat/injection_parameters.py
+++ b/pyfstat/injection_parameters.py
@@ -342,13 +342,8 @@ class AllSkyInjectionParametersGenerator(InjectionParametersGenerator):
     right ascension and declination in radians), which are sample isotropically
     across the celestial sphere.
 
-    ``Alpha``'s distribution is Uniform(0, 2 pi), and
-    ``sin(Delta)``'s distribution is Uniform(-1, 1).
-
-    The only reason this class exists is because, using the notation we specified
-    in the base class, there is no way to generate arcsine distributed numbers using
-    a specific seed, as numpy does not have such a number generator and hence has to
-    be constructed by applying a function to a uniform number.
+    `Alpha`'s distribution is Uniform(0, 2 pi), and
+    `sin(Delta)`'s distribution is Uniform(-1, 1).
     """
 
     def __init__(

--- a/pyfstat/injection_parameters.py
+++ b/pyfstat/injection_parameters.py
@@ -218,6 +218,15 @@ class InjectionParametersGenerator:
                 self.priors[parameter_name] = lambda val=parameter_prior: val
                 continue
 
+            if len(parameter_prior) > 1:
+                raise ValueError(
+                    f"{parameter_prior} does not follow"
+                    " the required format to specify a prior"
+                    " as the inner dictionary contains more than one key."
+                    " Please, specify a parameter's distribution as"
+                    " `{'parameter_name': {'parameter_distro': {**distro_kwargs}}}`."
+                )
+
             distribution = next(iter(parameter_prior))
 
             if distribution in _pyfstat_custom_priors:

--- a/pyfstat/injection_parameters.py
+++ b/pyfstat/injection_parameters.py
@@ -152,7 +152,13 @@ class InjectionParametersGenerator:
                 print(self.priors)
                 continue
 
-            prior_distribution = next(iter(parameter_prior))
+            try:
+                # Check if it can be treated as a dict, otherwise treat it as a number.
+                # FIXME Extreme duck typing?
+                prior_distribution = next(iter(parameter_prior))
+            except TypeError:
+                self.priors[parameter_name] = lambda val=parameter_prior: val
+                continue
 
             if "stats." in prior_distribution:
                 _, stats_function = prior_distribution.split(".")

--- a/pyfstat/injection_parameters.py
+++ b/pyfstat/injection_parameters.py
@@ -1,7 +1,7 @@
 """Generate injection parameters drawn from different prior populations"""
 import functools
 import logging
-from typing import Optional
+from typing import Callable, Optional
 
 import numpy as np
 from scipy import stats
@@ -11,7 +11,32 @@ logger = logging.getLogger(__name__)
 _pyfstat_custom_priors = {}
 
 
-def custom_prior(prior_function):
+def custom_prior(prior_function: Callable) -> Callable:
+    """
+    Intended to be used as a decorator to add custom functions to
+    the list of available priors for `InjectionParametersGenerator`.
+
+    For example:
+    ```
+    @pyfstat.custom_prior
+    def negative_log_uniform(generator):
+        return -10**(generator.uniform())
+    ```
+    will add the key `negative_log_uniform` to `_pyfstat_custom_priors`
+    with said function as the corresponding value.
+
+    Parameters
+    ----------
+    prior_function:
+        Function to be added into `_pyfstat_custom_priors` with a key
+        corresponding *exactly* to the name it was given at definition time.
+
+    Returns
+    -------
+    prior_function:
+        Same function as the input function.
+
+    """
 
     function_name = "{prior_function.__name__}"
     if function_name in _pyfstat_custom_priors:
@@ -19,7 +44,9 @@ def custom_prior(prior_function):
             f"Custom prior `{function_name}` already defined in `pyfstat._pyfstat_custom_priors.` "
             f"Please, use a different function name"
         )
+
     _pyfstat_custom_priors[prior_function.__name__] = prior_function
+
     return prior_function
 
 

--- a/pyfstat/injection_parameters.py
+++ b/pyfstat/injection_parameters.py
@@ -323,7 +323,7 @@ class InjectionParametersGenerator:
         }
 
     def draw_many(self, size) -> dict:
-        """Draw a ``size`` multi-dimensional parameter space point from the given priors.
+        """Draw ``size`` multi-dimensional parameter space points from the given priors.
 
         Parameters
         ----------

--- a/pyfstat/injection_parameters.py
+++ b/pyfstat/injection_parameters.py
@@ -206,10 +206,9 @@ class InjectionParametersGenerator:
                 "use either a `seed` or an already initialized `np.random.Generator`"
             )
         if (not seed) and (not generator):
-            logger.warning(
-                f"No `generator` was provided and `seed` was set to {seed}, "
-                "which looks uninitialized. "
-                "Please, make sure you are aware of your seed choice"
+            logger.info(
+                "No `generator` or `seed` was provided."
+                f" Will use default `np.random.default_rng({seed})`"
             )
 
         self._rng = generator or np.random.default_rng(seed)

--- a/pyfstat/injection_parameters.py
+++ b/pyfstat/injection_parameters.py
@@ -310,21 +310,14 @@ class InjectionParametersGenerator:
         Returns
         -------
         injection_parameters:
-            Structured array with parameter names as keys and their numeric values.
+            Dictionary of arrays. Each key corresponds to that found in `self.priors`.
+            Return values are as given by the corresponding method.
         """
 
-        injection_parameters = {
+        return {
             parameter_name: parameter_prior(size=size)
             for parameter_name, parameter_prior in self.priors.items()
         }
-
-        dtype = [(key, val.dtype) for key, val in injection_parameters.items()]
-
-        out = np.empty(size, dtype=dtype)
-        for key in injection_parameters:
-            out[key] = injection_parameters[key]
-
-        return out
 
 
 class AllSkyInjectionParametersGenerator(InjectionParametersGenerator):

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -12,7 +12,6 @@ import numpy as np
 from tqdm import tqdm, trange
 
 import pyfstat.utils as utils
-from pyfstat import injection_parameters
 from pyfstat.core import BaseSearchClass, SearchForSignalWithJumps
 
 logger = logging.getLogger(__name__)
@@ -1685,23 +1684,3 @@ class FrequencyAmplitudeModulatedArtifactWriter(FrequencyModulatedArtifactWriter
             Amplitude at time `t`.
         """
         return self.h0 * np.sin(2 * np.pi * t / self.Pmod + self.Pmod_phi)
-
-
-class InjectionParametersGenerator(injection_parameters.InjectionParametersGenerator):
-    def __new__(cls, *args, **kwargs):
-        logger.warning(
-            "This class was moved to a different module within this same package (`injection_parameters`) "
-            "and will be removed from this module (`make_sfts`) in a future release. "
-        )
-        super().__new__(cls, *args, **kwargs)
-
-
-class AllSkyInjectionParametersGenerator(
-    injection_parameters.AllSkyInjectionParametersGenerator
-):
-    def __new__(cls, *args, **kwargs):
-        logger.warning(
-            "This class was moved to a different module within this same package (`injection_parameters`) "
-            "and will be removed from this module (`make_sfts`) in a future release. "
-        )
-        super().__new__(cls, *args, **kwargs)

--- a/tests/test_injection_parameters.py
+++ b/tests/test_injection_parameters.py
@@ -83,14 +83,17 @@ def test_seed_and_generator_compatibility(input_priors, seed, rng_object):
     ipg_seed = InjectionParametersGenerator(priors=input_priors, seed=seed)
     ipg_gen = InjectionParametersGenerator(priors=input_priors, generator=rng_object)
 
-    assert np.all(ipg_gen.draw(size=5) == ipg_seed.draw(size=5))
+    gen_draw = ipg_gen.draw_many(size=5)
+    seed_draw = ipg_seed.draw_many(size=5)
+    for key in input_priors:
+        assert np.all(gen_draw[key] == seed_draw[key])
 
 
 @pytest.mark.flaky(max_runs=3, min_passes=1, rerun_filter=is_flaky)
 def test_rng_sampling(input_priors, rng_object):
     ipg = InjectionParametersGenerator(priors=input_priors, generator=rng_object)
 
-    samples = ipg.draw(size=10000)
+    samples = ipg.draw_many(size=10000)
     for key in ipg.priors:
         np.testing.assert_allclose(samples[key].mean(), 0, atol=5e-2)
 
@@ -99,7 +102,7 @@ def test_rng_sampling(input_priors, rng_object):
 def test_all_sky_generation(rng_object):
     all_sky = AllSkyInjectionParametersGenerator(generator=rng_object)
 
-    samples = all_sky.draw(size=10000)
+    samples = all_sky.draw_many(size=10000)
 
     np.testing.assert_allclose(samples["Alpha"].mean(), np.pi, atol=5e-2)
     np.testing.assert_allclose(samples["Delta"].mean(), 0, atol=5e-2)

--- a/tests/test_injection_parameters.py
+++ b/tests/test_injection_parameters.py
@@ -83,8 +83,7 @@ def test_seed_and_generator_compatibility(input_priors, seed, rng_object):
     ipg_seed = InjectionParametersGenerator(priors=input_priors, seed=seed)
     ipg_gen = InjectionParametersGenerator(priors=input_priors, generator=rng_object)
 
-    for i in range(5):
-        assert ipg_gen.draw() == ipg_seed.draw()
+    assert np.all(ipg_gen.draw(size=5) == ipg_seed.draw(size=5))
 
 
 @pytest.mark.flaky(max_runs=3, min_passes=1, rerun_filter=is_flaky)

--- a/tests/test_injection_parameters.py
+++ b/tests/test_injection_parameters.py
@@ -18,7 +18,6 @@ def my_custom_prior(generator, shift):
     return -2 * generator.uniform() + shift
 
 
-# FIXME add toml case
 @pytest.fixture(
     params=[
         {

--- a/tests/test_injection_parameters.py
+++ b/tests/test_injection_parameters.py
@@ -66,6 +66,14 @@ def test_prior_parsing(input_priors, rng_object):
     for key in input_priors:
         assert key in ipg.priors
 
+    faulty_prior = {"faulty_parameter": {"distro_one": {}, "distro_two": {}}}
+    with pytest.raises(ValueError):
+        InjectionParametersGenerator(priors=faulty_prior, generator=rng_object)
+
+    faulty_prior = {"faulty_parameter": {0: {}}}
+    with pytest.raises(ValueError):
+        InjectionParametersGenerator(priors=faulty_prior, generator=rng_object)
+
 
 def test_seed_and_generator_init(caplog, input_priors, seed, rng_object):
 

--- a/tests/test_injection_parameters.py
+++ b/tests/test_injection_parameters.py
@@ -4,12 +4,8 @@ import numpy as np
 import pytest
 from commons_for_tests import is_flaky
 
-from pyfstat import (
-    AllSkyInjectionParametersGenerator,
-    InjectionParametersGenerator,
-    custom_prior,
-)
-from pyfstat.injection_parameters import _pyfstat_custom_priors
+from pyfstat import AllSkyInjectionParametersGenerator, InjectionParametersGenerator
+from pyfstat.injection_parameters import _pyfstat_custom_priors, custom_prior
 
 
 @custom_prior

--- a/tests/test_injection_parameters.py
+++ b/tests/test_injection_parameters.py
@@ -2,21 +2,38 @@ import numpy as np
 import pytest
 from commons_for_tests import is_flaky
 
-from pyfstat import AllSkyInjectionParametersGenerator, InjectionParametersGenerator
+from pyfstat import (
+    AllSkyInjectionParametersGenerator,
+    InjectionParametersGenerator,
+    custom_prior,
+)
+from pyfstat.injection_parameters import _pyfstat_custom_priors
+
+print(_pyfstat_custom_priors)
 
 
+@custom_prior
 def my_custom_prior(generator, shift):
     # Mean 0 so tests are simple
     return -2 * generator.uniform() + shift
 
 
-@pytest.fixture()
-def input_priors():
-    return {
-        "gaussian_parameter": {"stats.norm": {"loc": 0.0, "scale": 1.0}},
-        # "custom_parameter": {"my_custom_prior": {"shift": 1.}},
-        "fixed_parameter": 0.0,
-    }
+# FIXME add toml case
+@pytest.fixture(
+    params=[
+        {
+            "gaussian_parameter": {"stats.norm": {"loc": 0.0, "scale": 1.0}},
+            "fixed_parameter": 0.0,
+        },
+        {
+            "function_prior": {"my_custom_prior": {"shift": 1.0}},
+            "now_from_module": {"uniform_sky_declination": {}},
+        },
+    ],
+    ids=["dictionary", "functions"],
+)
+def input_priors(request):
+    return request.param
 
 
 @pytest.fixture()

--- a/tests/test_injection_parameters.py
+++ b/tests/test_injection_parameters.py
@@ -1,0 +1,62 @@
+import numpy as np
+import pytest
+from commons_for_tests import is_flaky
+
+from pyfstat import AllSkyInjectionParametersGenerator, InjectionParametersGenerator
+
+
+def my_custom_prior(generator, shift):
+    # Mean 0 so tests are simple
+    return -2 * generator.uniform() + shift
+
+
+@pytest.fixture()
+def input_priors():
+    return {
+        "gaussian_parameter": {"stats.norm": {"loc": 0.0, "scale": 1.0}},
+        # "custom_parameter": {"my_custom_prior": {"shift": 1.}},
+    }
+
+
+@pytest.fixture()
+def seed():
+    return 150914
+
+
+@pytest.fixture()
+def rng_object(seed):
+    return np.random.default_rng(seed)
+
+
+def test_prior_parsing(input_priors, rng_object):
+    ipg = InjectionParametersGenerator(priors=input_priors, generator=rng_object)
+
+    for key in input_priors:
+        assert key in ipg.priors
+
+
+def test_seed_and_generator_consistency(input_priors, seed, rng_object):
+    ipg_seed = InjectionParametersGenerator(priors=input_priors, seed=seed)
+    ipg_gen = InjectionParametersGenerator(priors=input_priors, generator=rng_object)
+
+    for i in range(5):
+        assert ipg_gen.draw() == ipg_seed.draw()
+
+
+@pytest.mark.flaky(max_runs=3, min_passes=1, rerun_filter=is_flaky)
+def test_rng_sampling(input_priors, rng_object):
+    ipg = InjectionParametersGenerator(priors=input_priors, generator=rng_object)
+
+    samples = [ipg.draw() for i in range(10000)]
+    for key in ipg.priors:
+        np.testing.assert_allclose(np.mean([s[key] for s in samples]), 0, atol=5e-2)
+
+
+@pytest.mark.flaky(max_runs=3, min_passes=1, rerun_filter=is_flaky)
+def test_all_sky_generation(rng_object):
+    all_sky = AllSkyInjectionParametersGenerator(generator=rng_object)
+
+    samples = [all_sky.draw() for i in range(10000)]
+
+    np.testing.assert_allclose(np.mean([s["Alpha"] for s in samples]), np.pi, atol=5e-2)
+    np.testing.assert_allclose(np.mean([s["Delta"] for s in samples]), 0, atol=5e-2)

--- a/tests/test_injection_parameters.py
+++ b/tests/test_injection_parameters.py
@@ -82,9 +82,9 @@ def test_seed_and_generator_init(caplog, input_priors, seed, rng_object):
             priors=input_priors, seed=seed, generator=rng_object
         )
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.INFO):
         InjectionParametersGenerator(priors=input_priors, seed=None, generator=None)
-    assert "uninitialized" in caplog.text
+    assert "use default" in caplog.text
 
 
 def test_seed_and_generator_compatibility(input_priors, seed, rng_object):

--- a/tests/test_injection_parameters.py
+++ b/tests/test_injection_parameters.py
@@ -9,8 +9,6 @@ from pyfstat import (
 )
 from pyfstat.injection_parameters import _pyfstat_custom_priors
 
-print(_pyfstat_custom_priors)
-
 
 @custom_prior
 def my_custom_prior(generator, shift):
@@ -43,6 +41,18 @@ def seed():
 @pytest.fixture()
 def rng_object(seed):
     return np.random.default_rng(seed)
+
+
+def test_custom_prior_decorator():
+    @custom_prior
+    def dummy_prior(generator):
+        # For testing purposes
+        return
+
+    assert dummy_prior.__name__ in _pyfstat_custom_priors
+
+    with pytest.raises(ValueError):
+        custom_prior(dummy_prior)
 
 
 def test_prior_parsing(input_priors, rng_object):

--- a/tests/test_injection_parameters.py
+++ b/tests/test_injection_parameters.py
@@ -15,6 +15,7 @@ def input_priors():
     return {
         "gaussian_parameter": {"stats.norm": {"loc": 0.0, "scale": 1.0}},
         # "custom_parameter": {"my_custom_prior": {"shift": 1.}},
+        "fixed_parameter": 0.0,
     }
 
 

--- a/tests/test_injection_parameters.py
+++ b/tests/test_injection_parameters.py
@@ -1,3 +1,5 @@
+import logging
+
 import numpy as np
 import pytest
 from commons_for_tests import is_flaky
@@ -62,7 +64,19 @@ def test_prior_parsing(input_priors, rng_object):
         assert key in ipg.priors
 
 
-def test_seed_and_generator_consistency(input_priors, seed, rng_object):
+def test_seed_and_generator_init(caplog, input_priors, seed, rng_object):
+
+    with pytest.raises(ValueError):
+        InjectionParametersGenerator(
+            priors=input_priors, seed=seed, generator=rng_object
+        )
+
+    with caplog.at_level(logging.WARNING):
+        InjectionParametersGenerator(priors=input_priors, seed=None, generator=None)
+    assert "uninitialized" in caplog.text
+
+
+def test_seed_and_generator_compatibility(input_priors, seed, rng_object):
     ipg_seed = InjectionParametersGenerator(priors=input_priors, seed=seed)
     ipg_gen = InjectionParametersGenerator(priors=input_priors, generator=rng_object)
 

--- a/tests/test_old_api_injection_parameters.py
+++ b/tests/test_old_api_injection_parameters.py
@@ -7,11 +7,14 @@ import pyfstat
 
 @pytest.fixture(
     params=[
-        {key: {"uniform": {"low": key, "high": key}} for key in [0.0, 1.0]},
         {
-            key: (lambda value=key: value) for key in [0.0, 1.0]
+            f"parameter_{key}_old": {"uniform": {"low": key, "high": key}}
+            for key in [0.0, 1.0]
+        },
+        {
+            f"parameter_{key}_old": (lambda value=key: value) for key in [0.0, 1.0]
         },  # Lambda + Comprehension
-        {key: key for key in [0.0, 1.0]},
+        {f"parameter_{key}_old": key for key in [0.0, 1.0]},
     ],
     ids=["Numpy-priors", "callable-priors", "fixed-priors"],
 )
@@ -36,19 +39,22 @@ def seed():
 
 def test_prior_parsing(parameters_generator, empty_priors, seed):
     parameters = parameters_generator(priors=empty_priors, seed=seed).draw()
-    print(empty_priors)
-    for key in empty_priors:
-        assert parameters[key] == key
+    print(parameters)
+    for key in parameters:
+        if key not in ["Alpha", "Delta"]:
+            assert parameters[key] == float(key[-3:])
 
 
 def test_seed_and_generator_consistency(parameters_generator, seed):
-    priors = {"parameter": {"normal": {"loc": 0, "scale": 1}}}
+    priors = {"parameter_old": {"normal": {"loc": 0, "scale": 1}}}
 
     seed_generator = parameters_generator(priors=priors, seed=seed)
     generator_generator = parameters_generator(
         priors=priors, generator=np.random.default_rng(seed)
     )
     for i in range(5):
+        print(seed_generator.draw())
+        print(generator_generator.draw())
         assert (
             seed_generator.draw()["parameter"]
             == generator_generator.draw()["parameter"]
@@ -60,7 +66,7 @@ def test_rng_seed(parameters_generator, seed):
     samples = []
     for i in range(2):
         injection_generator = parameters_generator(
-            priors={"ParameterA": {"normal": {"loc": 0, "scale": 1}}}, seed=seed
+            priors={"ParameterA_old": {"normal": {"loc": 0, "scale": 1}}}, seed=seed
         )
         samples.append(injection_generator.draw())
 
@@ -72,7 +78,7 @@ def test_rng_seed(parameters_generator, seed):
 @pytest.mark.flaky(max_runs=5, min_passes=1, rerun_filter=is_flaky)
 def test_rng_generation(parameters_generator, seed):
     injection_generator = parameters_generator(
-        priors={"ParameterA": {"normal": {"loc": 0, "scale": 0.01}}}, seed=seed
+        priors={"ParameterA_old": {"normal": {"loc": 0, "scale": 0.01}}}, seed=seed
     )
 
     samples = [injection_generator.draw() for i in range(1000)]


### PR DESCRIPTION
Closes #485 

Things to do:

- [x] Rethink how to specify seeds and distributions. Probably the solution is [this one](https://stackoverflow.com/questions/16016959/scipy-stats-seed) (i.e. move to Scipy stats and let the class attach the random number generator).
- [x] Keep supporting fixed values.
- [x] Find a transparent way of specifying functions, that includes:
    - [x] A deterministic function being applied to the output of a random number generator.
    - [x] A random function which combines several sampling procedures into a black box (probably easy as giving `Generator` as an input). 
- ~Test that all these can be done from a TOML file with a proper syntax.~ Input is consistent with what the user can specify in a TOML file, so this is all god.
- ~Use structured arrays rather than dicts?~ Left for future implementation. Typing of outputs may be tricky.