### PR TITLE
fix gridcorner for matplotlib 3.8

### DIFF
--- a/etc/pyfstat-dev.yml
+++ b/etc/pyfstat-dev.yml
@@ -16,7 +16,7 @@ dependencies:
   - corner
   - dill
   - lalpulsar >=6.0
-  - matplotlib-base >=2.1
+  - matplotlib-base >=3.3
   - numpy <1.24.0
   - pathos
   - pip

--- a/pyfstat/gridcorner.py
+++ b/pyfstat/gridcorner.py
@@ -190,13 +190,13 @@ def gridcorner(
                 ax.set_yticks([])
                 continue
 
-            ax.get_shared_x_axes().join(axes[ndim - 1, j], ax)
+            ax.sharex(axes[ndim - 1, j])
             if i < ndim - 1:
-                ax.set_xticklabels([])
+                ax.tick_params(labelbottom=False)
             if j < i:
-                ax.get_shared_y_axes().join(axes[i, i - 1], ax)
+                ax.sharey(axes[i, i - 1])
                 if j > 0:
-                    ax.set_yticklabels([])
+                    ax.tick_params(labelleft=False)
             if j == i:
                 continue
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ requires = [
     "attrs",
     "corner",
     "dill",
-    "matplotlib>=2.1",
+    "matplotlib>=3.3",
     "numpy<1.24.0",
     "pathos",
     "ptemcee",


### PR DESCRIPTION
 - fixes error "'GrouperView' object has no attribute 'join'" ([example](https://github.com/PyFstat/PyFstat/actions/runs/6257706445/job/16990458444#step:8:1645))
 - ax.sharex and ax.sharey replacements require matplotlib >=3.8

After the replacement, the `ax.set_xticklabels([])` was then turning off the labels on all shared axes, hence the additional switch to using `ax.tick_params` was necessary.

Before-after from examples/grid_examples/PyFstat_example_grid_search_F0F1.py : - should look identical:

![PyFstatExampleGridSearchF0F1F2_projection_matrix_backup](https://github.com/PyFstat/PyFstat/assets/28396587/c0a6a49c-8b5e-4102-9ab1-8be7690d6382)

![PyFstatExampleGridSearchF0F1F2_projection_matrix](https://github.com/PyFstat/PyFstat/assets/28396587/f9a953b4-880d-4ae7-b77e-a81b36e00000)
