### PR TITLE
pin python<3.12 for now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.2 [12/10/2023]
+
+ - Pinned to python<3.12 until more dependencies are updated
+   and a few things fixed on our end.
+
 ## 2.0.1 [11/10/2023]
 
  - Fixed compatibility with matplotlib=3.8 and bumped minimum requirement to >=3.3.
@@ -53,7 +58,7 @@
  - This is the first PyFstat release to officially support python 3.11.
  - LALSuite is introducing an SFT specification and filename update
    - see https://dcc.ligo.org/T040164-v2/public)
-   - This version of PyFstat is pinned to `lalsuite<=7.11` (or `lalpulsar<6.0`) 
+   - This version of PyFstat is pinned to `lalsuite<=7.11` (or `lalpulsar<6.0`)
      so that it is ensured to keep working with the old convention.
    - Next PyFstat release will adapt to the LALSuite changes.
    - Added `get_official_sft_filename()` utility function to ease migration.
@@ -88,7 +93,7 @@
 
 ## 1.18.0 [06/09/2022]
 
- - refurbished logging system: 
+ - refurbished logging system:
    - on `import.pyfstat`, stdout logging at INFO level is activated
      unless there are already handlers attached to the root logger
    - recommended to further call `pyfstat.set_up_logger` and define an output log file,
@@ -114,7 +119,7 @@
      without worrying about the level one further down
    - moved `matplotlib` setup into new `utils.safe_X_less_plt()`
    - removed deprecated/unused helper functions
-        - `get_peak_values` 
+        - `get_peak_values`
         - `get_comb_values`
         - `get_sft_array`
  - can install with `NO_LALSUITE_FROM_PYPI` environment variable,
@@ -453,7 +458,7 @@
  - improved helper_functions.get_sft_array()
  - extended, cleaned up and further modularised test suite
  - updated examples to changes in Writer and other classes
- 
+
 ## 1.5.2 [06/08/2020]
 
  - fixed semi-coherent search bug introduced in 1.5.0:
@@ -465,7 +470,7 @@
       and deprecated get_median_stds()
     - fixes to some of the more exotic prior types.
  - Extended MCMC test coverage.
-   
+
 ## 1.5.1 [30/07/2020]
 
  - The only change in this release is an updated README

--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ Latest development versions can
 [also be installed with pip](#pip-install-from-github)
 or [from a local git clone](#install-pyfstat-from-source-zenodo-or-git-clone).
 
-If you don't have a recent `python` installation (`3.8+`) on your system,
+If you don't have a matching `python` installation
+(currently `3.8` to `3.11`)
+on your system,
 then `Docker` or `conda` are the easiest paths.
 
 In either case, be sure to also check out the notes on

--- a/etc/pyfstat-dev.yml
+++ b/etc/pyfstat-dev.yml
@@ -21,7 +21,7 @@ dependencies:
   - pathos
   - pip
   - ptemcee
-  - python >=3.8
+  - python >=3.8,<3.12
   - python-lal >=7.1.5
   - python-lalpulsar >=6.0
   - scipy

--- a/etc/pyfstat.yml
+++ b/etc/pyfstat.yml
@@ -2,5 +2,5 @@ name: pyfstat
 channels:
     - conda-forge
 dependencies:
-    - python >=3.8
+    - python >=3.8,<3.12
     - pyfstat

--- a/setup.py
+++ b/setup.py
@@ -7,14 +7,20 @@ import versioneer
 
 # check python version
 min_python_version = (3, 8, 0)  # (major,minor,micro)
+next_unsupported_python_version = (3, 12)  # (major,minor) - don't restrict micro
 python_version = sys.version_info
-print("Running Python version %s.%s.%s" % python_version[:3])
-if python_version < min_python_version:
+if (
+    python_version < min_python_version
+    or python_version > next_unsupported_python_version
+):
     sys.exit(
-        "Python < %s.%s.%s is not supported, aborting setup" % min_python_version[:3]
+        f"Python {'.'.join(str(v) for v in python_version[:3])} is not supported, aborting setup."
     )
 else:
-    print("Confirmed Python version %s.%s.%s or above" % min_python_version[:3])
+    print(
+        f"Confirmed Python version between [{'.'.join(str(v) for v in min_python_version[:3])},"
+        f" {'.'.join(str(v) for v in next_unsupported_python_version[:2])}]"
+    )
 
 
 here = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
There's a versioneer-ConfigParser incompatibility (see https://dev.azure.com/conda-forge/84710dde-1620-425b-80d0-4cf5baca359d/_apis/build/builds/802015/logs/7 ), which is probably easy to fix, but LALSuite hasn't been updated yet anyway (https://git.ligo.org/lscsoft/lalsuite/-/merge_requests/2201), so pin for now and check on it later.