### PR TITLE
Revert "pin to pytest<8.2.2"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ extras_require = {
         "flake8-isort",
         "isort",
     ],
-    "test": ["pytest<8.2.2", "pytest-cov", "flaky", "nbmake"],
+    "test": ["pytest", "pytest-cov", "flaky", "nbmake"],
     "wheel": ["wheel", "check-wheel-contents"],
 }
 for key in ["docs", "style", "test", "wheel"]:


### PR DESCRIPTION
This reverts commit 3d2ccf2946a8705c5a7477f2985fa12e11e75331.

 - at least locally, with pytest 8.3.2 and flaky 3.81 things seem to work again
 - closes #550