### PR TITLE
unpin numpy (allow >=2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.3.0 [DD/05/2025]
+
+ - Removed outdated pin to numpy<2.0, we should be compatible.
+
+
 ## 2.2.1 [24/02/2025]
 
  - Fixed some detection statistic / output values corner cases.

--- a/README.md
+++ b/README.md
@@ -171,9 +171,6 @@ which should all be pulled in automatically if you use `pip`:
 For a general introduction to installing modules, see
 [here](https://docs.python.org/3/installing/index.html).
 
-NOTE: currently we have pinned to
-`numpy<2.0` (same as LALSuite).
-
 NOTE: We require a recent LALSuite (>=7.13) / lalpulsar (>=6.0).
 If you need to work with older versions,
 the last PyFstat release supporting those was `1.19.1`.

--- a/etc/pyfstat-dev.yml
+++ b/etc/pyfstat-dev.yml
@@ -17,7 +17,7 @@ dependencies:
   - dill
   - lalpulsar >=6.0
   - matplotlib-base >=3.3
-  - numpy <2.0
+  - numpy
   - pandas
   - pathos
   - pip

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ requires = [
     "corner",
     "dill",
     "matplotlib>=3.3",
-    "numpy<2.0",
+    "numpy",
     "pandas",
     "pathos",
     "ptemcee",


### PR DESCRIPTION
I think the pin only remained in place after https://github.com/PyFstat/PyFstat/commit/6571123804f821c6a61d2bdd07607a8e06f80936 because of lalsuite (or maybe some other) dependencies, and since those seem to have all fixed their compatibility, I'm not getting any test failures unpinning.