### PR TITLE
drop python 3.9 support

### DIFF
--- a/.github/workflows/check_notebooks.yml
+++ b/.github/workflows/check_notebooks.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test_lalsuite_dev.yml
+++ b/.github/workflows/test_lalsuite_dev.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Latest development versions can
 or [from a local git clone](#install-pyfstat-from-source-zenodo-or-git-clone).
 
 If you don't have a matching `python` installation
-(currently `3.9` to `3.13`)
+(currently `3.10` to `3.13`)
 on your system,
 then `Docker` or `conda` are the easiest paths.
 
@@ -250,7 +250,7 @@ Here's what you need to know:
 
   This sets up everything for automated code quality tests (see below)
   to be checked for you at every commit.
-* The github automated tests currently run on `python` [3.9,3.10,3.11,3.12]
+* The github automated tests currently run on `python` [3.10,3.11,3.12,3.13]
   and new PRs need to pass all these.
 * You can also run the full test suite locally via `pytest tests/`,
   or run individual tests as explained

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 import versioneer
 
 # check python version
-min_python_version = (3, 9, 0)  # (major,minor,micro)
+min_python_version = (3, 10, 0)  # (major,minor,micro)
 next_unsupported_python_version = (3, 14)  # (major,minor) - don't restrict micro
 python_version = sys.version_info
 if (


### PR DESCRIPTION
It was end-of-lifed in late 2025: https://devguide.python.org/versions/