### PR TITLE
Writer timestamps handling improvements

### DIFF
--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -346,6 +346,13 @@ class Writer(BaseSearchClass):
                     " we will ignore the rest."
                 )
                 tsX = tsX[:, 0]
+            if not np.issubdtype(tsX.dtype, np.integer):
+                logger.warning(
+                    "Detected non-integer timestamps in timestamp file."
+                    " Will floor into ints."
+                )
+                tsX = tsX.astype(int)
+
             this_start_time = int(tsX[0])
             this_end_time = int(tsX[-1]) + self.Tsft
             tstart.append(this_start_time)

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -346,12 +346,12 @@ class Writer(BaseSearchClass):
                     " we will ignore the rest."
                 )
                 tsX = tsX[:, 0]
-            if not np.issubdtype(tsX.dtype, np.integer):
+            if not tsX[0].is_integer() or not tsX[-1].is_integer():
                 logger.warning(
                     "Detected non-integer timestamps in timestamp file."
-                    " Will floor into ints."
+                    " We will floor to the nearest integer for the SFT name"
+                    " and let MFDv5 to properly deal with it."
                 )
-                tsX = tsX.astype(int)
 
             this_start_time = int(tsX[0])
             this_end_time = int(tsX[-1]) + self.Tsft

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -349,8 +349,9 @@ class Writer(BaseSearchClass):
             if not tsX[0].is_integer() or not tsX[-1].is_integer():
                 logger.warning(
                     "Detected non-integer timestamps in timestamp file."
-                    " We will floor to the nearest integer for the SFT name"
-                    " and let MFDv5 to properly deal with it."
+                    " We will floor start and end times to the nearest integer"
+                    " for the SFT name,"
+                    " and let lalpulsar_Makefakedata_v5 handle the rest."
                 )
 
             this_start_time = int(tsX[0])

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -189,7 +189,7 @@ class Writer(BaseSearchClass):
             list of timestamps (`detectors` should be set),
             or comma-separated list of per-detector timestamps files
             (simple text files,
-            comments should use `%`,
+            comments must use `%`,
             the first column is interpreted as SFT start times
             and additional columns are ignored)
             WARNING: In that last case, order must match that of `detectors`!
@@ -340,7 +340,7 @@ class Writer(BaseSearchClass):
         self.sftfilenames = []  # This refers to the MFD output!
         for X, IFO in enumerate(IFOs):
             tsX = np.genfromtxt(tsfiles[X], comments="%")
-            if len(np.shape(tsX)) > 1:
+            if tsX.ndim > 1:
                 logger.warning(
                     f"Timestamps file {tsfiles[X]} has more than 1 column,"
                     " we will ignore the rest."

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -345,7 +345,7 @@ class Writer(BaseSearchClass):
                     f"Timestamps file {tsfiles[X]} has more than 1 column,"
                     " we will ignore the rest."
                 )
-                tsX = tsX[0, :]
+                tsX = tsX[:, 0]
             this_start_time = int(tsX[0])
             this_end_time = int(tsX[-1]) + self.Tsft
             tstart.append(this_start_time)

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -412,9 +412,7 @@ class Writer(BaseSearchClass):
             output_file = os.path.join(
                 self.outdir, f"{self.label}_timestamps_{ifos[ind]}.csv"
             )
-            left_column = np.floor(ts).reshape(-1, 1)
-            right_column = np.floor(1e9 * (np.reshape(ts, (-1, 1)) - left_column))
-            np.savetxt(output_file, np.hstack((left_column, right_column)), fmt="%d")
+            np.savetxt(output_file, ts.reshape(-1, 1), fmt="%d")
             timestamp_files.append(output_file)
         self.timestamps = ",".join(timestamp_files)
 

--- a/tests/test_make_sfts.py
+++ b/tests/test_make_sfts.py
@@ -431,7 +431,6 @@ class TestWriter(BaseForTestsWithData):
             )
             self.assertTrue(os.path.isfile(timestamps_file))
             ts = np.genfromtxt(timestamps_file)
-            ts = ts[:, 0] + 1e-9 * ts[:, 1]
             np.testing.assert_almost_equal(ts, timestamps[ifo])
 
         # Test dictionary with input detector
@@ -463,7 +462,6 @@ class TestWriter(BaseForTestsWithData):
             )
             self.assertTrue(os.path.isfile(timestamps_file))
             ts = np.genfromtxt(timestamps_file)
-            ts = ts[:, 0] + 1e-9 * ts[:, 1]
             np.testing.assert_almost_equal(ts, timestamps[ifo])
 
         # Test single list
@@ -493,7 +491,6 @@ class TestWriter(BaseForTestsWithData):
             )
             self.assertTrue(os.path.isfile(timestamps_file))
             ts = np.genfromtxt(timestamps_file)
-            ts = ts[:, 0] + 1e-9 * ts[:, 1]
             np.testing.assert_almost_equal(ts, timestamps)
 
 

--- a/tests/test_make_sfts.py
+++ b/tests/test_make_sfts.py
@@ -21,7 +21,8 @@ import pyfstat
 
 def test_timestamp_files(tmp_path, caplog):
 
-    single_column = 10000000 + 1800 * np.arange(10)
+    Tsft = 1800
+    single_column = 10000000 + Tsft * np.arange(10)
     np.savetxt(tmp_path / "single_column.txt", single_column[:, None])
 
     writer = pyfstat.Writer(
@@ -31,12 +32,12 @@ def test_timestamp_files(tmp_path, caplog):
         Band=0.1,
         detectors="H1",
         sqrtSX=1e-23,
-        Tsft=1800,
+        Tsft=Tsft,
         timestamps=str(tmp_path / "single_column.txt"),
     )
 
     assert single_column[0] == writer.tstart
-    assert single_column[-1] - single_column[0] == writer.duration - 1800
+    assert single_column[-1] - single_column[0] == writer.duration - Tsft
 
     np.savetxt(tmp_path / "dual_column.txt", np.hstack(2 * [single_column[:, None]]))
     with caplog.at_level("WARNING"):
@@ -47,7 +48,7 @@ def test_timestamp_files(tmp_path, caplog):
             Band=0.1,
             detectors="H1",
             sqrtSX=1e-23,
-            Tsft=1800,
+            Tsft=Tsft,
             timestamps=str(tmp_path / "dual_column.txt"),
         )
 
@@ -64,7 +65,7 @@ def test_timestamp_files(tmp_path, caplog):
             Band=0.1,
             detectors="H1",
             sqrtSX=1e-23,
-            Tsft=1800,
+            Tsft=Tsft,
             timestamps=str(tmp_path / "float_column.txt"),
         )
 
@@ -72,6 +73,7 @@ def test_timestamp_files(tmp_path, caplog):
         assert "non-integer timestamps" in log_message
         assert "floor" in log_message
 
+    # Test wrong number of detectors
     with pytest.raises(ValueError):
 
         writer = pyfstat.Writer(
@@ -84,6 +86,7 @@ def test_timestamp_files(tmp_path, caplog):
             timestamps=str(tmp_path / "single_column.txt"),
         )
 
+    # Test unspecified detectors
     with pytest.raises(ValueError):
 
         writer = pyfstat.Writer(

--- a/tests/test_make_sfts.py
+++ b/tests/test_make_sfts.py
@@ -326,10 +326,22 @@ class TestWriter(BaseForTestsWithData):
         )
         NB_recycling_writer.make_data(verbose=True)
 
-    def _test_writer_with_tsfiles(self, gaps=False):
-        """helper function to rerun with/without gaps"""
+    def _test_writer_with_tsfiles(self, gaps=False, nanoseconds=False):
+        """helper function for timestamps tests
+
+        Can be used to rerun timestamps tests with/without gaps,
+        and with new single-column (nanoseconds=False)
+        and old two-column (nanoseconds=True)
+        formats.
+        """
         IFOs = self.multi_detectors.split(",")
-        tsfiles = [os.path.join(self.outdir, f"timestamps_{IFO}.txt") for IFO in IFOs]
+        tsfiles = [
+            os.path.join(
+                self.outdir,
+                f"timestamps_{IFO}{'_gaps' if gaps else ''}{'_ns' if nanoseconds else ''}.txt",
+            )
+            for IFO in IFOs
+        ]
         numSFTs = []
         for X, tsfile in enumerate(tsfiles):
             with open(tsfile, "w") as fp:
@@ -338,7 +350,8 @@ class TestWriter(BaseForTestsWithData):
                     if (
                         not gaps or not k == X + 1
                     ):  # add gaps at different points for each IFO
-                        fp.write(f"{self.tstart + k*self.Tsft} 0\n")
+                        line = f"{self.tstart + k*self.Tsft}{' 0' if nanoseconds else ''}\n"
+                        fp.write(line)
                     k += 1
             if gaps:
                 numSFTs.append(k - 1)
@@ -385,8 +398,9 @@ class TestWriter(BaseForTestsWithData):
             )
 
     def test_timestamps(self):
-        self._test_writer_with_tsfiles(gaps=False)
-        self._test_writer_with_tsfiles(gaps=True)
+        for gaps in [False, True]:
+            for nanoseconds in [False, True]:
+                self._test_writer_with_tsfiles(gaps, nanoseconds)
 
     def test_timestamps_file_generation(self):
 


### PR DESCRIPTION
- check for missing `detectors` if `timestamps` are a string
- allow single-column timestamps files (and warn for Ncol>1)