### PR TITLE
add error check on inverted uniform prior bounds

### DIFF
--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -1215,6 +1215,11 @@ class MCMCSearch(BaseSearchClass):
             norm_trunc_warning = "norm" in prior_dict["type"] or norm_trunc_warning
 
             if prior_dict["type"] == "unif":
+                if prior_dict["lower"] > prior_dict["upper"]:  # pragma: no cover
+                    raise ValueError(
+                        f"Uniform prior bounds on {key} are the wrong way around:"
+                        f" lower bound {prior_dict['lower']} is above upper bound {prior_dict['upper']}."
+                    )
                 prior_bounds[key]["lower"] = prior_dict["lower"]
                 prior_bounds[key]["upper"] = prior_dict["upper"]
             elif prior_dict["type"] == "log10unif":


### PR DESCRIPTION
 - avoids obscure "initial samples outside posterior support" message from ptemcee
 - fixes https://github.com/PyFstat/PyFstat/issues/594

This now throws something like:
```
ValueError: Uniform prior bounds on F1 are the wrong way around: lower bound 0.0 is above upper bound -2e-10.
```