### PR TITLE
Allow core F-stat functions to take a dict for parameters

### DIFF
--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -124,7 +124,7 @@ class BaseSearchClass:
         matches = [item for sublist in matches for item in sublist]
         if len(matches) > 0:
             return matches
-        else:
+        else:  # pragma: no cover
             raise IOError("No sfts found matching {}".format(self.sftfilepattern))
 
     def tex_label0(self, key):
@@ -1151,12 +1151,15 @@ class ComputeFstat(BaseSearchClass):
         The full transient-F-stat map is also computed here,
         but stored in `self.FstatMap`, not returned.
 
-        NOTE the old way of calling this with explicit [F0,F1,F2,Alpha,Delta,...]
+        NOTE: the old way of calling this with explicit [F0,F1,F2,Alpha,Delta,...]
         parameters is DEPRECATED and may be removed in future versions.
         Currently, this method can be either called with
+
         * a complete set of `(F0, F1, F2, Alpha, Delta)`
           (plus optional binary parameters),
+
         * OR a `params` dictionary;
+
         and only the latter version will be supported going forward.
 
         Parameters
@@ -1248,13 +1251,15 @@ class ComputeFstat(BaseSearchClass):
             required_keys = ["F0", "Alpha", "Delta"]
             parkeys = list(params.keys())
             keysetdiff = np.setdiff1d(required_keys, parkeys)
-            if len(keysetdiff) > 0:
+            if len(keysetdiff) > 0:  # pragma: no cover
                 raise ValueError(
                     f"Required keys not found in params.keys(): {keysetdiff}"
                 )
             # all supported parameters are either required, binary, or of "Fk" type
             keysetdiff = np.setdiff1d(parkeys, required_keys + self.binary_keys)
-            if not np.all([key.startswith("F") for key in keysetdiff]):
+            if not np.all(
+                [key.startswith("F") for key in keysetdiff]
+            ):  # pragma: no cover
                 raise ValueError(
                     f"Unknown parameters in input dictionary: {[key for key in keysetdiff if not key.startswith('F')]}"
                 )
@@ -1264,11 +1269,11 @@ class ComputeFstat(BaseSearchClass):
             if self.binary:
                 for key in self.binary_keys:
                     bpar = eval(key)
-                    if bpar is None:
+                    if bpar is None:  # pragma: no cover
                         raise ValueError(f"We got self.binary but {key}=None.")
                     params[key] = float(bpar)
                 parkeys += self.binary_keys
-        else:
+        else:  # pragma: no cover
             raise ValueError(
                 "Need either a 'params' dictionary"
                 f" or a full set of {list(base_params_oldstyle.keys())} (DEPRECATED)"
@@ -1279,11 +1284,11 @@ class ComputeFstat(BaseSearchClass):
         for key in [key for key in parkeys if key.startswith("F")]:
             try:
                 k = int(key[1:])
-            except ValueError:
+            except ValueError:  # pragma: no cover
                 raise ValueError(
                     f"Unknown parameter {key} in input dictionary, it looks like a 'Fk'-style spindown term but cannot convert the part after the 'F' to an integer."
                 )
-            if k >= lalpulsar.PULSAR_MAX_SPINS:
+            if k >= lalpulsar.PULSAR_MAX_SPINS:  # pragma: no cover
                 raise ValueError(
                     f"Input parameter {key} exceeds lalpulsar.PULSAR_MAX_SPINS={lalpulsar.PULSAR_MAX_SPINS}."
                 )
@@ -1319,9 +1324,12 @@ class ComputeFstat(BaseSearchClass):
         NOTE the old way of calling this with explicit (F0,F1,F2,Alpha,Delta,...)
         parameters is DEPRECATED and may be removed in future versions.
         Currently, this method can be either called with
+
         * a complete set of `(F0, F1, F2, Alpha, Delta)`
           (plus optional binary parameters),
+
         * OR a `params` dictionary;
+
         and only the latter version will be supported going forward.
 
         Parameters

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -37,6 +37,80 @@ class BaseSearchClass:
     """
 
     binary_keys = ["asini", "period", "ecc", "tp", "argp"]
+    """List of extra parameters for sources in binaries."""
+
+    default_search_keys = [
+        "F0",
+        "F1",
+        "F2",
+        "Alpha",
+        "Delta",
+    ]
+    """Default order of the traditionally supported search parameter names.
+
+    FIXME: these are only used as fallbacks for the deprecated style
+    of passing keys one by one;
+    not needed when using the new parameters dictionary.
+    """
+
+    tex_labels = {
+        # standard Doppler parameters
+        "F0": r"$f$",
+        "F1": r"$\dot{f}$",
+        "F2": r"$\ddot{f}$",
+        "F3": r"$\dddot{f}$",
+        "Alpha": r"$\alpha$",
+        "Delta": r"$\delta$",
+        # binary parameters
+        "asini": r"$\mathrm{asin}\,i$",
+        "period": r"$P$",
+        "ecc": r"$\mathrm{ecc}$",
+        "tp": r"$t_p$",
+        "argp": r"$\mathrm{argp}$",
+        # transient parameters
+        "transient_tstart": r"$t_\mathrm{start}$",
+        "transient_duration": r"$\Delta T$",
+        # glitch parameters
+        "delta_F0": r"$\delta f$",
+        "delta_F1": r"$\delta \dot{f}$",
+        "tglitch": r"$t_\mathrm{glitch}$",
+        # detection statistics
+        "twoF": r"$\widetilde{2\mathcal{F}}$",
+        "maxTwoF": r"$\max\widetilde{2\mathcal{F}}$",
+        "log10BSGL": r"$\log_{10}\mathcal{B}_{\mathrm{SGL}}$",
+        "lnBtSG": r"$\ln\mathcal{B}_{\mathrm{tS/G}}$",
+    }
+    """Formatted labels used for plot annotations."""
+
+    unit_dictionary = dict(
+        # standard Doppler parameters
+        F0=r"Hz",
+        F1=r"Hz/s",
+        F2=r"Hz/s$^2$",
+        F3=r"Hz/s$^3$",
+        Alpha=r"rad",
+        Delta=r"rad",
+        # binary parameters
+        asini="",
+        period=r"s",
+        ecc="",
+        tp=r"s",
+        argp="",
+        # transient parameters
+        transient_tstart=r"s",
+        transient_duration=r"s",
+        # glitch parameters
+        delta_F0=r"Hz",
+        delta_F1=r"Hz/s",
+        tglitch=r"s",
+    )
+    """Units for standard parameters."""
+
+    fmt_detstat = "%.9g"
+    """Standard output precision for detection statistics."""
+
+    fmt_doppler = "%.16g"
+    """Standard output precision for Doppler (frequency evolution) parameters."""
 
     def __new__(cls, *args, **kwargs):
         logger.info(f"Creating {cls.__name__} object...")
@@ -52,6 +126,11 @@ class BaseSearchClass:
             return matches
         else:
             raise IOError("No sfts found matching {}".format(self.sftfilepattern))
+
+    def tex_label0(self, key):
+        """Formatted labels used for annotating central values in plots."""
+        label = self.tex_labels[key].strip("$")
+        return f"${label} - {label}_0$"
 
     def set_ephemeris_files(self, earth_ephem=None, sun_ephem=None):
         """Set the ephemeris files to use for the Earth and Sun.

--- a/pyfstat/grid_based_searches.py
+++ b/pyfstat/grid_based_searches.py
@@ -43,31 +43,6 @@ class GridSearch(BaseSearchClass):
     only the additional ones are documented here:
     """
 
-    tex_labels = {
-        "F0": r"$f$",
-        "F1": r"$\dot{f}$",
-        "F2": r"$\ddot{f}$",
-        "Alpha": r"$\alpha$",
-        "Delta": r"$\delta$",
-        "twoF": r"$\widetilde{2\mathcal{F}}$",
-        "maxTwoF": r"$\max\widetilde{2\mathcal{F}}$",
-        "log10BSGL": r"$\log_{10}\mathcal{B}_{\mathrm{S/GL}}$",
-        "lnBtSG": r"$\ln\mathcal{B}_{\mathrm{tS/G}}$",
-    }
-    """Formatted labels used for plot annotations."""
-
-    tex_labels0 = {
-        "F0": r"$-f_0$",
-        "F1": r"$-\dot{f}_0$",
-        "F2": r"$-\ddot{f}_0$",
-        "Alpha": r"$-\alpha_0$",
-        "Delta": r"$-\delta_0$",
-    }
-    """Formatted labels used for annotating central values in plots."""
-
-    fmt_detstat = "%.9g"
-    """Standard output precision for detection statistics."""
-
     @utils.initializer
     def __init__(
         self,
@@ -123,9 +98,9 @@ class GridSearch(BaseSearchClass):
         self._set_init_params_dict(locals())
         os.makedirs(outdir, exist_ok=True)
         self.set_out_file()
-        self.search_keys = ["F0", "F1", "F2", "Alpha", "Delta"]
-        for k in self.search_keys:
+        for k in self.default_search_keys:
             setattr(self, k, np.atleast_1d(getattr(self, k + "s")))
+        self.search_keys = self.default_search_keys.copy()
         if self.BSGL:
             self.detstat = "log10BSGL"
         else:
@@ -565,7 +540,7 @@ class GridSearch(BaseSearchClass):
         if xlabel:
             ax.set_xlabel(xlabel)
         elif x0:
-            ax.set_xlabel(self.tex_labels[xkey] + self.tex_labels0[xkey])
+            ax.set_xlabel(self.tex_label0(xkey))
         else:
             ax.set_xlabel(self.tex_labels[xkey])
         if ylabel:
@@ -722,14 +697,14 @@ class GridSearch(BaseSearchClass):
         if xlabel:
             ax.set_xlabel(xlabel)
         elif x0:
-            ax.set_xlabel(self.tex_labels[xkey] + self.tex_labels0[xkey])
+            ax.set_xlabel(self.tex_label0(xkey))
         else:
             ax.set_xlabel(self.tex_labels[xkey])
 
         if ylabel:
             ax.set_ylabel(ylabel)
         elif y0:
-            ax.set_ylabel(self.tex_labels[ykey] + self.tex_labels0[ykey])
+            ax.set_ylabel(self.tex_label0(ykey))
         else:
             ax.set_ylabel(self.tex_labels[ykey])
 
@@ -968,9 +943,9 @@ class TransientGridSearch(GridSearch):
         self.nsegs = 1
         os.makedirs(outdir, exist_ok=True)
         self.set_out_file()
-        self.search_keys = ["F0", "F1", "F2", "Alpha", "Delta"]
-        for k in self.search_keys:
+        for k in self.default_search_keys:
             setattr(self, k, np.atleast_1d(getattr(self, k + "s")))
+        self.search_keys = self.default_search_keys.copy()
         if self.BSGL and self.BtSG:  # pragma: no cover
             raise ValueError("Please choose only one of [BSGL,BtSG].")
         elif self.BSGL:
@@ -1255,12 +1230,7 @@ class GridGlitchSearch(GridSearch):
         self.input_arrays = False
         if tglitchs is None:
             raise ValueError("You must specify `tglitchs`")
-        self.search_keys = [
-            "F0",
-            "F1",
-            "F2",
-            "Alpha",
-            "Delta",
+        self.search_keys = self.default_search_keys + [
             "delta_F0",
             "delta_F1",
             "tglitch",
@@ -1293,8 +1263,8 @@ class GridGlitchSearch(GridSearch):
     def _get_savetxt_fmt_dict(self):
         """Define the output precision for each parameter and computed quantity."""
         fmt_dict = utils.get_doppler_params_output_format(self.output_keys)
-        fmt_dict["delta_F0"] = "%.16g"
-        fmt_dict["delta_F1"] = "%.16g"
+        fmt_dict["delta_F0"] = self.fmt_doppler
+        fmt_dict["delta_F1"] = self.fmt_doppler
         fmt_dict["tglitch"] = "%d"
         fmt_dict[self.detstat] = self.fmt_detstat
         return fmt_dict

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -386,7 +386,7 @@ class MCMCSearch(BaseSearchClass):
                 )
             full_theta_keys_copy.pop(full_theta_keys_copy.index(key))
 
-        if len(full_theta_keys_copy) > 0:
+        if len(full_theta_keys_copy) > 0:  # pragma: no cover
             raise ValueError(
                 ("Input dictionary `theta` is missing the following keys: {}").format(
                     full_theta_keys_copy
@@ -2147,14 +2147,24 @@ class MCMCSearch(BaseSearchClass):
                         a = prior["lower"]
                         b = prior["upper"]
                         line = r"{} & $\mathrm{{Unif}}$({}, {}) & {}\\"
-                    elif Type == "norm":
+                    elif Type == "log10unif":
+                        a = prior["log10lower"]
+                        b = prior["log10upper"]
+                        line = r"{} & $\mathrm{{log10Unif}}$({}, {}) & {}\\"
+                    else:
+                        # FIXME: Currently all non-uniform priors have loc and scale;
+                        # this assumption might break in the future,
+                        # but priors have to be redesigned anyway.
                         a = prior["loc"]
                         b = prior["scale"]
-                        line = r"{} & $\mathcal{{N}}$({}, {}) & {}\\"
-                    elif Type == "halfnorm":
-                        a = prior["loc"]
-                        b = prior["scale"]
-                        line = r"{} & $|\mathcal{{N}}$({}, {})| & {}\\"
+                        if Type == "norm":
+                            line = r"{} & $\mathcal{{N}}$({}, {}) & {}\\"
+                        elif Type == "halfnorm" or Type == "neghalfnorm":
+                            line = r"{} & $|\mathcal{{N}}$({}, {})| & {}\\"
+                        elif Type == "lognorm":
+                            line = r"{} & $|\mathcal{{lnN}}$({}, {})| & {}\\"
+                        else:  # pragma: no cover
+                            raise ValueError(f"Unknown prior type '{Type}'")
 
                     u = self.unit_dictionary[key]
                     s = self.tex_labels[key]
@@ -2576,7 +2586,7 @@ class MCMCGlitchSearch(MCMCSearch):
             else:
                 full_theta_keys_copy.pop(full_theta_keys_copy.index(key))
 
-        if len(full_theta_keys_copy) > 0:
+        if len(full_theta_keys_copy) > 0:  # pragma: no cover
             raise ValueError(
                 ("Input dictionary `theta` is missing the following keys: {}").format(
                     full_theta_keys_copy
@@ -3477,7 +3487,7 @@ class MCMCTransientSearch(MCMCSearch):
                 )
             full_theta_keys_copy.pop(full_theta_keys_copy.index(key))
 
-        if len(full_theta_keys_copy) > 0:
+        if len(full_theta_keys_copy) > 0:  # pragma: no cover
             raise ValueError(
                 ("Input dictionary `theta` is missing the following keys: {}").format(
                     full_theta_keys_copy

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -401,7 +401,7 @@ class MCMCSearch(BaseSearchClass):
     def _unpack_input_theta(self):
         self.full_theta_keys = ["F0", "F1", "F2", "Alpha", "Delta"]
         if self.binary:
-            self.full_theta_keys += ["asini", "period", "ecc", "tp", "argp"]
+            self.full_theta_keys += self.binary_keys
         full_theta_keys_copy = copy.copy(self.full_theta_keys)
 
         self.theta_keys = []
@@ -3563,7 +3563,7 @@ class MCMCTransientSearch(MCMCSearch):
     def _unpack_input_theta(self):
         self.full_theta_keys = ["F0", "F1", "F2", "Alpha", "Delta"]
         if self.binary:
-            self.full_theta_keys += ["asini", "period", "ecc", "tp", "argp"]
+            self.full_theta_keys += self.binary_keys
         self.full_theta_keys += ["transient_tstart", "transient_duration"]
         full_theta_keys_copy = copy.copy(self.full_theta_keys)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,6 +9,7 @@ import pytest
 from commons_for_tests import (
     BaseForTestsWithData,
     BaseForTestsWithOutdir,
+    default_binary_params,
     default_signal_params,
     default_Writer_params,
 )
@@ -156,6 +157,7 @@ class TestComputeFstat(BaseForTestsWithData):
             minCoverFreq=self.F0 - 0.1,
             maxCoverFreq=self.F0 + 0.1,
         )
+        # FIXME: This way is deprecated, remove test in future versions
         FS = search.get_fullycoherent_twoF(
             F0=self.F0,
             F1=self.F1,
@@ -163,6 +165,66 @@ class TestComputeFstat(BaseForTestsWithData):
             Alpha=self.Alpha,
             Delta=self.Delta,
         )
+        self.assertTrue(FS > 0.0)
+        # now with new input params option
+        FS_new = search.get_fullycoherent_twoF(
+            params={
+                "F0": self.F0,
+                "F1": self.F1,
+                "F2": self.F2,
+                "Alpha": self.Alpha,
+                "Delta": self.Delta,
+            }
+        )
+        np.isclose(FS_new, FS, rtol=1e-6, atol=0)
+        # now with higher spindowns
+        FS_sd = search.get_fullycoherent_twoF(
+            params={
+                "F0": self.F0,
+                "F1": self.F1,
+                "F2": self.F2,
+                # deliberately skipping F3 to test non-contiguous lists
+                # (omtited terms should be assumed as 0)
+                "F4": 1e-20,
+                "Alpha": self.Alpha,
+                "Delta": self.Delta,
+            }
+        )
+        np.isclose(FS_sd, FS, rtol=1e-6, atol=0)
+        # FIXME: extend test to properly test Fkdot matches?
+
+    def test_run_computefstatistic_single_point_injectSqrtSX_binary(self):
+        # not using any SFTs
+        search = pyfstat.ComputeFstat(
+            tref=self.tref,
+            minStartTime=self.tstart,
+            maxStartTime=self.tstart + self.duration,
+            detectors=self.detectors,
+            injectSqrtSX=self.sqrtSX,
+            minCoverFreq=self.F0 - 0.1,
+            maxCoverFreq=self.F0 + 0.1,
+            binary=True,
+        )
+        # FIXME: This way is deprecated, remove test in future versions
+        FS = search.get_fullycoherent_twoF(
+            F0=self.F0,
+            F1=self.F1,
+            F2=self.F2,
+            Alpha=self.Alpha,
+            Delta=self.Delta,
+            **default_binary_params,
+        )
+        self.assertTrue(FS > 0.0)
+        # now with new input params option
+        params = {
+            "F0": self.F0,
+            "F1": self.F1,
+            "F2": self.F2,
+            "Alpha": self.Alpha,
+            "Delta": self.Delta,
+        }
+        params.update(default_binary_params)
+        FS = search.get_fullycoherent_twoF(params=params)
         self.assertTrue(FS > 0.0)
 
     def test_run_computefstatistic_single_point_with_SFTs(self):

--- a/tests/test_grid_based_searches.py
+++ b/tests/test_grid_based_searches.py
@@ -20,9 +20,15 @@ class TestGridSearch(BaseForTestsWithData):
 
     def _test_plots(self, search_keys):
         for key in search_keys:
-            self.search.plot_1D(xkey=key, savefig=True)
+            self.search.plot_1D(xkey=key, x0=self.Writer.F0, savefig=True)
         if len(search_keys) == 2:
-            self.search.plot_2D(xkey=search_keys[0], ykey=search_keys[1], colorbar=True)
+            self.search.plot_2D(
+                xkey=search_keys[0],
+                ykey=search_keys[1],
+                x0=self.Writer.F0,
+                y0=self.Writer.F1,
+                colorbar=True,
+            )
         vals = [
             np.unique(self.search.data[key]) - getattr(self.Writer, key)
             for key in search_keys

--- a/tests/test_mcmc_based_searches.py
+++ b/tests/test_mcmc_based_searches.py
@@ -193,6 +193,7 @@ class TestMCMCSearch(BaseForMCMCSearchTests):
             )
             self.search.run(plot_walkers=False)
             self.search.print_summary()
+            self.search.write_prior_table()
             self._check_twoF_predicted()
             self._check_mcmc_quantiles()
             self._test_plots()


### PR DESCRIPTION
Some 2-year old edits I had lying around locally, rebased onto current master. This is a prerequisite for improvements such as #335.

`get_fullycoherent_detstat` and friends now take an optional `params` dictionary argument that can replace the old-style individual arguments for F0,... and the old style is already labeled as DEPRECATED and might be removed in the future. This will allow for including higher spindowns and non-standard parameters.

Along the way, I've also centralised the internal defaults for LaTeX labels into the core class.