### PR TITLE
implement params dict (for higher spindowns etc) in Writer and MCMC

### DIFF
--- a/examples/mcmc_examples/PyFstat_example_fully_coherent_MCMC_search.py
+++ b/examples/mcmc_examples/PyFstat_example_fully_coherent_MCMC_search.py
@@ -33,6 +33,7 @@ signal_parameters = {
     "F0": 30.0,
     "F1": -1e-10,
     "F2": 0,
+    "F3": 0,
     "Alpha": np.radians(83.6292),
     "Delta": np.radians(22.0144),
     "tref": mid_time,
@@ -41,7 +42,10 @@ signal_parameters = {
 }
 
 data = pyfstat.Writer(
-    label=label, outdir=outdir, **data_parameters, **signal_parameters
+    label=label,
+    outdir=outdir,
+    **data_parameters,
+    signal_parameters=signal_parameters,
 )
 data.make_data()
 
@@ -67,13 +71,13 @@ theta_prior = {
         "upper": signal_parameters["F1"] + DeltaF1 / 2.0,
     },
 }
-for key in "F2", "Alpha", "Delta":
+for key in "F2", "F3", "Alpha", "Delta":
     theta_prior[key] = signal_parameters[key]
 
 ntemps = 2
 log10beta_min = -0.5
 nwalkers = 100
-nsteps = [300, 300]
+nsteps = [100, 100]
 
 mcmc = pyfstat.MCMCSearch(
     label=label,

--- a/examples/other_examples/PyFstat_example_spectrogram.py
+++ b/examples/other_examples/PyFstat_example_spectrogram.py
@@ -28,6 +28,7 @@ logger = pyfstat.set_up_logger(label=label, outdir=outdir)
 
 signal = True  # turn off for pure noise spectrogram
 binary = True  # turn off for simpler isolated neutron star signal
+transient = False  # turn on for a time-limited signal
 
 # this sets how strong the signal is compared to the noise (higher value -> weaker)
 depth = 5
@@ -90,6 +91,15 @@ if binary:
         }
     )
 
+# optionally add transient parameters
+if transient:
+    signal_parameters.update(
+        {
+            "transientStartTime": segments[1]["tstart"],
+            "transientTau": segments[1]["duration"],
+            "transientWindowType": "exp",  # exponentially decaying signal amplitude
+        }
+    )
 # making data
 data = pyfstat.Writer(
     label=label,

--- a/examples/other_examples/PyFstat_example_spectrogram.py
+++ b/examples/other_examples/PyFstat_example_spectrogram.py
@@ -26,53 +26,80 @@ label = "PyFstatExampleSpectrogramNormPower"
 outdir = os.path.join("PyFstat_example_data", label)
 logger = pyfstat.set_up_logger(label=label, outdir=outdir)
 
+signal = True  # turn off for pure noise spectrogram
+binary = True  # turn off for simpler isolated neutron star signal
+
+# this sets how strong the signal is compared to the noise (higher value -> weaker)
 depth = 5
 
+# Define the tstart and duration of each segment of data,
+# including some gaps like in real observing runs.
 gap_duration = 10 * 86400
 Tsft = 1800
-
-segments = [  # Define the tstart and duration of each segment of data
+segments = [
     {"tstart": 1000000000, "duration": 120 * 86400},
     {"tstart": 1000000000 + 120 * 86400 + gap_duration, "duration": 300 * 86400},
     {"tstart": 1000000000 + 420 * 86400 + 2 * gap_duration, "duration": 120 * 86400},
 ]
 
+# Generate timestamps for each segment and concatenate them.
 timestamps = {
     "H1": np.concatenate(
-        [  # Generate timestamps for each segment and concatenate them
+        [
             segment["tstart"] + Tsft * np.arange(segment["duration"] // Tsft)
             for segment in segments
         ]
     )
 }
 
+# general parameters to configure the data to simulate
 data_parameters = {
     "sqrtSX": 1e-23,
     "timestamps": timestamps,
     "detectors": "H1",
     "Tsft": 1800,
 }
+# For pure noise, we need to select the frequency range ourselves.
+# For signals, PyFstat auto-estimates this.
+if not signal:
+    data_parameters.update(
+        {
+            "F0": 100.0,
+            "Band": 0.1,
+        }
+    )
 
+# parameters for a signal to inject (if signal==True)
 signal_parameters = {
     "F0": 100.0,
     "F1": 0,
     "F2": 0,
     "Alpha": 0.0,
     "Delta": 0.5,
-    "tp": segments[0]["tstart"],
-    "asini": 25.0,
-    "period": 50 * 86400,
     "tref": segments[0]["tstart"],
-    "h0": data_parameters["sqrtSX"] / depth,
+    "h0": data_parameters["sqrtSX"] / depth if signal else 0.0,
     "cosi": 1.0,
 }
+# optionally add binary orbital parameters
+if binary:
+    signal_parameters.update(
+        {
+            "tp": segments[0]["tstart"],
+            "asini": 25.0,
+            "period": 50 * 86400,
+        }
+    )
 
 # making data
-data = pyfstat.BinaryModulatedWriter(
-    label=label, outdir=outdir, **data_parameters, **signal_parameters
+data = pyfstat.Writer(
+    label=label,
+    outdir=outdir,
+    **data_parameters,
+    signal_parameters=signal_parameters,
 )
 data.make_data()
 
+# make the plot
 ax = pyfstat.utils.plot_spectrogram(
     sftfilepattern=data.sftfilepath,
     detector=data_parameters["detectors"],

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -756,6 +756,8 @@ class ComputeFstat(BaseSearchClass):
 
         logger.info("Initialising PulsarDoplerParams")
         PulsarDopplerParams = lalpulsar.PulsarDopplerParams()
+        if self.tref is None:
+            raise ValueError("tref must not be None (should be a GPS time)!")
         PulsarDopplerParams.refTime = self.tref
         PulsarDopplerParams.fkdot = np.zeros(lalpulsar.PULSAR_MAX_SPINS)
         self.PulsarDopplerParams = PulsarDopplerParams

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -11,7 +11,7 @@ import numpy as np
 from tqdm import tqdm, trange
 
 import pyfstat.utils as utils
-from pyfstat.core import BaseSearchClass, SearchForSignalWithJumps
+from pyfstat.core import BaseSearchClass, DeprecatedClass, SearchForSignalWithJumps
 
 logger = logging.getLogger(__name__)
 
@@ -34,30 +34,61 @@ class Writer(BaseSearchClass):
     """
 
     mfd = "lalpulsar_Makefakedata_v5"
+    max_fkdot = 6  # matching lalpulsar/lib/CWMakeFakeData.c as of a4864772
     """The executable; can be overridden by child classes."""
 
-    signal_parameter_labels = [
-        "tref",
-        "F0",
-        "F1",
-        "F2",
+    standard_signal_parameter_keys = ["tref"]
+    standard_signal_parameter_keys += [f"F{k}" for k in range(max_fkdot + 1)]
+    standard_signal_parameter_keys += [
         "Alpha",
         "Delta",
         "h0",
         "cosi",
         "psi",
         "phi",
+    ]
+    """Default convention of labels for various standard signal parameters."""
+
+    binary_signal_parameter_keys = [
+        "tp",
+        "argp",
+        "asini",
+        "ecc",
+        "period",
+    ]
+    """Default convention of labels for binary orbital signal parameters.
+
+    Kept separate to avoid setting these when not needed.
+    """
+
+    transient_signal_parameter_keys = [
         "transientWindowType",
         "transientStartTime",
         "transientTau",
     ]
-    """Default convention of labels for the various signal parameters."""
+    """Default convention of labels for transient signal parameters.
+
+    Kept separate to avoid setting these when not needed.
+    """
+
+    supported_signal_parameters = (
+        standard_signal_parameter_keys
+        + transient_signal_parameter_keys
+        + binary_signal_parameter_keys
+    )
+    """All standard parameter names.
+
+    This full set is not required,
+    but "supported" in the sense that the code knows about it,
+    and it will be used for various dictionary translations/copies.
+    """
 
     gps_time_and_string_formats_as_LAL = {
         "refTime": ":10.9f",
         "transientWindowType": ":s",
         "transientStartTime": ":10.0f",
         "transientTau": ":10.0f",
+        "orbitTp": ":10.9f",
     }
     """Dictionary to ensure proper format handling for some special parameters.
 
@@ -66,15 +97,17 @@ class Writer(BaseSearchClass):
     """
 
     required_signal_parameters = [
-        # leaving out "F1","F2","psi","phi","tref" as they have defaults
+        "tref",
         "F0",
         "Alpha",
         "Delta",
         "cosi",
     ]
     """List of parameters required for a successful execution of Makefakedata_v5.
-    The rest of available parameters are not required as they have default values
-    silently given by Makefakedata_v5
+
+    The rest of available parameters
+    ("F1","F2",...,"psi","phi" and optional binary/transient parameters)
+    are not required, as they can default to 0.
     """
 
     @utils.initializer
@@ -85,14 +118,15 @@ class Writer(BaseSearchClass):
         duration=None,
         tref=None,
         F0=None,
-        F1=0,
-        F2=0,
+        F1=None,
+        F2=None,
         Alpha=None,
         Delta=None,
         h0=None,
         cosi=None,
-        psi=0.0,
-        phi=0,
+        psi=None,
+        phi=None,
+        signal_parameters=None,
         Tsft=1800,
         outdir=".",
         sqrtSX=None,
@@ -104,7 +138,7 @@ class Writer(BaseSearchClass):
         detectors=None,
         earth_ephem=None,
         sun_ephem=None,
-        transientWindowType="none",
+        transientWindowType=None,
         transientStartTime=None,
         transientTau=None,
         randSeed=None,
@@ -135,18 +169,35 @@ class Writer(BaseSearchClass):
             `SFTConstraint <https://lscsoft.docs.ligo.org/lalsuite/lalpulsar/struct_s_f_t_constraints.html>`_.
             NOTE: mutually exclusive with `timestamps`.
         tref: float or None
+            DEPRECATED, include this in `signal_parameters` instead!
             Reference time for simulated signals.
             Default is `None`, which sets the reference time to `tstart`.
         F0: float or None
-            Frequency of a signal to inject.
-            Also used (if `Band` is not `None`) as center of frequency band.
-            Also needed when noise-only (`h0=None` or `h0==0`)
-            but no `noiseSFTs` given,
-            in which case it is also used as center of frequency band.
+            If `Band` is not `None`, this is the frequency band center for the SFTs,
+            and is required if no `noiseSFTs` or `signal_parameters` are given.
+            Also used as the frequency of a signal to be injected,
+            if `signal_parameters` or a non-zero `h0` are set.
+            Can be used interchangeably with `signal_parameters['F0']`.
         F1, F2, Alpha, Delta, h0, cosi, psi, phi: float or None
-            Additional frequency evolution and amplitude parameters for a signal.
-            If `h0=None` or `h0=0`, these are all ignored.
-            If `h0>0`, then at least `[Alpha,Delta,cosi]` need to be set explicitly.
+            DEPRECATED: Additional frequency evolution and amplitude parameters for a signal.
+            Include these in `signal_parameters` instead!
+        signal_parameters: dict
+            A dictionary of frequency evolution and amplitude parameters for a signal to inject.
+            If `h0=0`, the other parameters are all ignored.
+            If `h0>0`, then at least `[Alpha,Delta,cosi,tref]` need to also be set explicitly.
+            `F0` can be either set here or as a separate argument;
+            if both are set, they must be the same.
+            Also supported:
+            * spin-down terms Fk with `1<k<=6`
+            * binary parameters `asini, period, ecc, tp, argp`
+            * transientWindowType (str):
+            If omitted or `none`, a fully persistent CW signal is simulated.
+            If `rect` or `exp`, a transient signal with the corresponding
+            amplitude evolution is simulated.
+            * transientStartTime (int or None):
+            Start time for a transient signal.
+            * transientTau (int or None):
+            Duration (`rect` case) or decay time (`exp` case) of a transient signal.
         Tsft: int
             The SFT duration in seconds.
             Will be ignored if `noiseSFTs` are given.
@@ -185,12 +236,15 @@ class Writer(BaseSearchClass):
             If None, will check standard sources as per
             utils.get_ephemeris_files().
         transientWindowType: str
+            DEPRECATED, include this in `signal_parameters` instead!
             If `none`, a fully persistent CW signal is simulated.
             If `rect` or `exp`, a transient signal with the corresponding
             amplitude evolution is simulated.
         transientStartTime: int or None
+            DEPRECATED, include this in `signal_parameters` instead!
             Start time for a transient signal.
         transientTau: int or None
+            DEPRECATED, include this in `signal_parameters` instead!
             Duration (`rect` case) or decay time (`exp` case) of a transient signal.
         randSeed: int or None
             Optionally fix the random seed of Gaussian noise generation
@@ -214,7 +268,7 @@ class Writer(BaseSearchClass):
 
         self.set_ephemeris_files(earth_ephem, sun_ephem)
         self._basic_setup()
-        self._parse_args_consistent_with_mfd()
+        self._parse_signal_params_consistent_with_mfd()
         self.calculate_fmin_Band()
 
     def _get_sft_constraints_from_tstart_duration(self):
@@ -440,16 +494,6 @@ class Writer(BaseSearchClass):
 
         os.makedirs(self.outdir, exist_ok=True)
         self.config_file_name = os.path.join(self.outdir, self.label + ".cff")
-        self.theta = np.array([self.phi, self.F0, self.F1, self.F2])
-
-        if self.h0 and np.any(
-            [getattr(self, k, None) is None for k in self.required_signal_parameters]
-        ):
-            raise ValueError(
-                "If h0>0, also need all of ({:s})".format(
-                    ",".join(self.required_signal_parameters)
-                )
-            )
 
         incompatible_with_TS = ["tstart", "duration", "noiseSFTs"]
         TS_required_options = ["Tsft"]
@@ -489,9 +533,6 @@ class Writer(BaseSearchClass):
         self.sftfilenames = [os.path.join(self.outdir, fn) for fn in self.sftfilenames]
         self.sftfilepath = ";".join(self.sftfilenames)
 
-        if self.tref is None:
-            self.tref = self.tstart
-
         if getattr(self, "SFTWindowBeta", None):
             raise ValueError(
                 "Option 'SFTWindowBeta' is defunct, please use 'SFTWindowParam'."
@@ -518,14 +559,128 @@ class Writer(BaseSearchClass):
         """
         return self.tstart + self.duration
 
-    def _parse_args_consistent_with_mfd(self):
-        """Internal method to ensure parameters are handled consistently with MFD."""
-        self.signal_parameters = self.translate_keys_to_lal(
-            {
+    def _parse_signal_params_consistent_with_mfd(self):
+        """Internal method to ensure parameters are handled consistently with MFD.
+
+        FIXME: This can be simplified once the deprecated style
+        of passing individual parameters is removed.
+        """
+        if self.signal_parameters is not None:
+            for key, val in self.signal_parameters.items():
+                if val is None:  # pragma: no cover
+                    raise ValueError(
+                        "Entries in a 'signal_parameters' dictionary must not be `None`!"
+                    )
+            for key in self.required_signal_parameters:
+                if (
+                    not key == "F0" and key not in self.signal_parameters.keys()
+                ):  # pragma: no cover
+                    raise ValueError(
+                        f"Missing required entry '{key}' in 'signal_parameters' dictionary!"
+                    )
+            for key in self.signal_parameters.keys():
+                if self.__dict__.get(key, None) is not None and not key == "F0":
+                    raise ValueError(
+                        f"Cannot set {key} both via 'signal_parameters' and as a separate option!"
+                    )
+            if "F0" in self.signal_parameters.keys():
+                if self.F0 is None:
+                    self.F0 = self.signal_parameters["F0"]
+                    logger.info(
+                        f"Setting self.F0={self.F0} from signal.parameters['F0']."
+                    )
+                if self.signal_parameters["F0"] != self.F0:  # pragma: no cover
+                    raise ValueError(
+                        "'F0' entry in 'self.signal_parameters' must be the same as"
+                        f" the separate F0 option ({self.signal_parameters['F0']}!={self.F0})"
+                    )
+            else:
+                logger.info(f"Setting signal.parameters['F0']={self.F0}")
+                self.signal_parameters["F0"] = self.F0
+            for key in self.standard_signal_parameter_keys:
+                if key not in self.signal_parameters.keys():
+                    self.signal_parameters[key] = 0.0
+                    logger.info(
+                        f"Assigning default: {key}={self.signal_parameters[key]}"
+                    )
+            # need to copy this for some special cases such as GlitchWriter:
+            self.tref = self.signal_parameters["tref"]
+        elif np.all(
+            [
+                key == "tref" or self.__dict__[key] is not None
+                for key in self.required_signal_parameters
+            ]
+        ):
+            # excluding special case of tref which has a legacy default
+            logger.warning(
+                "Passing injection parameters individually is DEPRECATED"
+                " and will be removed in a future version of PyFstat."
+                " Please change to using a 'signal_parameters' dictionary."
+            )
+            if self.tref is None:
+                logger.info(f"Assigning default: tref={self.tstart}")
+                self.tref = self.tstart
+            for key in ["F1", "F2", "phi", "psi"]:
+                if self.__dict__[key] is None:
+                    self.__dict__[key] = 0.0
+                    logger.info(f"Assigning default: {key}={self.__dict__[key]}")
+            # copy all supported and user-set parameters over to new-style dictionary
+            self.signal_parameters = {
                 key: self.__dict__[key]
-                for key in self.signal_parameter_labels
+                for key in self.supported_signal_parameters
                 if self.__dict__.get(key, None) is not None
             }
+        elif (self.h0 is None or self.h0 == 0.0) and np.any(
+            [
+                self.__dict__.get(key, None) is not None and key != "h0"
+                for key in self.supported_signal_parameters
+            ]
+        ):
+            ignored_params = [
+                key
+                for key in self.supported_signal_parameters
+                if self.__dict__.get(key, None) is not None and key != "h0"
+            ]
+            logger.warning(
+                "No 'signal_parameters' dictionary given"
+                f" and separate h0={self.h0},"
+                f" will ignore all other signal parameters ({ignored_params})"
+                " and not inject a signal."
+            )
+            return
+        elif np.any(
+            [
+                self.__dict__.get(key, None) is not None and key not in ["h0", "F0"]
+                for key in self.standard_signal_parameter_keys
+            ]
+        ):  # pragma: no cover
+            raise ValueError(
+                f"Need either a 'signal_parameters' dictionary"
+                f"{' (not given)' if self.signal_parameters is None else ''}"
+                f" or a full set of individual options {self.required_signal_parameters} (DEPRECATED,"
+                f" {sum([self.__dict__[key] is not None for key in self.required_signal_parameters])} of {len(self.required_signal_parameters)} given"
+                f") plus optional transient and binary parameters (also DEPRECATED)."
+            )
+        else:
+            logger.info("No signal parameter options given, no injection will be done.")
+            return
+
+        if self.signal_parameters["h0"] and np.any(
+            [
+                self.signal_parameters[key] is None
+                for key in self.required_signal_parameters
+            ]
+        ):
+            raise ValueError(
+                "If h0>0, also need all of ({:s})".format(
+                    ",".join(self.required_signal_parameters)
+                )
+            )
+
+        # translate to lalpulsar-style names
+        self.signal_parameters = self.translate_keys_to_lal(self.signal_parameters)
+        logger.debug(
+            f"Parsed signal_parameters dictionary for injection:\n{self.signal_parameters}"
         )
 
         self.signal_formats = {
@@ -577,17 +732,29 @@ class Writer(BaseSearchClass):
                 " (corresponding to default F-statistic settings).".format(extraBins)
             )
             fkdot = np.zeros(lalpulsar.PULSAR_MAX_SPINS)
-            for k in range(3):
-                fkdot[k] = getattr(self, f"F{k}")
+            fkdot[0] = self.F0
+            if self.signal_parameters:
+                for k in range(self.max_fkdot + 1):
+                    if f"f{k + 1}dot" in self.signal_parameters.keys():
+                        fkdot[k + 1] = self.signal_parameters[f"f{k + 1}dot"]
+                tref = self.signal_parameters.get("refTime", self.tstart)
+                maxOrbitAsini = self.signal_parameters.get("orbitasini", 0.0)
+                minOrbitPeriod = self.signal_parameters.get("orbitPeriod", 0.0)
+                maxOrbitEcc = self.signal_parameters.get("orbitEcc", 0.0)
+            else:
+                tref = self.tstart
+                maxOrbitAsini = 0.0
+                minOrbitPeriod = 0.0
+                maxOrbitEcc = 0.0
             minCoverFreq, maxCoverFreq = utils.get_covering_band(
-                tref=self.tref,
+                tref=tref,
                 tstart=self.tstart,
                 tend=self.tend,
                 fkdot=fkdot,
                 fkdotBand=np.zeros(lalpulsar.PULSAR_MAX_SPINS),
-                maxOrbitAsini=getattr(self, "asini", 0.0),
-                minOrbitPeriod=getattr(self, "period", 0.0),
-                maxOrbitEcc=getattr(self, "ecc", 0.0),
+                maxOrbitAsini=maxOrbitAsini,
+                minOrbitPeriod=minOrbitPeriod,
+                maxOrbitEcc=maxOrbitEcc,
             )
             self.fmin = minCoverFreq - extraBins / self.Tsft
             self.Band = maxCoverFreq - minCoverFreq + 2 * extraBins / self.Tsft
@@ -706,13 +873,15 @@ class Writer(BaseSearchClass):
                     " header in old file '{}'. {}".format(sftfile, need_new)
                 )
                 return False
-            if not utils.match_commandlines(cl_old, cl_mfd):
+            cls_match, unmatched_items = utils.match_commandlines(cl_old, cl_mfd)
+            if not cls_match:
                 logger.info(
                     "......commandlines unmatched for first SFT in old"
                     " file '{}':".format(sftfile)
                 )
-                logger.info(cl_old)
-                logger.info(cl_mfd)
+                logger.info(f"Old CL: {cl_old}")
+                logger.info(f"New CL: {cl_mfd}")
+                logger.info(f"Unmatched items: {unmatched_items}")
                 logger.info(need_new)
                 return False
         logger.info("......OK: Commandline matched with old SFT header(s).")
@@ -756,10 +925,12 @@ class Writer(BaseSearchClass):
 
     def make_data(self, verbose=False):
         """A convenience wrapper to generate a cff file and then SFTs."""
-        if self.h0:
+        if self.signal_parameters:
             self.make_cff(verbose)
         else:
-            logger.info("Got h0=0, not writing an injection .cff file.")
+            logger.info(
+                "No signal parameters given, not writing an injection .cff file."
+            )
         self.run_makefakedata()
 
     def run_makefakedata(self):
@@ -827,7 +998,7 @@ class Writer(BaseSearchClass):
         if hasattr(self, "Band") and self.Band:
             cl_mfd.append("--Band={:.16g}".format(self.Band))
         cl_mfd.append("--Tsft={}".format(self.Tsft))
-        if self.h0:
+        if self.signal_parameters and self.signal_parameters["h0"]:
             cl_mfd.append('--injectionSources="{}"'.format(self.config_file_name))
         earth_ephem = getattr(self, "earth_ephem", None)
         sun_ephem = getattr(self, "sun_ephem", None)
@@ -857,12 +1028,12 @@ class Writer(BaseSearchClass):
             Detectors will be paired to list elements following alphabetical order.
         """
         twoF_expected, twoF_sigma = utils.predict_fstat(
-            h0=self.h0,
-            cosi=self.cosi,
-            psi=self.psi,
-            Alpha=self.Alpha,
-            Delta=self.Delta,
-            F0=self.F0,
+            h0=self.signal_parameters["h0"],
+            cosi=self.signal_parameters["cosi"],
+            psi=self.signal_parameters["psi"],
+            Alpha=self.signal_parameters["Alpha"],
+            Delta=self.signal_parameters["Delta"],
+            F0=self.signal_parameters["Freq"],
             sftfilepattern=self.sftfilepath,
             minStartTime=self.tstart,
             duration=self.duration,
@@ -871,15 +1042,21 @@ class Writer(BaseSearchClass):
             tempory_filename=os.path.join(self.outdir, self.label + ".tmp"),
             earth_ephem=self.earth_ephem,
             sun_ephem=self.sun_ephem,
-            transientWindowType=self.transientWindowType,
-            transientStartTime=self.transientStartTime,
-            transientTau=self.transientTau,
+            transientWindowType=self.signal_parameters.get(
+                "transientWindowType", "none"
+            ),
+            transientStartTime=self.signal_parameters.get("transientStartTime", None),
+            transientTau=self.signal_parameters.get("transientTau", None),
         )
         return twoF_expected
 
 
-class BinaryModulatedWriter(Writer):
-    """Special Writer variant for simulating a CW signal for a source in a binary system."""
+class BinaryModulatedWriter(Writer, DeprecatedClass):
+    """Special Writer variant for simulating a CW signal for a source in a binary system.
+
+    DEPRECATED: This can now be replaced by the standard Writer class,
+        passing the values for `[tp,argp,asini,ecc,period]` in the `signal_parameters` dictionary.
+    """
 
     @utils.initializer
     def __init__(
@@ -889,19 +1066,20 @@ class BinaryModulatedWriter(Writer):
         duration=None,
         tref=None,
         F0=None,
-        F1=0,
-        F2=0,
+        F1=None,
+        F2=None,
         Alpha=None,
         Delta=None,
-        tp=0.0,
-        argp=0.0,
-        asini=0.0,
-        ecc=0.0,
-        period=0.0,
+        tp=None,
+        argp=None,
+        asini=None,
+        ecc=None,
+        period=None,
         h0=None,
         cosi=None,
-        psi=0.0,
-        phi=0,
+        psi=None,
+        phi=None,
+        signal_parameters=None,
         Tsft=1800,
         outdir=".",
         sqrtSX=None,
@@ -913,7 +1091,7 @@ class BinaryModulatedWriter(Writer):
         detectors=None,
         earth_ephem=None,
         sun_ephem=None,
-        transientWindowType="none",
+        transientWindowType=None,
         transientStartTime=None,
         transientTau=None,
         randSeed=None,
@@ -928,14 +1106,6 @@ class BinaryModulatedWriter(Writer):
         tp, argp, asini, ecc, period:
             binary orbit parameters
         """
-        self.signal_parameter_labels = super().signal_parameter_labels + [
-            "tp",
-            "argp",
-            "asini",
-            "ecc",
-            "period",
-        ]
-        self.gps_time_and_string_formats_as_LAL["orbitTp"] = ":10.9f"
 
         super().__init__(
             label=label,
@@ -951,6 +1121,7 @@ class BinaryModulatedWriter(Writer):
             cosi=cosi,
             psi=psi,
             phi=phi,
+            signal_parameters=signal_parameters,
             Tsft=Tsft,
             outdir=outdir,
             sqrtSX=sqrtSX,
@@ -992,11 +1163,9 @@ class LineWriter(Writer):
     """Required parameters for Makefakedata_v4 to success. Any other parameter is
     silently given a default value by Makefakedata_v4.
     """
-    signal_parameters_labels = required_signal_parameters + [
-        "transientWindowType",
-        "transientStartTime",
-        "transientTau",
-    ]
+    supported_signal_parameters = (
+        required_signal_parameters + Writer.transient_signal_parameter_keys
+    )
     """Other signal parameters will be removed before passing to Makefakedata_v4."""
 
     def __init__(self, *args, **kwargs):
@@ -1011,35 +1180,40 @@ class LineWriter(Writer):
                 "on single-detector SFT sets once at a time."
             )
 
-    def _parse_args_consistent_with_mfd(self):
+    def _parse_signal_params_consistent_with_mfd(self):
         """
         Adapt input arguments.
         Take care of minor inconsistencies between MFD_v4 and MFD_v5
         """
-        super()._parse_args_consistent_with_mfd()
+        super()._parse_signal_params_consistent_with_mfd()
 
         # FIXME: There should be a smoother way to translate keys
-        lal_required_signal_parameters = self.translate_keys_to_lal(
+        lal_supported_signal_parameters = self.translate_keys_to_lal(
             dict(
                 zip(
-                    self.required_signal_parameters,
-                    [0] * len(self.required_signal_parameters),
+                    self.supported_signal_parameters,
+                    [0] * len(self.supported_signal_parameters),
                 )
             )
         )
 
-        if any(
-            key not in lal_required_signal_parameters for key in self.signal_parameters
+        if self.signal_parameters and np.any(
+            [
+                key not in lal_supported_signal_parameters
+                for key in self.signal_parameters
+            ]
         ):
             logger.warning(
                 "Injection of line artifacts only uses the following parameters:\n"
-                f"{self.required_signal_parameters}.\n"
+                f"{self.supported_signal_parameters}\n"
+                f"(for lalpulsar: {list(lal_supported_signal_parameters.keys())}).\n"
                 "Any other parameter will be purged from this class now"
             )
             params_to_purge = list(
-                set(self.signal_parameters) - set(lal_required_signal_parameters)
+                set(self.signal_parameters)
+                - set(lal_supported_signal_parameters.keys())
             )
-            logger.info(
+            logger.warning(
                 "Purging input parameters that are not meaningful for LineWriter: {}".format(
                     params_to_purge
                 )
@@ -1047,17 +1221,25 @@ class LineWriter(Writer):
             for key in params_to_purge:
                 self.signal_parameters.pop(key)
 
-        if "transientTau" in self.signal_parameters:
+        if self.signal_parameters and "transientTau" in self.signal_parameters:
             self.signal_parameters["transientTauDays"] = (
                 self.signal_parameters.pop("transientTau") / 86400.0
             )
-            self.signal_formats["transientTauDays"] = self.signal_formats.pop(
-                "transientTau"
-            )
+
+        if self.signal_parameters:
+            self.signal_formats = {
+                key: self.gps_time_and_string_formats_as_LAL.get(key, ":.16g")
+                for key in self.signal_parameters
+            }
+
+        logger.debug(
+            f"Final signal_parameters dictionary for {self.mfd}:"
+            f" {self.signal_parameters}"
+        )
 
     def _build_MFD_command_line(self):
         """Generate the SFT data calling Makefakedata_v4."""
-
+        logger.info(f"Building {self.mfd} commandline...")
         cl_mfd = [self.mfd]
 
         cl_mfd.append("--lineFeature=TRUE")
@@ -1096,10 +1278,18 @@ class LineWriter(Writer):
         if getattr(self, "Band", None):
             cl_mfd.append("--Band={:.16g}".format(self.Band))
         cl_mfd.append("--Tsft={}".format(self.Tsft))
-        if self.h0:
+        if self.signal_parameters and self.signal_parameters.get("h0", None):
             cl_mfd.append(
                 " ".join(
-                    f"--{key}={value:.16g}"
+                    (
+                        '--{}="{{{}}}"'.format(key, self.signal_formats[key]).format(
+                            value
+                        )
+                        if self.signal_formats[key] == ":s"
+                        else "--{}={{{}}}".format(key, self.signal_formats[key]).format(
+                            value
+                        )
+                    )
                     for key, value in self.signal_parameters.items()
                 )
             )
@@ -1133,14 +1323,15 @@ class GlitchWriter(SearchForSignalWithJumps, Writer):
         delta_F2=0,
         tref=None,
         F0=None,
-        F1=0,
-        F2=0,
+        F1=None,
+        F2=None,
         Alpha=None,
         Delta=None,
         h0=None,
         cosi=None,
-        psi=0.0,
-        phi=0,
+        psi=None,
+        phi=None,
+        signal_parameters=None,
         Tsft=1800,
         outdir=".",
         sqrtSX=None,
@@ -1171,6 +1362,7 @@ class GlitchWriter(SearchForSignalWithJumps, Writer):
 
         self.set_ephemeris_files(earth_ephem, sun_ephem)
         self._basic_setup()
+        self._parse_signal_params_consistent_with_mfd()
         self.calculate_fmin_Band()
 
         shapes = np.array(
@@ -1197,13 +1389,25 @@ class GlitchWriter(SearchForSignalWithJumps, Writer):
         tbs = np.array(self.tbounds)
         self.durations = tbs[1:] - tbs[:-1]
 
-        self.delta_thetas = np.atleast_2d(
-            np.array([delta_phi, delta_F0, delta_F1, delta_F2]).T
-        )
+        if self.signal_parameters:
+            if self.signal_parameters.get("transientWindowType", None) is None:
+                # for the way we inject glitches, we always need this
+                self.signal_parameters["transientWindowType"] = self.transientWindowType
+            self.theta = np.array(
+                [
+                    self.signal_parameters["phi0"],
+                    self.signal_parameters["Freq"],
+                    self.signal_parameters["f1dot"],
+                    self.signal_parameters["f2dot"],
+                ]
+            )
+            self.delta_thetas = np.atleast_2d(
+                np.array([delta_phi, delta_F0, delta_F1, delta_F2]).T
+            )
 
     def _get_base_template(self, i, Alpha, Delta, h0, cosi, psi, phi, F0, F1, F2, tref):
         """FIXME: ported over from Writer,
-        should be replaced by a more elegant reuse of _parse_args_consistent_with_mfd
+        should be replaced by a more elegant reuse of _parse_signal_params_consistent_with_mfd
         """
         return """[TS{}]
 Alpha = {:1.18e}
@@ -1327,17 +1531,17 @@ transientTau = {:10.0f}\n"""
         for i, (t, d, ts) in enumerate(zip(thetas, self.durations, self.tbounds[:-1])):
             line = self._get_single_config_line(
                 i,
-                self.Alpha,
-                self.Delta,
-                self.h0,
-                self.cosi,
-                self.psi,
+                self.signal_parameters["Alpha"],
+                self.signal_parameters["Delta"],
+                self.signal_parameters["h0"],
+                self.signal_parameters["cosi"],
+                self.signal_parameters["psi"],
                 t[0],
                 t[1],
                 t[2],
                 t[3],
-                self.tref,
-                self.transientWindowType,
+                self.signal_parameters["refTime"],
+                self.signal_parameters["transientWindowType"],
                 ts,
                 d,
             )

--- a/pyfstat/make_sfts.py
+++ b/pyfstat/make_sfts.py
@@ -320,7 +320,7 @@ class Writer(BaseSearchClass):
         noise_multi_sft_catalog = lalpulsar.GetMultiSFTCatalogView(
             lalpulsar.SFTdataFind(self.noiseSFTs, SFTConstraint)
         )
-        if noise_multi_sft_catalog.length == 0:
+        if noise_multi_sft_catalog.length == 0:  # pragma: no cover
             raise IOError("Got empty SFT catalog.")
 
         # Information to be extracted from the SFTs themselves
@@ -356,9 +356,9 @@ class Writer(BaseSearchClass):
 
         # Get the "overall" values of the search
         Tsft = np.unique(Tsft)
-        if len(Tsft) != 1:
+        if len(Tsft) != 1:  # pragma: no cover
             raise ValueError(f"SFTs contain different basetimes: {Tsft}")
-        if Tsft[0] != self.Tsft:
+        if Tsft[0] != self.Tsft:  # pragma: no cover
             logger.warning(
                 f"Overwriting self.Tsft={self.Tsft}"
                 f" with value {Tsft[0]} read from noiseSFTs."
@@ -381,7 +381,7 @@ class Writer(BaseSearchClass):
         IFOs = self.detectors.split(",")
         # at this point, it's definitely a comma-separated string
         tsfiles = self.timestamps.split(",")
-        if len(IFOs) != len(tsfiles):
+        if len(IFOs) != len(tsfiles):  # pragma: no cover
             raise ValueError(
                 f"Length of detectors=='{self.detectors}'"
                 f" does not match that of timestamps=='{self.timestamps}'"
@@ -453,7 +453,7 @@ class Writer(BaseSearchClass):
 
             if self.detectors is not None:
                 ifos_in_detectors = self.detectors.split(",")
-                if np.setdiff1d(ifos, ifos_in_detectors).size:
+                if np.setdiff1d(ifos, ifos_in_detectors).size:  # pragma: no cover
                     raise ValueError(
                         f"Detector names in timestamps dictionary ({ifos}) "
                         f"are inconsistent with detector names given via keyword ({ifos_in_detectors})."
@@ -479,14 +479,14 @@ class Writer(BaseSearchClass):
     def _basic_setup(self):
         """Basic parameters handling, path setup etc."""
 
-        if not self.label.isalnum():
+        if not self.label.isalnum():  # pragma: no cover
             raise ValueError(
                 f"Label '{self.label}' is not alphanumeric,"
                 " which is incompatible with the SFTv3 naming specification"
                 " ( https://dcc.ligo.org/T040164-v2/public )."
                 " Please avoid underscores, hyphens etc."
             )
-        if len(self.label) > 60:
+        if len(self.label) > 60:  # pragma: no cover
             raise ValueError(
                 f"Label {self.label} is too long to comply with SFT naming rules"
                 f" ({len(self.label)}>60)."
@@ -502,12 +502,14 @@ class Writer(BaseSearchClass):
         if getattr(self, "timestamps", None) is not None:
             if np.any(
                 [getattr(self, k, None) is not None for k in incompatible_with_TS]
-            ):
+            ):  # pragma: no cover
                 raise ValueError(
                     "timestamps option is incompatible with"
                     f" ({','.join(incompatible_with_TS)})."
                 )
-            if np.any([getattr(self, k, None) is None for k in TS_required_options]):
+            if np.any(
+                [getattr(self, k, None) is None for k in TS_required_options]
+            ):  # pragma: no cover
                 raise ValueError(
                     "With timestamps option, need also all of"
                     f" ({','.join(TS_required_options)})."
@@ -521,7 +523,9 @@ class Writer(BaseSearchClass):
                 "internal consistency across input SFTs."
             )
             self._get_setup_from_noiseSFTs()
-        elif np.any([getattr(self, k, None) is None for k in no_noiseSFTs_options]):
+        elif np.any(
+            [getattr(self, k, None) is None for k in no_noiseSFTs_options]
+        ):  # pragma: no cover
             raise ValueError(
                 "Need either noiseSFTs, timestamps or all of ({:s}).".format(
                     ",".join(no_noiseSFTs_options)
@@ -533,11 +537,11 @@ class Writer(BaseSearchClass):
         self.sftfilenames = [os.path.join(self.outdir, fn) for fn in self.sftfilenames]
         self.sftfilepath = ";".join(self.sftfilenames)
 
-        if getattr(self, "SFTWindowBeta", None):
+        if getattr(self, "SFTWindowBeta", None):  # pragma: no cover
             raise ValueError(
                 "Option 'SFTWindowBeta' is defunct, please use 'SFTWindowParam'."
             )
-        if getattr(self, "SFTWindowType", None):
+        if getattr(self, "SFTWindowType", None):  # pragma: no cover
             try:
                 lal.CheckNamedWindow(
                     self.SFTWindowType, self.SFTWindowParam is not None
@@ -579,7 +583,9 @@ class Writer(BaseSearchClass):
                         f"Missing required entry '{key}' in 'signal_parameters' dictionary!"
                     )
             for key in self.signal_parameters.keys():
-                if self.__dict__.get(key, None) is not None and not key == "F0":
+                if (
+                    self.__dict__.get(key, None) is not None and not key == "F0"
+                ):  # pragma: no cover
                     raise ValueError(
                         f"Cannot set {key} both via 'signal_parameters' and as a separate option!"
                     )
@@ -591,11 +597,17 @@ class Writer(BaseSearchClass):
                     )
                 if self.signal_parameters["F0"] != self.F0:  # pragma: no cover
                     raise ValueError(
-                        "'F0' entry in 'self.signal_parameters' must be the same as"
+                        "'F0' entry in 'signal_parameters' must be the same as"
                         f" the separate F0 option ({self.signal_parameters['F0']}!={self.F0})"
                     )
+            elif getattr(self, "F0", None) is None:  # pragma: no cover
+                raise ValueError(
+                    "F0 required either in signal_parameters or as separate option."
+                )
             else:
-                logger.info(f"Setting signal.parameters['F0']={self.F0}")
+                logger.info(
+                    f"Setting signal_parameters['F0']={self.F0} from separate option."
+                )
                 self.signal_parameters["F0"] = self.F0
             for key in self.standard_signal_parameter_keys:
                 if key not in self.signal_parameters.keys():
@@ -670,7 +682,7 @@ class Writer(BaseSearchClass):
                 self.signal_parameters[key] is None
                 for key in self.required_signal_parameters
             ]
-        ):
+        ):  # pragma: no cover
             raise ValueError(
                 "If h0>0, also need all of ({:s})".format(
                     ",".join(self.required_signal_parameters)
@@ -867,7 +879,7 @@ class Writer(BaseSearchClass):
         for sftfile in self.sftfilenames:
             catalog = lalpulsar.SFTdataFind(sftfile, None)
             cl_old = utils.get_commandline_from_SFTDescriptor(catalog.data[0])
-            if len(cl_old) == 0:
+            if len(cl_old) == 0:  # pragma: no cover
                 logger.info(
                     "......could not obtain comparison commandline from first SFT"
                     " header in old file '{}'. {}".format(sftfile, need_new)

--- a/pyfstat/optimal_setup_functions.py
+++ b/pyfstat/optimal_setup_functions.py
@@ -132,7 +132,7 @@ def _get_nsegs_ip1(
         f, 0.4 * nsegs_i, method="Powell", tol=1, options={"maxiter": 10}
     )
     logger.info("{} with {} evaluations".format(res["message"], res["nfev"]))
-    nsegs_ip1 = int(res.x)
+    nsegs_ip1 = int(res.x[0])
     if nsegs_ip1 == 0:
         nsegs_ip1 = 1
     if res.success:

--- a/pyfstat/utils/cli.py
+++ b/pyfstat/utils/cli.py
@@ -82,6 +82,8 @@ def match_commandlines(cl1, cl2, be_strict_about_full_executable_path=False):
     -------
     match: bool
         Whether the executable and all `key=val` pairs of the two strings matched.
+    unmatched: np.ndarray
+        Sorted 1D array of unique items that are in only one of the commandlines.
     """
     cl1s = cl1.split(" ")
     cl2s = cl2.split(" ")
@@ -91,4 +93,4 @@ def match_commandlines(cl1, cl2, be_strict_about_full_executable_path=False):
         cl1s[0] = os.path.basename(cl1s[0])
         cl2s[0] = os.path.basename(cl2s[0])
     unmatched = np.setxor1d(cl1s, cl2s)
-    return len(unmatched) == 0
+    return len(unmatched) == 0, unmatched

--- a/tests/commons_for_tests.py
+++ b/tests/commons_for_tests.py
@@ -77,6 +77,7 @@ default_signal_params_no_sky = {
     "F0": 30.0,
     "F1": -1e-10,
     "F2": 0,
+    "F3": 0,
     "h0": 5.0,
     "cosi": 0,
     "psi": 0,

--- a/tests/commons_for_tests.py
+++ b/tests/commons_for_tests.py
@@ -60,10 +60,9 @@ def outdir(request):
 
 
 default_Writer_params = {
-    "label": "test",
     "sqrtSX": 1,
     "Tsft": 1800,
-    "tstart": 700000000,
+    "tstart": 1000000000,
     "duration": 4 * 1800,
     "detectors": "H1",
     "SFTWindowType": "tukey",
@@ -74,10 +73,11 @@ default_Writer_params = {
 
 
 default_signal_params_no_sky = {
+    "tref": default_Writer_params["tstart"],
     "F0": 30.0,
     "F1": -1e-10,
-    "F2": 0,
-    "F3": 0,
+    "F2": 1e-18,
+    "F3": 0.0,
     "h0": 5.0,
     "cosi": 0,
     "psi": 0,
@@ -163,7 +163,7 @@ def default_transient_parameters():
 # ============================================================================
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="class", params=["old", "new"])
 def data_fixture(request, outdir):
     """Pytest fixture that provides test data with a Writer object and SFTs.
 
@@ -183,7 +183,6 @@ def data_fixture(request, outdir):
     Yields:
         The test class instance with Writer and related attributes set
     """
-    # Skip making outdir, since Writer should do so on first call
     # Note: outdir fixture already handles directory creation
 
     # Get test class - this fixture requires a class-based test
@@ -194,42 +193,85 @@ def data_fixture(request, outdir):
             "Use @pytest.mark.usefixtures('data_fixture') on a test class."
         )
 
-    # Create fake data SFTs
-    # If we directly set any options as self.xy = 1 here,
-    # then values set for derived classes may get overwritten,
-    # so use a default dict and only insert if no value previously set
-    params = {**default_Writer_params, **default_signal_params}
-    for key, val in params.items():
-        if not hasattr(test_cls, key):
-            setattr(test_cls, key, val)
+    # transitionary setup to keep testing
+    # the old, deprecated signal parameters style for Writer
+    test_cls.style = request.param
 
-    test_cls.tref = test_cls.tstart
+    # Allow overwriting parameters from child classes
+    signal_params = {}
+    for key, val in default_signal_params.items():
+        signal_params[key] = getattr(test_cls, key, default_signal_params[key])
+
+    # Create fake data SFTs
     test_cls.Writer = pyfstat.Writer(
-        label=test_cls.label,
-        tstart=test_cls.tstart,
-        duration=test_cls.duration,
-        tref=test_cls.tref,
-        F0=test_cls.F0,
-        F1=test_cls.F1,
-        F2=test_cls.F2,
-        Alpha=test_cls.Alpha,
-        Delta=test_cls.Delta,
-        h0=test_cls.h0,
-        cosi=test_cls.cosi,
-        Tsft=test_cls.Tsft,
+        label=getattr(test_cls, "label", "TestWriter"),
+        tstart=getattr(test_cls, "tstart", default_Writer_params["tstart"]),
+        duration=getattr(test_cls, "duration", default_Writer_params["duration"]),
+        tref=(
+            getattr(test_cls, "tref", default_signal_params["tref"])
+            if test_cls.style == "old"
+            else None
+        ),
+        F0=(
+            getattr(test_cls, "F0", default_signal_params["F0"])
+            if test_cls.style == "old"
+            else None
+        ),
+        F1=(
+            getattr(test_cls, "F1", default_signal_params["F1"])
+            if test_cls.style == "old"
+            else None
+        ),
+        F2=(
+            getattr(test_cls, "F2", default_signal_params["F2"])
+            if test_cls.style == "old"
+            else None
+        ),
+        Alpha=(
+            getattr(test_cls, "Alpha", default_signal_params["Alpha"])
+            if test_cls.style == "old"
+            else None
+        ),
+        Delta=(
+            getattr(test_cls, "Delta", default_signal_params["Delta"])
+            if test_cls.style == "old"
+            else None
+        ),
+        h0=(
+            getattr(test_cls, "h0", default_signal_params["h0"])
+            if test_cls.style == "old"
+            else None
+        ),
+        cosi=(
+            getattr(test_cls, "cosi", default_signal_params["cosi"])
+            if test_cls.style == "old"
+            else None
+        ),
+        psi=(
+            getattr(test_cls, "psi", default_signal_params["psi"])
+            if test_cls.style == "old"
+            else None
+        ),
+        phi=(
+            getattr(test_cls, "phi", default_signal_params["phi"])
+            if test_cls.style == "old"
+            else None
+        ),
+        signal_parameters=signal_params if test_cls.style == "new" else None,
+        Tsft=getattr(test_cls, "Tsft", default_Writer_params["Tsft"]),
         outdir=test_cls.outdir,
-        sqrtSX=test_cls.sqrtSX,
-        Band=test_cls.Band,
-        detectors=test_cls.detectors,
-        SFTWindowType=test_cls.SFTWindowType,
-        SFTWindowParam=test_cls.SFTWindowParam,
-        randSeed=test_cls.randSeed,
+        sqrtSX=getattr(test_cls, "sqrtSX", default_Writer_params["sqrtSX"]),
+        Band=getattr(test_cls, "Band", default_Writer_params["Band"]),
+        detectors=getattr(test_cls, "detectors", default_Writer_params["detectors"]),
+        SFTWindowType=getattr(
+            test_cls, "SFTWindowType", default_Writer_params["SFTWindowType"]
+        ),
+        SFTWindowParam=getattr(
+            test_cls, "SFTWindowParam", default_Writer_params["SFTWindowParam"]
+        ),
+        randSeed=getattr(test_cls, "randSeed", default_Writer_params["randSeed"]),
     )
     test_cls.Writer.make_data(verbose=True)
-    test_cls.search_keys = ["F0", "F1", "F2", "Alpha", "Delta"]
-    test_cls.search_ranges = {
-        key: [getattr(test_cls, key)] for key in test_cls.search_keys
-    }
 
     yield test_cls
 
@@ -302,7 +344,7 @@ class BaseForTestsWithData(BaseForTestsWithOutdir):
         for key, val in {**default_Writer_params, **default_signal_params}.items():
             if not hasattr(cls, key):
                 setattr(cls, key, val)
-        cls.tref = cls.tstart
+        # cls.tref = cls.tstart
         cls.Writer = pyfstat.Writer(
             label=cls.label,
             tstart=cls.tstart,

--- a/tests/test_example_fixtures.py
+++ b/tests/test_example_fixtures.py
@@ -71,13 +71,6 @@ class TestExampleWithData:
         # The sftfilepath may contain wildcards, so check the directory
         assert os.path.isdir(self.outdir)
 
-    def test_search_keys_available(self):
-        """Test that search keys and ranges are available."""
-        assert hasattr(self, "search_keys")
-        assert hasattr(self, "search_ranges")
-        assert "F0" in self.search_keys
-        assert "F0" in self.search_ranges
-
 
 # ============================================================================
 # Examples using default parameter fixtures
@@ -106,7 +99,6 @@ def test_with_dictionary_constants():
     directly, which is recommended when you don't need to modify them.
     """
     # Import and use dictionaries directly
-    assert default_Writer_params["label"] == "test"
     assert default_signal_params["F0"] == 30.0
 
     # Merge dictionaries for custom configurations

--- a/tests/test_grid_based_searches.py
+++ b/tests/test_grid_based_searches.py
@@ -423,7 +423,7 @@ class TestSearchOverGridFile(BaseForTestsWithData):
             for F3 in self.F3s:
                 for F0 in np.arange(*self.F0s):
                     fp.write(
-                        f"{F0:.16g} {self.Writer.signal_parameters["Alpha"]:.16g} {self.Writer.signal_parameters["Delta"]:.16g} {self.Writer.signal_parameters["f1dot"]:.16g} {self.Writer.signal_parameters["f2dot"]:.16g}  {F3:.16g}"
+                        f"{F0:.16g} {self.Writer.signal_parameters['Alpha']:.16g} {self.Writer.signal_parameters['Delta']:.16g} {self.Writer.signal_parameters['f1dot']:.16g} {self.Writer.signal_parameters['f2dot']:.16g}  {F3:.16g}"
                     )
                     if binary:
                         for key in default_binary_params.keys():

--- a/tests/test_grid_based_searches.py
+++ b/tests/test_grid_based_searches.py
@@ -20,13 +20,17 @@ class TestGridSearch(BaseForTestsWithData):
 
     def _test_plots(self, search_keys):
         for key in search_keys:
-            self.search.plot_1D(xkey=key, x0=self.Writer.F0, savefig=True)
+            self.search.plot_1D(
+                xkey=key,
+                x0=self.Writer.signal_parameters["Freq"],
+                savefig=True,
+            )
         if len(search_keys) == 2:
             self.search.plot_2D(
                 xkey=search_keys[0],
                 ykey=search_keys[1],
-                x0=self.Writer.F0,
-                y0=self.Writer.F1,
+                x0=self.Writer.signal_parameters["Freq"],
+                y0=self.Writer.signal_parameters["f1dot"],
                 colorbar=True,
             )
         vals = [
@@ -54,11 +58,11 @@ class TestGridSearch(BaseForTestsWithData):
             self.outdir,
             self.Writer.sftfilepath,
             F0s=self.F0s,
-            F1s=[self.Writer.F1],
-            F2s=[self.Writer.F2],
-            Alphas=[self.Writer.Alpha],
-            Deltas=[self.Writer.Delta],
-            tref=self.tref,
+            F1s=[self.Writer.signal_parameters["f1dot"]],
+            F2s=[self.Writer.signal_parameters["f2dot"]],
+            Alphas=[self.Writer.signal_parameters["Alpha"]],
+            Deltas=[self.Writer.signal_parameters["Delta"]],
+            tref=self.Writer.signal_parameters["refTime"],
             BSGL=self.BSGL,
         )
         self.search.run()
@@ -75,10 +79,10 @@ class TestGridSearch(BaseForTestsWithData):
             self.Writer.sftfilepath,
             F0s=self.F0s,
             F1s=self.F1s,
-            F2s=[self.Writer.F2],
-            Alphas=[self.Writer.Alpha],
-            Deltas=[self.Writer.Delta],
-            tref=self.tref,
+            F2s=[self.Writer.signal_parameters["f2dot"]],
+            Alphas=[self.Writer.signal_parameters["Alpha"]],
+            Deltas=[self.Writer.signal_parameters["Delta"]],
+            tref=self.Writer.signal_parameters["refTime"],
             BSGL=self.BSGL,
         )
         self.search.run()
@@ -94,11 +98,11 @@ class TestGridSearch(BaseForTestsWithData):
             self.outdir,
             self.Writer.sftfilepath,
             F0s=self.F0s,
-            F1s=[self.Writer.F1],
-            F2s=[self.Writer.F2],
-            Alphas=[self.Writer.Alpha],
-            Deltas=[self.Writer.Delta],
-            tref=self.tref,
+            F1s=[self.Writer.signal_parameters["f1dot"]],
+            F2s=[self.Writer.signal_parameters["f2dot"]],
+            Alphas=[self.Writer.signal_parameters["Alpha"]],
+            Deltas=[self.Writer.signal_parameters["Delta"]],
+            tref=self.Writer.signal_parameters["refTime"],
         )
         self.search.run()
         self.assertTrue(os.path.isfile(self.search.out_file))
@@ -109,14 +113,23 @@ class TestGridSearch(BaseForTestsWithData):
         CFSv2_loudest_file = os.path.join(self.outdir, "CFSv2_Fstat_loudest.txt")
         cl_CFSv2 = []
         cl_CFSv2.append("lalpulsar_ComputeFstatistic_v2")
-        cl_CFSv2.append("--Alpha {} --AlphaBand 0".format(self.Alpha))
-        cl_CFSv2.append("--Delta {} --DeltaBand 0".format(self.Delta))
+        cl_CFSv2.append(
+            "--Alpha {} --AlphaBand 0".format(self.Writer.signal_parameters["Alpha"])
+        )
+        cl_CFSv2.append(
+            "--Delta {} --DeltaBand 0".format(self.Writer.signal_parameters["Delta"])
+        )
         cl_CFSv2.append("--Freq {}".format(self.F0s[0]))
         cl_CFSv2.append("--FreqBand {}".format(self.F0s[1] - self.F0s[0]))
         cl_CFSv2.append("--dFreq {}".format(self.F0s[2]))
-        cl_CFSv2.append("--f1dot {} --f1dotBand 0".format(self.F1))
+        cl_CFSv2.append(
+            "--f1dot {} --f1dotBand 0".format(self.Writer.signal_parameters["f1dot"])
+        )
+        cl_CFSv2.append(
+            "--f2dot {} --f2dotBand 0".format(self.Writer.signal_parameters["f2dot"])
+        )
         cl_CFSv2.append("--DataFiles '{}'".format(self.Writer.sftfilepath))
-        cl_CFSv2.append("--refTime {}".format(self.tref))
+        cl_CFSv2.append("--refTime {}".format(self.Writer.signal_parameters["refTime"]))
         cl_CFSv2.append("--outputFstat " + CFSv2_out_file)
         cl_CFSv2.append("--outputLoudest " + CFSv2_loudest_file)
         # to match ComputeFstat default (and hence PyFstat) defaults on older
@@ -131,7 +144,9 @@ class TestGridSearch(BaseForTestsWithData):
         )
         self.assertTrue(
             len(np.atleast_1d(CFSv2_out["2F"]))
-            == len(np.atleast_1d(pyfstat_out["twoF"]))
+            == len(np.atleast_1d(pyfstat_out["twoF"])),
+            f"Length of output arrays from CFSv2 ({len(np.atleast_1d(CFSv2_out['2F']))})"
+            f" and PyFstat ({len(np.atleast_1d(pyfstat_out['twoF']))}) differ.",
         )
         self.assertTrue(np.max(np.abs(CFSv2_out["freq"] - pyfstat_out["F0"]) < 1e-16))
         self.assertTrue(np.max(np.abs(CFSv2_out["2F"] - pyfstat_out["twoF"]) < 1))
@@ -162,11 +177,11 @@ class TestGridSearch(BaseForTestsWithData):
             self.outdir,
             self.Writer.sftfilepath,
             F0s=self.F0s,
-            F1s=[self.Writer.F1],
-            F2s=[self.Writer.F2],
-            Alphas=[self.Writer.Alpha],
-            Deltas=[self.Writer.Delta],
-            tref=self.tref,
+            F1s=[self.Writer.signal_parameters["f1dot"]],
+            F2s=[self.Writer.signal_parameters["f2dot"]],
+            Alphas=[self.Writer.signal_parameters["Alpha"]],
+            Deltas=[self.Writer.signal_parameters["Delta"]],
+            tref=self.Writer.signal_parameters["refTime"],
             nsegs=2,
             BSGL=self.BSGL,
         )
@@ -182,11 +197,11 @@ class TestGridSearch(BaseForTestsWithData):
             self.Writer.sftfilepath,
             F0s=self.F0s,
             F1s=self.F1s,
-            F2s=[self.Writer.F2],
-            Alphas=[self.Writer.Alpha],
-            Deltas=[self.Writer.Delta],
-            tref=self.tref,
-            tglitchs=[self.tref],
+            F2s=[self.Writer.signal_parameters["f2dot"]],
+            Alphas=[self.Writer.signal_parameters["Alpha"]],
+            Deltas=[self.Writer.signal_parameters["Delta"]],
+            tref=self.Writer.signal_parameters["refTime"],
+            tglitchs=[self.Writer.signal_parameters["refTime"]],
             # BSGL=self.BSGL,  # not supported by this class
         )
         self.search.run()
@@ -207,17 +222,23 @@ class TestGridSearchBSGL(TestGridSearch):
         # just restricted to the single detector.
         SFTs_H1 = self.Writer.sftfilepath.split(";")[0]
         SFTs_L1 = self.Writer.sftfilepath.split(";")[1]
+        linefreq = self.Writer.signal_parameters["Freq"] + 0.005
+        F0s_wider = [
+            29.99,
+            30.01,
+            1e-3,
+        ]  # need coarse grid spacing to separate line from signal injection
         extra_writer = pyfstat.Writer(
             label=self.label + "WithLine",
             outdir=self.outdir,
-            tref=self.tref,
-            F0=self.Writer.F0 + 0.0005,
-            F1=self.Writer.F1,
-            F2=self.Writer.F2,
-            Alpha=self.Writer.Alpha,
-            Delta=self.Writer.Delta,
-            h0=10 * self.Writer.h0,
-            cosi=self.Writer.cosi,
+            tref=self.Writer.signal_parameters["refTime"],
+            F0=linefreq,
+            F1=self.Writer.signal_parameters["f1dot"],
+            F2=self.Writer.signal_parameters["f2dot"],
+            Alpha=self.Writer.signal_parameters["Alpha"],
+            Delta=self.Writer.signal_parameters["Delta"],
+            h0=10 * self.Writer.signal_parameters["h0"],
+            cosi=self.Writer.signal_parameters["cosi"],
             sqrtSX=0,  # don't add yet another set of Gaussian noise
             noiseSFTs=SFTs_H1,
             SFTWindowType=self.Writer.SFTWindowType,
@@ -230,12 +251,12 @@ class TestGridSearchBSGL(TestGridSearch):
             label="GridSearch",
             outdir=self.outdir,
             sftfilepattern=data_with_line,
-            F0s=self.F0s,
-            F1s=[self.Writer.F1],
-            F2s=[self.Writer.F2],
-            Alphas=[self.Writer.Alpha],
-            Deltas=[self.Writer.Delta],
-            tref=self.tref,
+            F0s=F0s_wider,
+            F1s=[self.Writer.signal_parameters["f1dot"]],
+            F2s=[self.Writer.signal_parameters["f2dot"]],
+            Alphas=[self.Writer.signal_parameters["Alpha"]],
+            Deltas=[self.Writer.signal_parameters["Delta"]],
+            tref=self.Writer.signal_parameters["refTime"],
             singleFstats=True,
             BSGL=False,
         )
@@ -248,12 +269,12 @@ class TestGridSearchBSGL(TestGridSearch):
             label="GridSearch",
             outdir=self.outdir,
             sftfilepattern=data_with_line,
-            F0s=self.F0s,
-            F1s=[self.Writer.F1],
-            F2s=[self.Writer.F2],
-            Alphas=[self.Writer.Alpha],
-            Deltas=[self.Writer.Delta],
-            tref=self.tref,
+            F0s=F0s_wider,
+            F1s=[self.Writer.signal_parameters["f1dot"]],
+            F2s=[self.Writer.signal_parameters["f2dot"]],
+            Alphas=[self.Writer.signal_parameters["Alpha"]],
+            Deltas=[self.Writer.signal_parameters["Delta"]],
+            tref=self.Writer.signal_parameters["refTime"],
             BSGL=True,
         )
         searchBSGL.run()
@@ -276,9 +297,9 @@ class TestGridSearchBSGL(TestGridSearch):
             msg=f"The BSGL search should produce a lower max2F value than the F search, but {maxBSGL_point['twoF']} >= {max2F_point_searchF['twoF']}",
         )
         self.assertTrue(
-            np.abs(maxBSGL_point["F0"] - self.F0)
-            < np.abs(max2F_point_searchF["F0"] - self.F0),
-            msg="The maxBSGL point should be the true multi-IFO signal, while max2F should have fallen for the single-IFO line. But the former is further away from the injection frequency.",
+            np.abs(maxBSGL_point["F0"] - self.Writer.signal_parameters["Freq"])
+            < np.abs(max2F_point_searchF["F0"] - self.Writer.signal_parameters["Freq"]),
+            msg=f"The maxBSGL point ({maxBSGL_point['F0']}) should be the true multi-IFO signal ({self.Writer.signal_parameters['Freq']}), while max2F  ({max2F_point_searchF['F0']}) should have fallen for the single-IFO line ({linefreq}).",
         )
         self.assertTrue(
             maxBSGL_point["twoFH1"] < max2F_point_searchF["twoFH1"],
@@ -316,11 +337,11 @@ class TestTransientGridSearch(BaseForTestsWithData):
             self.outdir,
             self.Writer.sftfilepath,
             F0s=self.F0s,
-            F1s=[self.Writer.F1],
-            F2s=[self.Writer.F2],
-            Alphas=[self.Writer.Alpha],
-            Deltas=[self.Writer.Delta],
-            tref=self.tref,
+            F1s=[self.Writer.signal_parameters["f1dot"]],
+            F2s=[self.Writer.signal_parameters["f2dot"]],
+            Alphas=[self.Writer.signal_parameters["Alpha"]],
+            Deltas=[self.Writer.signal_parameters["Delta"]],
+            tref=self.Writer.signal_parameters["refTime"],
             singleFstats=singleFstats,
             BSGL=BSGL,
             BtSG=BtSG,
@@ -402,7 +423,7 @@ class TestSearchOverGridFile(BaseForTestsWithData):
             for F3 in self.F3s:
                 for F0 in np.arange(*self.F0s):
                     fp.write(
-                        f"{F0:.16g} {self.Writer.Alpha:.16g} {self.Writer.Delta:.16g} {self.Writer.F1:.16g} {self.Writer.F2:.16g}  {F3:.16g}"
+                        f"{F0:.16g} {self.Writer.signal_parameters["Alpha"]:.16g} {self.Writer.signal_parameters["Delta"]:.16g} {self.Writer.signal_parameters["f1dot"]:.16g} {self.Writer.signal_parameters["f2dot"]:.16g}  {F3:.16g}"
                     )
                     if binary:
                         for key in default_binary_params.keys():
@@ -417,17 +438,17 @@ class TestSearchOverGridFile(BaseForTestsWithData):
         cl_CFSv2.append("lalpulsar_ComputeFstatistic_v2")
         cl_CFSv2.append(f"--Freq {self.F0s[0]:.16g}")
         cl_CFSv2.append(f"--FreqBand {(self.F0s[1] - self.F0s[0]):.16g}")
-        cl_CFSv2.append(f"--Alpha {self.Writer.Alpha:.16g}")
-        cl_CFSv2.append(f"--Delta {self.Writer.Delta:.16g}")
-        cl_CFSv2.append(f"--f1dot {self.Writer.F1:.16g}")
+        cl_CFSv2.append(f"--Alpha {self.Writer.signal_parameters['Alpha']:.16g}")
+        cl_CFSv2.append(f"--Delta {self.Writer.signal_parameters['Delta']:.16g}")
+        cl_CFSv2.append(f"--f1dot {self.Writer.signal_parameters['f1dot']:.16g}")
         cl_CFSv2.append(f"--f1dotBand {3e-7:.16g}")
-        cl_CFSv2.append(f"--f2dot {self.Writer.F2:.16g}")
+        cl_CFSv2.append(f"--f2dot {self.Writer.signal_parameters['f2dot']:.16g}")
         cl_CFSv2.append(f"--f2dotBand {3e-11:.16g}")
         cl_CFSv2.append(f"--f3dot {self.F3s[0]:.16g}")
         cl_CFSv2.append(f"--f3dotBand {3e-15:.16g}")
         cl_CFSv2.append("--gridType 8")
         cl_CFSv2.append("--DataFiles '{}'".format(self.Writer.sftfilepath))
-        cl_CFSv2.append("--refTime {}".format(self.tref))
+        cl_CFSv2.append("--refTime {}".format(self.Writer.signal_parameters["refTime"]))
         cl_CFSv2.append(f"--metricMismatch {0.02:.16g}")
         cl_CFSv2.append("--countTemplates TRUE")
         cl_CFSv2.append("--strictSpindownBounds TRUE")
@@ -467,7 +488,7 @@ class TestSearchOverGridFile(BaseForTestsWithData):
             outdir=self.outdir,
             sftfilepattern=self.Writer.sftfilepath,
             gridfile=self.gridfile,
-            tref=self.tref,
+            tref=self.Writer.signal_parameters["refTime"],
             reading_method=reading_method,
             BtSG=BtSG,
             **transient_search_params,
@@ -490,10 +511,10 @@ class TestSearchOverGridFile(BaseForTestsWithData):
             cl_CFSv2.append(f"--Freq {self.F0s[0]:.16g}")
             cl_CFSv2.append(f"--FreqBand {self.F0s[1] - self.F0s[0]:.16g}")
             cl_CFSv2.append(f"--dFreq {self.F0s[2]:.16g}")
-            cl_CFSv2.append(f"--Alpha {self.Writer.Alpha:.16g}")
-            cl_CFSv2.append(f"--Delta {self.Writer.Delta:.16g}")
-            cl_CFSv2.append(f"--f1dot {self.Writer.F1:.16g}")
-            cl_CFSv2.append(f"--f2dot {self.Writer.F2:.16g}")
+            cl_CFSv2.append(f"--Alpha {self.Writer.signal_parameters['Alpha']:.16g}")
+            cl_CFSv2.append(f"--Delta {self.Writer.signal_parameters['Delta']:.16g}")
+            cl_CFSv2.append(f"--f1dot {self.Writer.signal_parameters['f1dot']:.16g}")
+            cl_CFSv2.append(f"--f2dot {self.Writer.signal_parameters['f2dot']:.16g}")
             cl_CFSv2.append(f"--f3dot {self.F3s[0]:.16g}")
             cl_CFSv2.append(f"--f3dotBand {(self.F3s[1] - self.F3s[0]):.16g}")
             cl_CFSv2.append(f"--df3dot {(self.F3s[1] - self.F3s[0]):.16g}")
@@ -518,7 +539,7 @@ class TestSearchOverGridFile(BaseForTestsWithData):
             CFSv2_out_file_transient = CFSv2_out_file.replace(".txt", "_transient.txt")
             cl_CFSv2.append(f"--outputTransientStats {CFSv2_out_file_transient}")
         cl_CFSv2.append("--DataFiles '{}'".format(self.Writer.sftfilepath))
-        cl_CFSv2.append("--refTime {}".format(self.tref))
+        cl_CFSv2.append("--refTime {}".format(self.Writer.signal_parameters["refTime"]))
         cl_CFSv2.append("--outputFstat " + CFSv2_out_file)
         cl_CFSv2.append("--outputLoudest " + CFSv2_loudest_file)
         # to match ComputeFstat default (and hence PyFstat) defaults on older

--- a/tests/test_make_sfts.py
+++ b/tests/test_make_sfts.py
@@ -110,6 +110,63 @@ class TestWriter:
         self.Writer.make_cff(verbose=True)
         assert os.path.isfile(os.path.join(".", self.outdir, self.label + ".cff"))
 
+    def test_make_cff_new_style_separate_F0(self):
+        if self.style == "old":
+            pytest.skip()
+        signal_params = default_signal_params.copy()
+        signal_params.pop("F0")
+        test_Writer = pyfstat.Writer(
+            label=self.label + "NoF0",
+            tstart=self.Writer.tstart,
+            duration=self.Writer.duration,
+            signal_parameters=signal_params,
+            F0=default_signal_params["F0"],
+            Tsft=self.Writer.Tsft,
+            outdir=self.outdir,
+            sqrtSX=self.Writer.sqrtSX,
+            Band=self.Writer.Band,
+            detectors=self.Writer.detectors,
+            SFTWindowType=self.Writer.SFTWindowType,
+            SFTWindowParam=self.Writer.SFTWindowParam,
+            randSeed=self.Writer.randSeed,
+        )
+        test_Writer.make_cff(verbose=True)
+        assert os.path.isfile(
+            os.path.join(".", test_Writer.outdir, test_Writer.label + ".cff")
+        )
+
+    def test_make_cff_old_style_without_tref(self):
+        if self.style == "new":
+            pytest.skip()
+        test_Writer = pyfstat.Writer(
+            label=self.label + "NoTref",
+            tstart=self.Writer.tstart,
+            duration=self.Writer.duration,
+            tref=None,
+            F0=default_signal_params["F0"],
+            F1=default_signal_params["F1"],
+            F2=default_signal_params["F2"],
+            Alpha=default_signal_params["Alpha"],
+            Delta=default_signal_params["Delta"],
+            h0=default_signal_params["h0"],
+            cosi=default_signal_params["cosi"],
+            psi=default_signal_params["psi"],
+            phi=default_signal_params["phi"],
+            signal_parameters=None,
+            Tsft=self.Writer.Tsft,
+            outdir=self.outdir,
+            sqrtSX=self.Writer.sqrtSX,
+            Band=self.Writer.Band,
+            detectors=self.Writer.detectors,
+            SFTWindowType=self.Writer.SFTWindowType,
+            SFTWindowParam=self.Writer.SFTWindowParam,
+            randSeed=self.Writer.randSeed,
+        )
+        test_Writer.make_cff(verbose=True)
+        assert os.path.isfile(
+            os.path.join(".", test_Writer.outdir, test_Writer.label + ".cff")
+        )
+
     def test_run_makefakedata(self):
         self.Writer.make_data(verbose=True)
         numSFTs = int(np.ceil(self.Writer.duration / self.Writer.Tsft))
@@ -724,7 +781,7 @@ class TestLineWriter(TestWriter):
             )
             max_power_freq_index_with_line = max_power_freq_index[line_active_mask]
 
-            # Maximum power should be a the transient line whenever that's on
+            # Maximum power should be at the transient line whenever that's on
             assert np.all(
                 max_power_freq_index_with_line == max_power_freq_index_with_line[0]
             )

--- a/tests/test_make_sfts.py
+++ b/tests/test_make_sfts.py
@@ -330,8 +330,8 @@ class TestWriter:
             max_freqs_noise_and_signal = noise_and_signal_freqs[
                 np.argmax(ns_data, axis=0)
             ]
-            assert len(
-                times[ifo] == int(np.ceil(self.Writer.duration / self.Writer.Tsft))
+            assert len(times[ifo]) == int(
+                np.ceil(self.Writer.duration / self.Writer.Tsft)
             )
             # FIXME: CW signals don't have to peak at the same frequency, but there
             # are some consistency criteria which may be useful to implement here.

--- a/tests/test_mcmc_based_searches.py
+++ b/tests/test_mcmc_based_searches.py
@@ -43,8 +43,8 @@ class BaseForMCMCSearchTests(BaseForTestsWithData):
             inj = {k: getattr(self.Writer, k) for k in self.max_dict}
         else:
             inj = {
-                "transient_tstart": self.Writer.transientStartTime,
-                "transient_duration": self.Writer.transientTau,
+                "transient_tstart": self.Writer.signal_parameters["transientStartTime"],
+                "transient_duration": self.Writer.signal_parameters["transientTau"],
             }
 
         for k in self.max_dict.keys():
@@ -218,10 +218,10 @@ class TestMCMCSearchBSGL(TestMCMCSearch):
             F0=self.Writer.F0 + 0.5e-2,
             F1=0,
             F2=0,
-            Alpha=self.Writer.Alpha,
-            Delta=self.Writer.Delta,
-            h0=10 * self.Writer.h0,
-            cosi=self.Writer.cosi,
+            Alpha=self.Writer.signal_parameters["Alpha"],
+            Delta=self.Writer.signal_parameters["Delta"],
+            h0=10 * self.Writer.signal_parameters["h0"],
+            cosi=self.Writer.signal_parameters["cosi"],
             sqrtSX=0,  # don't add yet another set of Gaussian noise
             noiseSFTs=SFTs_H1,
             SFTWindowType=self.Writer.SFTWindowType,
@@ -412,8 +412,11 @@ class TestMCMCTransientSearch(BaseForMCMCSearchTests):
             label=self.label,
             tstart=self.tstart,
             duration=self.duration,
-            tref=self.tref,
-            **default_signal_params,
+            **{
+                k: v
+                for k, v in default_signal_params.items()
+                if not (k.startswith("F") and int(k[-1]) > 2)
+            },
             outdir=self.outdir,
             sqrtSX=self.sqrtSX,
             Band=self.Band,


### PR DESCRIPTION
This continues what we already did for `core`.

* Writer and subclasses:
  * now support both an "old" mode (individual named signal parameter arguments) and a "new" mode (`signal_parameters` input dictionary).
  * The "old" one throws a deprecation warning, but should still work (and is still getting tested).
  * The "new" one supports spindowns up to 6th order, same as MFDv5.
  * In the new mode, "tref" needs to be included in the dictionary as well.
  * As a side bonus, `BinaryModulatedWriter` is no longer necessary, since one can just pass binary arguments to the main `Writer`. Same deprecation status.
* The MCMC classes maintain the same user interface as before, as priors were already set through a dict.
  * Spindowns up to `lalpulsar.PULSAR_MAX_DETECTORS` are supported, same as in core.
* Examples `PyFstat_example_spectrogram.py` and `PyFstat_example_fully_coherent_MCMC_search` have been updated to the new style, others not yet.