### PR TITLE
enable python 3.13 support

### DIFF
--- a/.github/workflows/check_notebooks.yml
+++ b/.github/workflows/check_notebooks.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.13"
     - name: Install package and development dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test_lalsuite_dev.yml
+++ b/.github/workflows/test_lalsuite_dev.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 2.3.0 [DD/05/2025]
+## 2.3.0 [28/05/2025]
 
- - Removed outdated pin to numpy<2.0, we should be compatible.
+ - Enabled support for python 3.13 and numpy 2.0.
 
 
 ## 2.2.1 [24/02/2025]

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Latest development versions can
 or [from a local git clone](#install-pyfstat-from-source-zenodo-or-git-clone).
 
 If you don't have a matching `python` installation
-(currently `3.9` to `3.12`)
+(currently `3.9` to `3.13`)
 on your system,
 then `Docker` or `conda` are the easiest paths.
 
@@ -74,12 +74,14 @@ or [conda environment](#conda-installation)
 (you really should!),
 on many systems you may need to use the `--user` flag.
 
-Note that the PyFstat installation will fail at the
-LALSuite dependency stage
-if your `pip` is too old (e.g. 18.1); to fix this, do
+Note that the PyFstat installation can fail with
+`Could not find a version that satisfies the requirement lalsuite`
+if e.g. your `pip`, `setuptools` or `glibc` versions are too old.
+To fix the first two cases, you can run
 ```
 pip install --upgrade pip setuptools
 ```
+For the latter, you should likely upgrade your system.
 
 ### conda installation
 

--- a/etc/pyfstat-dev.yml
+++ b/etc/pyfstat-dev.yml
@@ -22,7 +22,7 @@ dependencies:
   - pathos
   - pip
   - ptemcee
-  - python >=3.9,<=3.12
+  - python >=3.9,<=3.13
   - python-lal >=7.1.5
   - python-lalpulsar >=6.0
   - scipy

--- a/etc/pyfstat.yml
+++ b/etc/pyfstat.yml
@@ -2,5 +2,5 @@ name: pyfstat
 channels:
     - conda-forge
 dependencies:
-    - python >=3.9,<=3.12
+    - python >=3.9,<=3.13
     - pyfstat

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import versioneer
 
 # check python version
 min_python_version = (3, 9, 0)  # (major,minor,micro)
-next_unsupported_python_version = (3, 13)  # (major,minor) - don't restrict micro
+next_unsupported_python_version = (3, 14)  # (major,minor) - don't restrict micro
 python_version = sys.version_info
 if (
     python_version < min_python_version

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ requires = [
     "scipy",
     "setuptools; python_version >= '3.12'",
     "tqdm",
-    "versioneer",
 ]
 lalsuite = "lalsuite[lalpulsar]>=7.13"
 extras_require = {


### PR DESCRIPTION
Lalsuite has it now, so we can as well. No errors found in local testing.

Also remove the explicit `versioneer` dependence from `setup.py`. The local copy should be enough ("vendored mode") as far as I understand, and at least local testing was happy with it that way. (It also has never been a dependency in the conda recipes, see https://github.com/conda-forge/pyfstat-feedstock/blob/main/recipe/meta.yaml and discussion at https://github.com/conda-forge/pyfstat-feedstock/pull/34 ,)