### PR TITLE
upgrade setuptools in integration.yml

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,7 +24,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install package and development dependencies
       run: |
-        python -m pip install --upgrade pip
+        # we might still need a newer pip to be able to pull in lalsuite
+        # we need setuptools>=69.3.0 to support PEP 625 and avoid PyPI deprecation warnings
+        python -m pip install --upgrade pip setuptools
         pip install -e ${GITHUB_WORKSPACE}[test,wheel]
     - name: Run test suite with pytest
       run: |


### PR DESCRIPTION
- we need setuptools>=69.3.0 to support PEP 625
- to avoid PyPI deprecation warnings about sdist filename