### PR TITLE
Solve overflow problem in plot_spectrogram.

### DIFF
--- a/pyfstat/utils/sft.py
+++ b/pyfstat/utils/sft.py
@@ -362,7 +362,9 @@ def plot_spectrogram(
                 raise ValueError(
                     "Value of sqrtSX needed to compute the normalized power."
                 )
-            q *= 2 / (Tsft * sqrtSX**2)
+            q *= (
+                2 / (Tsft * sqrtSX) / sqrtSX
+            )  # we divide in two steps to avoid overflows
             label = "Normalized power"
         else:
             label = "Power"


### PR DESCRIPTION
Spectogram example was giving this warning:
```
/home/maferrerma/miniforge3/envs/pyfstat/lib/python3.13/site-packages/pyfstat/utils/sft.py:365: RuntimeWarning: overflow encountered in cast
  q *= 2 / (Tsft * sqrtSX**2)
/home/maferrerma/miniforge3/envs/pyfstat/lib/python3.13/site-packages/pyfstat/utils/sft.py:365: RuntimeWarning: invalid value encountered in multiply
  q *= 2 / (Tsft * sqrtSX**2)
```
and giving a blank spectogram in some environments.