### PR TITLE
fix segfault in get_semicoherent_single_IFO_twoFs() with recent lalsuite

### DIFF
--- a/docs/source/pyfstat.utils.rst
+++ b/docs/source/pyfstat.utils.rst
@@ -7,13 +7,21 @@ Most of these are used internally by other parts of the package
 and are of interest mostly only for developers,
 but others can also be helpful for end users.
 
-Functions in these modules can be directly acessed via ``pyfstat.utils``
+Functions in these modules can be directly accessed via ``pyfstat.utils``
 without explicitly mentioning the specific module in where they reside.
 (E.g. just call ``pyfstat.utils.some_function``,
 not ``pyfstat.utils.some_topic.some_function``.)
 
 Submodules
 ----------
+
+pyfstat.utils.atoms module
+--------------------------
+
+.. automodule:: pyfstat.utils.atoms
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 pyfstat.utils.cli module
 ------------------------

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -1317,19 +1317,10 @@ class ComputeFstat(BaseSearchClass):
         # and return the maximum of that?
         idx_maxTwoF = self.FstatMap.get_maxF_idx()
         for X in range(self.FstatResults.numDetectors):
-            # For each detector, we need to build a MultiFstatAtomVector
-            # because that's what the Fstat map function expects.
-            singleIFOmultiFatoms = lalpulsar.CreateMultiFstatAtomVector(1)
-            # The first [0] index on the multiFatoms here is over frequency bins;
+            # The [0] index on the multiFatoms here is over frequency bins;
             # we always operate on a single bin.
-            singleIFOmultiFatoms.data[0] = lalpulsar.CreateFstatAtomVector(
-                self.FstatResults.multiFatoms[0].data[X].length
-            )
-            singleIFOmultiFatoms.data[0].TAtom = (
-                self.FstatResults.multiFatoms[0].data[X].TAtom
-            )
-            singleIFOmultiFatoms.data[0].data = (
-                self.FstatResults.multiFatoms[0].data[X].data
+            singleIFOmultiFatoms = utils.extract_singleIFOmultiFatoms_from_multiAtoms(
+                self.FstatResults.multiFatoms[0], X
             )
             FXstatMap, timingFXstatMap = tcw.call_compute_transient_fstat_map(
                 self.tCWFstatMapVersion,
@@ -1987,38 +1978,11 @@ class SemiCoherentSearch(ComputeFstat):
                 "This function is available only if singleFstats or BSGL options were set."
             )
         for X in range(self.FstatResults.numDetectors):
-            # For each detector, we need to build a MultiFstatAtomVector
-            # because that's what the Fstat map function expects.
-            singleIFOmultiFatoms = lalpulsar.CreateMultiFstatAtomVector(1)
-            # The first [0] index on the multiFatoms here is over frequency bins;
+            # The [0] index on the multiFatoms here is over frequency bins;
             # we always operate on a single bin.
-            singleIFOmultiFatoms.data[0] = lalpulsar.CreateFstatAtomVector(
-                self.FstatResults.multiFatoms[0].data[X].length
+            singleIFOmultiFatoms = utils.extract_singleIFOmultiFatoms_from_multiAtoms(
+                self.FstatResults.multiFatoms[0], X
             )
-            singleIFOmultiFatoms.data[0].TAtom = (
-                self.FstatResults.multiFatoms[0].data[X].TAtom
-            )
-            # we manually copy the atoms data,
-            # since assigning the whole array can cause a segfault
-            # from memory cleanup
-            # in looping over this function
-            # singleIFOmultiFatoms.data[0].data = (
-            #     self.FstatResults.multiFatoms[0].data[X].data
-            # )
-            for k in range(singleIFOmultiFatoms.data[0].length):
-                for key in [
-                    "timestamp",
-                    "a2_alpha",
-                    "b2_alpha",
-                    "ab_alpha",
-                    "Fa_alpha",
-                    "Fb_alpha",
-                ]:
-                    setattr(
-                        singleIFOmultiFatoms.data[0].data[k],
-                        key,
-                        getattr(self.FstatResults.multiFatoms[0].data[X].data[k], key),
-                    )
             FXstatMap = lalpulsar.ComputeTransientFstatMap(
                 multiFstatAtoms=singleIFOmultiFatoms,
                 windowRange=self.semicoherentWindowRange,

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -1998,9 +1998,27 @@ class SemiCoherentSearch(ComputeFstat):
             singleIFOmultiFatoms.data[0].TAtom = (
                 self.FstatResults.multiFatoms[0].data[X].TAtom
             )
-            singleIFOmultiFatoms.data[0].data = (
-                self.FstatResults.multiFatoms[0].data[X].data
-            )
+            # we manually copy the atoms data,
+            # since assigning the whole array can cause a segfault
+            # from memory cleanup
+            # in looping over this function
+            # singleIFOmultiFatoms.data[0].data = (
+            #     self.FstatResults.multiFatoms[0].data[X].data
+            # )
+            for k in range(singleIFOmultiFatoms.data[0].length):
+                for key in [
+                    "timestamp",
+                    "a2_alpha",
+                    "b2_alpha",
+                    "ab_alpha",
+                    "Fa_alpha",
+                    "Fb_alpha",
+                ]:
+                    setattr(
+                        singleIFOmultiFatoms.data[0].data[k],
+                        key,
+                        getattr(self.FstatResults.multiFatoms[0].data[X].data[k], key),
+                    )
             FXstatMap = lalpulsar.ComputeTransientFstatMap(
                 multiFstatAtoms=singleIFOmultiFatoms,
                 windowRange=self.semicoherentWindowRange,

--- a/pyfstat/utils/__init__.py
+++ b/pyfstat/utils/__init__.py
@@ -6,6 +6,7 @@ and are of interest mostly only for developers,
 but others can also be helpful for end users.
 """
 
+from .atoms import extract_singleIFOmultiFatoms_from_multiAtoms
 from .cli import match_commandlines, run_commandline
 from .converting import (
     convert_aPlus_aCross_to_h0_cosi,

--- a/pyfstat/utils/__init__.py
+++ b/pyfstat/utils/__init__.py
@@ -6,7 +6,7 @@ and are of interest mostly only for developers,
 but others can also be helpful for end users.
 """
 
-from .atoms import extract_singleIFOmultiFatoms_from_multiAtoms
+from .atoms import copy_FstatAtomVector, extract_singleIFOmultiFatoms_from_multiAtoms
 from .cli import match_commandlines, run_commandline
 from .converting import (
     convert_aPlus_aCross_to_h0_cosi,

--- a/pyfstat/utils/atoms.py
+++ b/pyfstat/utils/atoms.py
@@ -37,15 +37,13 @@ def extract_singleIFOmultiFatoms_from_multiAtoms(
     # we deep-copy the entries of the atoms vector,
     # since just assigning the whole array can cause a segfault
     # from memory cleanup in looping over this function
-    singleIFOmultiFatoms.data[0] = copy_FstatAtomVector(
-        singleIFOmultiFatoms.data[0], multiAtoms.data[X]
-    )
+    copy_FstatAtomVector(singleIFOmultiFatoms.data[0], multiAtoms.data[X])
     return singleIFOmultiFatoms
 
 
 def copy_FstatAtomVector(
     dest: lalpulsar.FstatAtomVector, src: lalpulsar.FstatAtomVector
-) -> lalpulsar.FstatAtomVector:
+):
     """Deep-copy an FstatAtomVector with all its per-SFT FstatAtoms.
 
     The two vectors must have the same length,
@@ -56,12 +54,9 @@ def copy_FstatAtomVector(
     dest:
         The destination vector to copy to.
         Must already be allocated.
+        Will be modified in-place.
     src:
         The source vector to copy from.
-    Returns
-    -------
-    dest:
-        The updated destination vector.
     """
     if dest.length != src.length:
         raise ValueError(
@@ -72,4 +67,3 @@ def copy_FstatAtomVector(
         # this is now copying the actual FstatAtom object,
         # with its actual data in memory (no more pointers)
         dest.data[k] = src.data[k]
-    return dest

--- a/pyfstat/utils/atoms.py
+++ b/pyfstat/utils/atoms.py
@@ -34,14 +34,9 @@ def extract_singleIFOmultiFatoms_from_multiAtoms(
     singleIFOmultiFatoms.data[0] = lalpulsar.CreateFstatAtomVector(
         multiAtoms.data[X].length
     )
-    singleIFOmultiFatoms.data[0].TAtom = multiAtoms.data[X].TAtom
-    # we deep-copy the atoms data,
+    # we deep-copy the entries of the atoms vector,
     # since just assigning the whole array can cause a segfault
-    # from memory cleanup
-    # in looping over this function
-    # singleIFOmultiFatoms.data[0].data = (
-    #     multiAtoms.data[X].data
-    # )
+    # from memory cleanup in looping over this function
     singleIFOmultiFatoms.data[0] = copy_FstatAtomVector(
         singleIFOmultiFatoms.data[0], multiAtoms.data[X]
     )
@@ -72,38 +67,9 @@ def copy_FstatAtomVector(
         raise ValueError(
             f"Lengths of destination and source vectors do not match. ({dest.length} != {src.length})"
         )
+    dest.TAtom = src.TAtom
     for k in range(dest.length):
-        dest.data[k] = copy_FstatAtom(dest.data[k], src.data[k])
-    return dest
-
-
-def copy_FstatAtom(
-    dest: lalpulsar.FstatAtom, src: lalpulsar.FstatAtom
-) -> lalpulsar.FstatAtom:
-    """Deep-copy an FstatAtom with all its fields.
-
-    Parameters
-    -------
-    dest:
-        The destination atom object to copy to.
-    src:
-        The source atom object to copy from.
-    Returns
-    -------
-    dest:
-        The updated destination atom object.
-    """
-    for key in [
-        "timestamp",
-        "a2_alpha",
-        "b2_alpha",
-        "ab_alpha",
-        "Fa_alpha",
-        "Fb_alpha",
-    ]:
-        setattr(
-            dest,
-            key,
-            getattr(src, key),
-        )
+        # this is now copying the actual FstatAtom object,
+        # with its actual data in memory (no more pointers)
+        dest.data[k] = src.data[k]
     return dest

--- a/pyfstat/utils/atoms.py
+++ b/pyfstat/utils/atoms.py
@@ -26,7 +26,7 @@ def extract_singleIFOmultiFatoms_from_multiAtoms(
     singleIFOmultiFatoms:
         Length-1 MultiFstatAtomVector with only the data for detector `X`.
     """
-    if X > multiAtoms.length:
+    if X >= multiAtoms.length:
         raise ValueError(
             f"Detector index {X} is out of range for multiAtoms of length {multiAtoms.length}."
         )

--- a/pyfstat/utils/atoms.py
+++ b/pyfstat/utils/atoms.py
@@ -1,0 +1,109 @@
+import logging
+
+import lalpulsar
+
+logger = logging.getLogger(__name__)
+
+
+def extract_singleIFOmultiFatoms_from_multiAtoms(
+    multiAtoms: lalpulsar.MultiFstatAtomVector, X: int
+) -> lalpulsar.MultiFstatAtomVector:
+    """Extract a length-1 MultiFstatAtomVector from a larger MultiFstatAtomVector.
+
+    The result is needed as input to ``lalpulsar.ComputeTransientFstatMap`` in some places.
+
+    The new object is freshly allocated,
+    and we do a deep copy of the actual per-timestamp atoms.
+
+    Parameters
+    -------
+    multiAtoms:
+        Fully allocated multi-detector struct of `length > X`.
+    X:
+        The detector index for which to extract atoms.
+    Returns
+    -------
+    singleIFOmultiFatoms:
+        Length-1 MultiFstatAtomVector with only the data for detector `X`.
+    """
+    if X > multiAtoms.length:
+        raise ValueError(
+            f"Detector index {X} is out of range for multiAtoms of length {multiAtoms.length}."
+        )
+    singleIFOmultiFatoms = lalpulsar.CreateMultiFstatAtomVector(1)
+    singleIFOmultiFatoms.data[0] = lalpulsar.CreateFstatAtomVector(
+        multiAtoms.data[X].length
+    )
+    singleIFOmultiFatoms.data[0].TAtom = multiAtoms.data[X].TAtom
+    # we deep-copy the atoms data,
+    # since just assigning the whole array can cause a segfault
+    # from memory cleanup
+    # in looping over this function
+    # singleIFOmultiFatoms.data[0].data = (
+    #     multiAtoms.data[X].data
+    # )
+    singleIFOmultiFatoms.data[0] = copy_FstatAtomVector(
+        singleIFOmultiFatoms.data[0], multiAtoms.data[X]
+    )
+    return singleIFOmultiFatoms
+
+
+def copy_FstatAtomVector(
+    dest: lalpulsar.FstatAtomVector, src: lalpulsar.FstatAtomVector
+) -> lalpulsar.FstatAtomVector:
+    """Deep-copy an FstatAtomVector with all its per-SFT FstatAtoms.
+
+    The two vectors must have the same length,
+    and the destination vector must already be allocated.
+
+    Parameters
+    -------
+    dest:
+        The destination vector to copy to.
+        Must already be allocated.
+    src:
+        The source vector to copy from.
+    Returns
+    -------
+    dest:
+        The updated destination vector.
+    """
+    if dest.length != src.length:
+        raise ValueError(
+            f"Lengths of destination and source vectors do not match. ({dest.length} != {src.length})"
+        )
+    for k in range(dest.length):
+        dest.data[k] = copy_FstatAtom(dest.data[k], src.data[k])
+    return dest
+
+
+def copy_FstatAtom(
+    dest: lalpulsar.FstatAtom, src: lalpulsar.FstatAtom
+) -> lalpulsar.FstatAtom:
+    """Deep-copy an FstatAtom with all its fields.
+
+    Parameters
+    -------
+    dest:
+        The destination atom object to copy to.
+    src:
+        The source atom object to copy from.
+    Returns
+    -------
+    dest:
+        The updated destination atom object.
+    """
+    for key in [
+        "timestamp",
+        "a2_alpha",
+        "b2_alpha",
+        "ab_alpha",
+        "Fa_alpha",
+        "Fb_alpha",
+    ]:
+        setattr(
+            dest,
+            key,
+            getattr(src, key),
+        )
+    return dest

--- a/tests/test_utils/test_atoms.py
+++ b/tests/test_utils/test_atoms.py
@@ -1,7 +1,7 @@
 import lalpulsar
 import pytest
 
-from pyfstat.utils.atoms import (
+from pyfstat.utils import (
     copy_FstatAtomVector,
     extract_singleIFOmultiFatoms_from_multiAtoms,
 )

--- a/tests/test_utils/test_atoms.py
+++ b/tests/test_utils/test_atoms.py
@@ -1,0 +1,74 @@
+import lalpulsar
+import pytest
+
+from pyfstat.utils.atoms import (
+    copy_FstatAtomVector,
+    extract_singleIFOmultiFatoms_from_multiAtoms,
+)
+
+
+@pytest.fixture
+def arbitrary_singleAtoms():
+    single_atoms = lalpulsar.CreateFstatAtomVector(5)
+    for i in range(single_atoms.length):
+
+        for attr in ["TAtom"]:
+            setattr(single_atoms, attr, i)
+        for attr in [
+            "timestamp",
+            "a2_alpha",
+            "b2_alpha",
+            "ab_alpha",
+            "Fa_alpha",
+            "Fb_alpha",
+        ]:
+            setattr(single_atoms.data[i], attr, i)
+
+    return single_atoms
+
+
+@pytest.fixture
+def arbitrary_multiAtoms(arbitrary_singleAtoms):
+    ma = lalpulsar.CreateMultiFstatAtomVector(1)
+    ma.data[0] = arbitrary_singleAtoms
+    return ma
+
+
+def compare_FstatAtomVector(vectorA, vectorB):
+
+    for attr in ["TAtom", "length"]:
+        assert getattr(vectorA, attr) == getattr(vectorB, attr)
+
+    for i in range(vectorA.length):
+
+        for attr in [
+            "timestamp",
+            "a2_alpha",
+            "b2_alpha",
+            "ab_alpha",
+            "Fa_alpha",
+            "Fb_alpha",
+        ]:
+            assert getattr(vectorA.data[i], attr) == getattr(vectorB.data[i], attr)
+
+
+def test_extract_singleIFOmultiFatoms_from_multiAtoms(
+    arbitrary_singleAtoms, arbitrary_multiAtoms
+):
+
+    single_atoms = extract_singleIFOmultiFatoms_from_multiAtoms(arbitrary_multiAtoms, 0)
+    compare_FstatAtomVector(single_atoms.data[0], arbitrary_multiAtoms.data[0])
+
+    with pytest.raises(ValueError):
+        extract_singleIFOmultiFatoms_from_multiAtoms(arbitrary_multiAtoms, 1)
+
+
+def test_copy_FstatAtomVector(arbitrary_singleAtoms):
+
+    single_atoms = lalpulsar.CreateFstatAtomVector(arbitrary_singleAtoms.length)
+    copy_FstatAtomVector(single_atoms, arbitrary_singleAtoms)
+    compare_FstatAtomVector(single_atoms, arbitrary_singleAtoms)
+
+    faulty_atoms = lalpulsar.CreateFstatAtomVector(arbitrary_singleAtoms.length + 1)
+    with pytest.raises(ValueError):
+        copy_FstatAtomVector(faulty_atoms, arbitrary_singleAtoms)

--- a/tests/test_utils/test_atoms.py
+++ b/tests/test_utils/test_atoms.py
@@ -10,10 +10,11 @@ from pyfstat.utils import (
 @pytest.fixture
 def arbitrary_singleAtoms():
     single_atoms = lalpulsar.CreateFstatAtomVector(5)
+
+    single_atoms.TAtom = 1800
+
     for i in range(single_atoms.length):
 
-        for attr in ["TAtom"]:
-            setattr(single_atoms, attr, i)
         for attr in [
             "timestamp",
             "a2_alpha",


### PR DESCRIPTION
 - fixes #488
 - segfault discovered via `pytest tests/test_grid_based_searches.py::TestGridSearchBSGL::test_semicoherent_grid_search` with `lalsuite>=7.10.1.dev20221025`
 - non-elegant solution for now: manual deepcopy of atoms data array
 - timing impact seems to negligible 