### PR TITLE
try conda-test without mamba

### DIFF
--- a/.github/workflows/conda-test.yml
+++ b/.github/workflows/conda-test.yml
@@ -14,7 +14,6 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: "3.10"
-          mamba-version: "*"
           channels: conda-forge
           channel-priority: true
           activate-environment: pyfstat-dev


### PR DESCRIPTION
This seems to fix #519: -> https://github.com/PyFstat/PyFstat/actions/runs/4046072271/jobs/6958397252 :heavy_check_mark: 

Since mamba is marked as experimental, I guess just skipping it for now when there's an incomprehensible error is the easiest way out. Any objections @Rodrigo-Tenorio ?