### PR TITLE
Update .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,11 @@
 # Required
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/source/conf.py
@@ -20,7 +25,6 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.8
   install:
     - method: pip
       path: .


### PR DESCRIPTION
 - python.version got deprecated
 - specify os
 - hope this solves "Could not find a version that satisfies the requirement lalsuite>=7.13" (e.g. https://readthedocs.org/projects/pyfstat/builds/20023707/ )