### PR TITLE
corner 2.2.2 requires length-3 list for quantiles

### DIFF
--- a/examples/glitch_examples/PyFstat_example_glitch_robust_directed_MCMC_search_on_1_glitch.py
+++ b/examples/glitch_examples/PyFstat_example_glitch_robust_directed_MCMC_search_on_1_glitch.py
@@ -94,7 +94,7 @@ logger.info("Making corner plot...")
 mcmc.plot_corner(
     label_offset=0.25,
     truths={"F0": F0, "F1": F1, "delta_F0": delta_F0, "tglitch": tstart + dtglitch},
-    quantiles=(0.16, 0.84),
+    quantiles=(0.16, 0.5, 0.84),
     hist_kwargs=dict(lw=1.5, zorder=-1),
     truth_color="C3",
 )

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -1065,7 +1065,7 @@ class MCMCSearch(BaseSearchClass):
                 hist_kwargs=hist_kwargs,
                 show_titles=True,
                 fill_contours=True,
-                quantiles=[0.05, 0.95]
+                quantiles=[0.05, 0.5, 0.95]  # [lower, central, upper]
                 if "quantiles" not in kwargs
                 else kwargs.pop("quantiles"),
                 verbose=True if "verbose" not in kwargs else kwargs.pop("verbose"),


### PR DESCRIPTION
 - fixes #532
- This format seems to have been already supported by corner <2.2.2 as well, so no need to introduce a dependency pin.
- Now gives us 3 dashed lines, the extra one at median:

![TestMCMCSearch-uniformF0-uniformF1-fixedSky_corner](https://user-images.githubusercontent.com/28396587/231403883-77596078-7f78-472f-8009-2d0585f6afbb.png)