### PR TITLE
add sphinx_autodoc_defaultargs and update to sphinx 5.3.0

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,6 +38,7 @@ extensions = [
     "sphinx_rtd_theme",
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",  # https://github.com/tox-dev/sphinx-autodoc-typehints/issues/15
+    "sphinx_autodoc_defaultargs",  # should be loaded after napoleon
     "sphinx_autodoc_typehints",  # Must import napoleon before typehints
     "sphinx.ext.viewcode",
     "sphinx_gallery.gen_gallery",
@@ -87,3 +88,12 @@ sphinx_gallery_conf = {
     "plot_gallery": "False",  # our examples are slow, so we can't generate plots every time the docs are built
     "line_numbers": True,
 }
+
+# defaultargs options
+rst_prolog = (
+    """
+.. |default| raw:: html
+
+    <div class="default-value-section">"""
+    + ' <span class="default-value-label">Default:</span>'
+)

--- a/setup.py
+++ b/setup.py
@@ -42,13 +42,14 @@ extras_require = {
         "pre-commit",
     ],
     "docs": [
-        "sphinx==5.1.1",
-        "sphinx_autodoc_typehints==1.19.2",
-        "sphinx_rtd_theme==0.5.1",
+        "sphinx==5.3.0",
+        "sphinx_autodoc_defaultargs==0.1.2",
+        "sphinx_autodoc_typehints==1.19.5",
         "sphinx_gallery==0.11.1",
+        "sphinx_rtd_theme==0.5.1",
         "m2r2==0.3.3",
         "mistune==0.8.4",
-        "Pillow==9.2.0",
+        "Pillow==9.3.0",
     ],
     "pycuda": ["pycuda"],
     "style": [


### PR DESCRIPTION
A feature I've been subconsciously missing for a long time, and only now found out there's a module for it.
![Screenshot_20221107_092503](https://user-images.githubusercontent.com/28396587/200261306-5ab09828-c706-4eb1-9fdb-84fd9710772e.png)

The `rst_prolog` stuff in the config comes from [their "Usage" recommendation](https://github.com/zwang123/sphinx-autodoc-defaultargs/blob/e3e4a123380ca54b7052571d0b2ac2f27fed2af3/README.md#usage) and seems to be called a "substitution rule" in sphinx lingo.