### PR TITLE
pin lalsuite==7.11

### DIFF
--- a/etc/pyfstat-dev.yml
+++ b/etc/pyfstat-dev.yml
@@ -15,7 +15,7 @@ dependencies:
   - attrs
   - corner
   - dill
-  - lalpulsar >=5.0.0
+  - lalpulsar >=5.0.0,<6.0.0
   - matplotlib-base >=2.1
   - numpy
   - pathos
@@ -23,7 +23,7 @@ dependencies:
   - ptemcee
   - python >=3.8
   - python-lal >=7.1.5
-  - python-lalpulsar >=5.0.0
+  - python-lalpulsar >=5.0.0,<6.0.0
   - scipy
   - tqdm
   - pip:

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ requires = [
     "tqdm",
     "versioneer",
 ]
-lalsuite = "lalsuite>=7.7"
+lalsuite = "lalsuite>=7.7,<=7.11"
 extras_require = {
     "chainconsumer": ["chainconsumer"],
     "dev": [


### PR DESCRIPTION
Lalsuite 7.11 (including lalpulsar 5.2.0) came out today, and we'll likely put in at least one feature before our next release requiring functions added in that release. Next, we expect the backwards-incompatible release (with bump to lalpulsar 6.0.0 and probably (but not sure) to lalsuite 8.0) which we do _not_ want to have our CI or users pull in as upgrades automatically, so we want to pin <= that. (see #481)

We could try `lalsuite>=7.11,<8.0` but since we're not entirely sure of the next version's number, we can just go with `==7.11` for now and, if another backwards-compatible release happens first, rebump in a minor release from our side.

Conda to be done separately, as usual.