### PR TITLE
adapt integration.yml to using OIDC for PyPI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -40,9 +40,10 @@ jobs:
         python setup.py sdist bdist_wheel
         check-wheel-contents dist/*.whl
     - name: upload artifacts
+      if: matrix.python-version == 3.8  # only upload from one version (oldest, for max compatibility)
       uses: actions/upload-artifact@v3
       with:
-        name: dist
+        name: python-package-distributions
         path: dist/
 
   testpypi-publish:
@@ -64,7 +65,7 @@ jobs:
     - name: Publish package distributions to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        repository_url: https://test.pypi.org/legacy/
+        repository-url: https://test.pypi.org/legacy/
 
   pypi-publish:
     name: Upload release to PyPI

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -47,7 +47,7 @@ jobs:
 
   testpypi-publish:
     name: Upload release to TestPyPI
-    if: matrix.python-version == 3.8 && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     needs: build
     runs-on: ubuntu-latest
     environment:
@@ -68,7 +68,7 @@ jobs:
 
   pypi-publish:
     name: Upload release to PyPI
-    if: matrix.python-version == 3.8 && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     needs: [build, testpypi-publish]
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -39,16 +39,48 @@ jobs:
       run: |
         python setup.py sdist bdist_wheel
         check-wheel-contents dist/*.whl
-    - name: Publish package to TestPyPI
-      if: matrix.python-version == 3.8 && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    - name: upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: dist
+        path: dist/
+
+  testpypi-publish:
+    name: Upload release to TestPyPI
+    if: matrix.python-version == 3.8 && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/PyFstat
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+    - name: Download dist artifacts
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish package distributions to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        user: __token__
-        password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
-    - name: Publish package to PyPI
-      if: matrix.python-version == 3.8 && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@release/v1
+
+  pypi-publish:
+    name: Upload release to PyPI
+    if: matrix.python-version == 3.8 && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    needs: [build, testpypi-publish]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/PyFstat
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+    - name: Download dist artifacts
+      uses: actions/download-artifact@v3
       with:
-        user: __token__
-        password: ${{ secrets.pypi_password }}\
+        name: python-package-distributions
+        path: dist/
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
- follows new https://docs.pypi.org/trusted-publishers/ model
- split into separate jobs build, testpypi-publish, pypi-publish
- use environments
- use artifact upload/download