### PR TITLE
change lalsuite pin to <7.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ requires = [
     "tqdm",
     "versioneer",
 ]
-lalsuite = "lalsuite>=7.7,<=7.11"
+lalsuite = "lalsuite>=7.7,<7.12"
 extras_require = {
     "chainconsumer": ["chainconsumer"],
     "dev": [


### PR DESCRIPTION
 -  because current dev versions are 7.11.1.dev*
 -  so dev test jobs (e.g. [here](https://github.com/PyFstat/PyFstat/actions/runs/4055238044)) still only pull in the 7.11 release