### PR TITLE
add standalone flake8 action

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,0 +1,22 @@
+name: Integration Tests
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    # We want to run on external PRs, but not on our own internal PRs as they'll be run
+    # by the push to the branch.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Install package and development dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e ${GITHUB_WORKSPACE}[style]
+    - name: Linting with flake8
+      run: |
+        flake8 --count --statistics .

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,4 +1,4 @@
-name: Integration Tests
+name: Flake8 linting
 
 on: [push, pull_request]
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,10 +25,7 @@ jobs:
     - name: Install package and development dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e ${GITHUB_WORKSPACE}[style,test,wheel]
-    - name: Linting with flake8
-      run: |
-        flake8 --count --statistics .
+        pip install -e ${GITHUB_WORKSPACE}[test,wheel]
     - name: Run test suite with pytest
       run: |
         (cd .. && pytest --durations=0 $GITHUB_WORKSPACE/tests/ --log-file=$GITHUB_WORKSPACE/tests.log)


### PR DESCRIPTION
Continue making actions less monolithic. In this case, still install project as normal, since this allows using the same plugins and versions as defined in setup.py, even if it might be a bit overkill for linting only.