### PR TITLE
update sphinx executable in binder postBuild

### DIFF
--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -22,7 +22,7 @@ find . -delete
 NOTEBOOKS_SCRIPTS_DIR=.generated-notebooks
 mkdir -p ${NOTEBOOKS_SCRIPTS_DIR}
 cp -r ${TMP_DIR}/* ${NOTEBOOKS_SCRIPTS_DIR}
-find ${NOTEBOOKS_SCRIPTS_DIR} -name '*.py' ! -name '*run_all*' ! -name '*utils*' -exec sphx_glr_python_to_jupyter.py '{}' +
+find ${NOTEBOOKS_SCRIPTS_DIR} -name '*.py' ! -name '*run_all*' ! -name '*utils*' -exec sphinx_gallery_py2jupyter '{}' +
 
 # This symlink is required
 mkdir notebooks


### PR DESCRIPTION
- from sphx_glr_python_to_jupyter which seems to no longer exist (in sphinx-gallery 0.16) with similar-sounding sphinx_gallery_py2jupyter
- closes #538