### PR TITLE
remove utils.get_lal_exec()

### DIFF
--- a/examples/followup_examples/PyFstat_example_semi_coherent_directed_follow_up.py
+++ b/examples/followup_examples/PyFstat_example_semi_coherent_directed_follow_up.py
@@ -44,7 +44,7 @@ data = pyfstat.Writer(
 )
 data.make_data()
 
-# The predicted twoF, given by lalapps_predictFstat can be accessed by
+# The predicted twoF (expectation over noise realizations) can be accessed by
 twoF = data.predict_fstat()
 logger.info("Predicted twoF value: {}\n".format(twoF))
 

--- a/examples/mcmc_examples/PyFstat_example_MCMC_search_using_initialisation.py
+++ b/examples/mcmc_examples/PyFstat_example_MCMC_search_using_initialisation.py
@@ -44,7 +44,7 @@ data = pyfstat.Writer(
 )
 data.make_data()
 
-# The predicted twoF, given by lalapps_predictFstat can be accessed by
+# The predicted twoF (expectation over noise realizations) can be accessed by
 twoF = data.predict_fstat()
 logger.info("Predicted twoF value: {}\n".format(twoF))
 

--- a/examples/mcmc_examples/PyFstat_example_fully_coherent_MCMC_search.py
+++ b/examples/mcmc_examples/PyFstat_example_fully_coherent_MCMC_search.py
@@ -45,7 +45,7 @@ data = pyfstat.Writer(
 )
 data.make_data()
 
-# The predicted twoF, given by lalapps_predictFstat can be accessed by
+# The predicted twoF (expectation over noise realizations) can be accessed by
 twoF = data.predict_fstat()
 logger.info("Predicted twoF value: {}\n".format(twoF))
 

--- a/examples/mcmc_examples/PyFstat_example_fully_coherent_MCMC_search_with_BSGL.py
+++ b/examples/mcmc_examples/PyFstat_example_fully_coherent_MCMC_search_with_BSGL.py
@@ -47,7 +47,7 @@ data = pyfstat.Writer(
 )
 data.make_data()
 
-# The predicted twoF, given by lalapps_predictFstat can be accessed by
+# The predicted twoF (expectation over noise realizations) can be accessed by
 twoF = data.predict_fstat()
 logger.info("Predicted twoF value: {}\n".format(twoF))
 

--- a/examples/mcmc_examples/PyFstat_example_semi_coherent_MCMC_search.py
+++ b/examples/mcmc_examples/PyFstat_example_semi_coherent_MCMC_search.py
@@ -43,7 +43,7 @@ data = pyfstat.Writer(
 )
 data.make_data()
 
-# The predicted twoF, given by lalapps_predictFstat can be accessed by
+# The predicted twoF (expectation over noise realizations) can be accessed by
 twoF = data.predict_fstat()
 logger.info("Predicted twoF value: {}\n".format(twoF))
 

--- a/examples/other_examples/PyFstat_example_twoF_cumulative.py
+++ b/examples/other_examples/PyFstat_example_twoF_cumulative.py
@@ -65,7 +65,7 @@ data = pyfstat.BinaryModulatedWriter(
 )
 data.make_data()
 
-# The predicted twoF, given by lalapps_predictFstat can be accessed by
+# The predicted twoF (expectation over noise realizations) can be accessed by
 twoF = data.predict_fstat()
 logger.info("Predicted twoF value: {}\n".format(twoF))
 

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -34,7 +34,7 @@ class Writer(BaseSearchClass):
     for more detailed help with some of the parameters.
     """
 
-    mfd = utils.get_lal_exec("Makefakedata_v5")
+    mfd = "lalpulsar_Makefakedata_v5"
     """The executable; can be overridden by child classes."""
 
     signal_parameter_labels = [
@@ -1000,7 +1000,7 @@ class LineWriter(Writer):
     NOTE: All signal parameters except for `h0`, `Freq`, `phi0` and transient parameters will be ignored.
     """
 
-    mfd = utils.get_lal_exec("Makefakedata_v4")
+    mfd = "lalpulsar_Makefakedata_v4"
     """The executable (older version that supports the `--lineFeature` option)."""
 
     required_signal_parameters = [
@@ -1599,7 +1599,7 @@ class FrequencyModulatedArtifactWriter(Writer):
             os.remove(SFTFile_fullpath)
 
         inpattern = os.path.join(self.tmp_outdir, "*sft")
-        cl_splitSFTS = utils.get_lal_exec("splitSFTs")
+        cl_splitSFTS = "lalpulsar_splitSFTs"
         cl_splitSFTS += " -fs {} -fb {} -fe {} -n {} -- {}".format(
             self.fmin, self.Band, self.fmin + self.Band, self.outdir, inpattern
         )
@@ -1708,7 +1708,7 @@ class FrequencyModulatedArtifactWriter(Writer):
     def run_makefakedata_v4(self, mid_time, lineFreq, linePhi, h0, tmp_outdir):
         """Generate SFT data using the MFDv4 code with the --lineFeature option."""
         cl_mfd = []
-        cl_mfd.append(utils.get_lal_exec("Makefakedata_v4"))
+        cl_mfd.append("lalpulsar_Makefakedata_v4")
         cl_mfd.append("--outSingleSFT=FALSE")
         cl_mfd.append('--outSFTbname="{}"'.format(tmp_outdir))
         cl_mfd.append("--IFO={}".format(self.detectors))

--- a/pyfstat/utils/__init__.py
+++ b/pyfstat/utils/__init__.py
@@ -26,7 +26,7 @@ from .io import (
     read_txt_file_with_header,
 )
 from .predict import get_predict_fstat_parameters_from_dict, predict_fstat
-from .runlalsuite import generate_loudest_file, get_covering_band, get_lal_exec
+from .runlalsuite import generate_loudest_file, get_covering_band
 from .sft import (
     get_commandline_from_SFTDescriptor,
     get_official_sft_filename,

--- a/pyfstat/utils/predict.py
+++ b/pyfstat/utils/predict.py
@@ -7,7 +7,6 @@ from .cli import run_commandline
 from .converting import parse_list_of_numbers
 from .ephemeris import get_ephemeris_files
 from .io import read_par
-from .runlalsuite import get_lal_exec
 
 logger = logging.getLogger(__name__)
 
@@ -85,7 +84,7 @@ def predict_fstat(
     """
 
     cl_pfs = []
-    cl_pfs.append(get_lal_exec("PredictFstat"))
+    cl_pfs.append("lalpulsar_PredictFstat")
 
     pars = {"h0": h0, "cosi": cosi, "psi": psi, "Alpha": Alpha, "Delta": Delta}
     cl_pfs.extend([f"--{key}={val}" for key, val in pars.items() if val is not None])

--- a/pyfstat/utils/runlalsuite.py
+++ b/pyfstat/utils/runlalsuite.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import shutil
 
 import lal
 import lalpulsar
@@ -9,33 +8,6 @@ import numpy as np
 from .cli import run_commandline
 
 logger = logging.getLogger(__name__)
-
-
-def get_lal_exec(cmd):
-    """Get a lalpulsar/lalapps executable name with the right prefix.
-
-    This is purely to allow for backwards compatibility
-    if, for whatever reason,
-    someone needs to run with old releases
-    (lalapps<9.0.0 and lalpulsar<5.0.0)
-    from before the executables were moved.
-
-    Parameters
-    -------
-    cmd: str
-        Base executable name without lalapps/lalpulsar prefix.
-
-    Returns
-    -------
-    full_cmd: str
-        Full executable name with the right prefix.
-    """
-    full_cmd = shutil.which("lalpulsar_" + cmd) or shutil.which("lalapps_" + cmd)
-    if full_cmd is None:
-        raise RuntimeError(
-            f"Could not find either lalpulsar or lalapps version of command {cmd}."
-        )
-    return os.path.basename(full_cmd)
 
 
 def get_covering_band(
@@ -169,7 +141,7 @@ def generate_loudest_file(
         )
 
     loudest_file = os.path.join(outdir, label + ".loudest")
-    cmd = get_lal_exec("ComputeFstatistic_v2")
+    cmd = "lalpulsar_ComputeFstatistic_v2"
     CFSv2_params = {
         "DataFiles": f'"{sftfilepattern}"',
         "outputLoudest": loudest_file,

--- a/tests/test_grid_based_searches.py
+++ b/tests/test_grid_based_searches.py
@@ -102,7 +102,7 @@ class TestGridSearch(BaseForTestsWithData):
         CFSv2_out_file = os.path.join(self.outdir, "CFSv2_Fstat_out.txt")
         CFSv2_loudest_file = os.path.join(self.outdir, "CFSv2_Fstat_loudest.txt")
         cl_CFSv2 = []
-        cl_CFSv2.append(pyfstat.utils.get_lal_exec("ComputeFstatistic_v2"))
+        cl_CFSv2.append("lalpulsar_ComputeFstatistic_v2")
         cl_CFSv2.append("--Alpha {} --AlphaBand 0".format(self.Alpha))
         cl_CFSv2.append("--Delta {} --DeltaBand 0".format(self.Delta))
         cl_CFSv2.append("--Freq {}".format(self.F0s[0]))

--- a/tests/test_make_sfts.py
+++ b/tests/test_make_sfts.py
@@ -386,7 +386,7 @@ class TestWriter(BaseForTestsWithData):
         )
         writer.make_data(verbose=True)
         # split them by frequency
-        cl_split = pyfstat.utils.get_lal_exec("splitSFTs")
+        cl_split = "lalpulsar_splitSFTs"
         cl_split += " --frequency-bandwidth 1"
         cl_split += f" --start-frequency {writer.fmin}"
         cl_split += f" --end-frequency {writer.fmin+writer.Band}"


### PR DESCRIPTION
- lalapps->lalpulsar migration is long over, so simplify away this transition helper
- closes #524
- also, in examples: remove outdated lalapps references in comments