### PR TITLE
add singleFstats flag to MCMCSearch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v6.0.0
     hooks:
         - id: check-added-large-files
         - id: check-case-conflict
@@ -13,31 +13,31 @@ repos:
         - id: end-of-file-fixer
         - id: trailing-whitespace
   - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 8.0.0
     hooks:
       - id: isort
         args: ["--profile", "black", "--filter-files"]
         name: isort (python)
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.4.2
+    rev: 26.1.0
     hooks:
       - id: black
       - id: black-jupyter
   - repo: https://github.com/pycqa/flake8
-    rev: 7.1.0
+    rev: 7.3.0
     hooks:
     - id: flake8
       additional_dependencies: [
           'flake8-docstrings==1.7.0',
           'flake8-executable==2.1.3',
-          'flake8-import-order==0.18.2',
+          'flake8-import-order==0.19.2',
       ]
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.4
+    rev: v2.4.1
     hooks:
     - id: codespell
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.7.1
+    rev: 0.9.1
     hooks:
       - id: nbstripout
         args: ["--extra-keys", '"metadata.language_info.pygments_lexer metadata.language_info.version"']

--- a/examples/mcmc_examples/PyFstat_example_fully_coherent_MCMC_search_with_BSGL.py
+++ b/examples/mcmc_examples/PyFstat_example_fully_coherent_MCMC_search_with_BSGL.py
@@ -121,6 +121,7 @@ mcmc_F = pyfstat.MCMCSearch(
     ntemps=ntemps,
     log10beta_min=log10beta_min,
     BSGL=False,
+    singleFstats=True,
 )
 mcmc_F.transform_dictionary = transform_dict
 mcmc_F.run(

--- a/pyfstat/core.py
+++ b/pyfstat/core.py
@@ -2026,7 +2026,7 @@ class SemiCoherentSearch(ComputeFstat):
         covering `[self.minStartTime,self.maxStartTime]`
         and `self.Tcoh` will be the total duration divided by `self.nsegs`.
 
-        Each segment is required to be at least two SFTs long.f
+        Each segment is required to be at least two SFTs long.
         """
         logger.info(
             (
@@ -2043,7 +2043,9 @@ class SemiCoherentSearch(ComputeFstat):
                 self.nsegs, self.Tcoh, self.Tcoh / 86400.0
             )
         )
-        logger.debug("Segment boundaries: {}".format(self.tboundaries))
+        logger.debug(
+            f"Segment boundaries: {', '.join(f'{tb:.2f}' for tb in self.tboundaries)}"
+        )
         if self.Tcoh < 2 * self.Tsft:
             raise RuntimeError(
                 "Per-segment coherent time {} may not be < Tsft={}"
@@ -2239,12 +2241,61 @@ class SemiCoherentSearch(ComputeFstat):
             singleIFOmultiFatoms = utils.extract_singleIFOmultiFatoms_from_multiAtoms(
                 self.FstatResults.multiFatoms[0], X
             )
-            FXstatMap = lalpulsar.ComputeTransientFstatMap(
-                multiFstatAtoms=singleIFOmultiFatoms,
-                windowRange=self.semicoherentWindowRange,
-                useFReg=False,
+            singleIFOtimestamps = [
+                singleIFOmultiFatoms.data[0].data[k].timestamp
+                for k in range(singleIFOmultiFatoms.data[0].length)
+            ]
+            logger.debug(
+                f"X={X} single-IFO timestamps: [{singleIFOtimestamps[0]},{singleIFOtimestamps[-1]}]"
             )
-            twoFX_per_segment = 2 * FXstatMap.F_mn.data[:, 0]
+            if self.semicoherentWindowRange.t0 < singleIFOtimestamps[0]:
+                # Workaround for issue still to be fixed in lalpulsar.ComputeTransientFstatMap()
+                # with a window start time before the first SFT.
+                # This only fixes issues in the first segment,
+                # not if there are multiple segments starting before one of the detectors turns on.
+                twoFX_per_segment = np.zeros(self.nsegs)
+                singleIFOsemicoherentWindowRange = lalpulsar.transientWindowRange_t()
+                for key in ["type", "dt0", "tauBand", "dtau"]:
+                    setattr(
+                        singleIFOsemicoherentWindowRange,
+                        key,
+                        getattr(self.semicoherentWindowRange, key),
+                    )
+                # For the first segment, shift the start time and shorten the duration,
+                # keeping the original end time.
+                singleIFOsemicoherentWindowRange.t0 = singleIFOtimestamps[0]
+                singleIFOsemicoherentWindowRange.t0Band = 0
+                singleIFOsemicoherentWindowRange.tau -= (
+                    self.semicoherentWindowRange.t0 - singleIFOtimestamps[0]
+                )
+                FXstatMap = lalpulsar.ComputeTransientFstatMap(
+                    multiFstatAtoms=singleIFOmultiFatoms,
+                    windowRange=singleIFOsemicoherentWindowRange,
+                    useFReg=False,
+                )
+                twoFX_per_segment[0] = 2 * FXstatMap.F_mn.data[0, 0]
+                if self.nsegs > 1:
+                    # for all later segments, use the original start/end times
+                    singleIFOsemicoherentWindowRange.t0 = int(self.tboundaries[1])
+                    singleIFOsemicoherentWindowRange.t0Band = int(
+                        self.tboundaries[-1] - self.tboundaries[1] - self.Tcoh
+                    )
+                    singleIFOsemicoherentWindowRange.tau = (
+                        self.semicoherentWindowRange.tau
+                    )
+                    FXstatMap = lalpulsar.ComputeTransientFstatMap(
+                        multiFstatAtoms=singleIFOmultiFatoms,
+                        windowRange=singleIFOsemicoherentWindowRange,
+                        useFReg=False,
+                    )
+                    twoFX_per_segment[1:] = 2 * FXstatMap.F_mn.data[:, 0]
+            else:
+                FXstatMap = lalpulsar.ComputeTransientFstatMap(
+                    multiFstatAtoms=singleIFOmultiFatoms,
+                    windowRange=self.semicoherentWindowRange,
+                    useFReg=False,
+                )
+                twoFX_per_segment = 2 * FXstatMap.F_mn.data[:, 0]
             self.twoFX[X] = twoFX_per_segment.sum()
             if np.isnan(self.twoFX[X]):
                 logger.debug(

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -343,6 +343,14 @@ class MCMCSearch(BaseSearchClass):
             self.minStartTime = self.search.minStartTime
         if self.maxStartTime is None:
             self.maxStartTime = self.search.maxStartTime
+        if not self.BSGL:
+            # We turn this off unless needed for BSGL,
+            # because the main sampler run will not return any extra stats anyway,
+            # and we will just recompute these in post-processing.
+            # (see add_samples_to_detstats()).
+            # But we do this only after initiating the self.search object,
+            # so that whatToCompute is set up correctly.
+            self.search.singleFstats = False
 
     def _logp(self, theta_vals, theta_prior, theta_keys, search):
         H = [
@@ -1921,6 +1929,9 @@ class MCMCSearch(BaseSearchClass):
         samples_out = copy.copy(self.samples)
         detstat = np.atleast_2d(self._get_detstat_from_loglikelihood()).T
         if self.singleFstats or self.BSGL:
+            # first ensure that the singleFstats attribute of the search object is in fact set,
+            # since to speed up the main sampling stage we might have skipped it there (in the non-BSGL case).
+            self.search.singleFstats = True
             twoF = np.zeros_like(detstat)
             if self.BSGL:
                 self.search.BSGL = (
@@ -2604,6 +2615,14 @@ class MCMCGlitchSearch(MCMCSearch):
             sun_ephem=self.sun_ephem,
             allowedMismatchFromSFTLength=self.allowedMismatchFromSFTLength,
         )
+        if not self.BSGL:
+            # We turn this off unless needed for BSGL,
+            # because the main sampler run will not return any extra stats anyway,
+            # and we will just recompute these in post-processing.
+            # (see add_samples_to_detstats()).
+            # But we do this only after initiating the self.search object,
+            # so that whatToCompute is set up correctly.
+            self.search.singleFstats = False
         if self.minStartTime is None:
             self.minStartTime = self.search.minStartTime
         if self.maxStartTime is None:
@@ -2964,6 +2983,14 @@ class MCMCSemiCoherentSearch(MCMCSearch):
             sun_ephem=self.sun_ephem,
             allowedMismatchFromSFTLength=self.allowedMismatchFromSFTLength,
         )
+        if not self.BSGL:
+            # We turn this off unless needed for BSGL,
+            # because the main sampler run will not return any extra stats anyway,
+            # and we will just recompute these in post-processing.
+            # (see add_samples_to_detstats()).
+            # But we do this only after initiating the self.search object,
+            # so that whatToCompute is set up correctly.
+            self.search.singleFstats = False
         if self.minStartTime is None:
             self.minStartTime = self.search.minStartTime
         if self.maxStartTime is None:

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -103,6 +103,7 @@ class MCMCSearch(BaseSearchClass):
         theta_initial=None,
         rhohatmax=1000,
         binary=False,
+        singleFstats=False,
         BSGL=False,
         BtSG=False,
         SSBprec=None,
@@ -159,6 +160,10 @@ class MCMCSearch(BaseSearchClass):
             evidence.
         binary: bool, optional
             If true, search over binary orbital parameters.
+        singleFstats: bool
+            If true, also include the single-detector twoF values in the final samples export.
+            Note these values are only added in post-processing,
+            not during the sampler run.
         BSGL: bool, optional
             If true, use the BSGL statistic.
         BtSG: bool, optional
@@ -209,6 +214,7 @@ class MCMCSearch(BaseSearchClass):
         self.theta_initial = theta_initial
         self.rhohatmax = rhohatmax
         self.binary = binary
+        self.singleFstats = singleFstats
         self.BSGL = BSGL
         self.BtSG = BtSG
         self.SSBprec = SSBprec
@@ -319,6 +325,7 @@ class MCMCSearch(BaseSearchClass):
             search_ranges=search_ranges,
             detectors=self.detectors,
             BSGL=self.BSGL,
+            singleFstats=self.singleFstats,
             transientWindowType=self.transientWindowType,
             minStartTime=self.minStartTime,
             maxStartTime=self.maxStartTime,
@@ -411,11 +418,6 @@ class MCMCSearch(BaseSearchClass):
         self.theta_idxs = [self.theta_idxs[i] for i in idxs]
         self.theta_symbols = [self.theta_symbols[i] for i in idxs]
         self.theta_keys = [self.theta_keys[i] for i in idxs]
-
-        self.output_keys = self.theta_keys.copy()
-        self.output_keys.append("twoF")
-        if self.BSGL:
-            self.output_keys.append("log10BSGL")
 
     def _evaluate_logpost(self, p0vec):
         init_logp = np.array(
@@ -1869,11 +1871,23 @@ class MCMCSearch(BaseSearchClass):
                     logger.info(key)
             return False
 
+    def _get_output_keys(self):
+        self.output_keys = self.theta_keys.copy()
+        self.output_keys.append("twoF")
+        if self.singleFstats or self.BSGL:
+            self.output_keys += [f"twoF{IFO}" for IFO in self.search.detector_names]
+        if self.BSGL:
+            self.output_keys.append("log10BSGL")
+
     def _get_savetxt_fmt_dict(self):
         fmt_dict = utils.get_doppler_params_output_format(
             self.theta_keys, self.fmt_doppler
         )
         fmt_dict["twoF"] = self.fmt_detstat
+        if self.singleFstats or self.BSGL:
+            fmt_dict.update(
+                {f"twoF{IFO}": self.fmt_detstat for IFO in self.search.detector_names}
+            )
         if self.BSGL:
             fmt_dict["log10BSGL"] = self.fmt_detstat
         return fmt_dict
@@ -1888,33 +1902,85 @@ class MCMCSearch(BaseSearchClass):
         fmt_list = [fmt_dict[key] for key in self.output_keys]
         return fmt_list
 
-    def export_samples_to_disk(self):
+    def add_samples_to_detstats(self):
         """
-        Export MCMC samples into a text file using `numpy.savetxt`.
+        Add detection statistics to the sampled parameter-space points.
+
+        This includes 2F
+        and additional detection statistics (BSGL, single-detector 2F)
+        if requested,
+        and also stores the samples augmented with these values
+        to self.samples_with_detstats
+
+        For convenience, we always save a twoF column,
+        even if log10BSGL was used for the likelihood.
+        If requested, BSGL and/or single-IFO F-stats are added.
+        The actual detstat used (twoF or BSGL) always goes last.
         """
-        self.samples_file = os.path.join(self.outdir, self.label + "_samples.dat")
-        logger.info("Exporting samples to {}".format(self.samples_file))
-        header = "\n".join(self.output_file_header)
-        header += "\n" + " ".join(self.output_keys)
-        outfmt = self._get_savetxt_fmt_list()
+
         samples_out = copy.copy(self.samples)
-        # For convenience, we always save a twoF column,
-        # even if log10BSGL was used for the likelihood.
         detstat = np.atleast_2d(self._get_detstat_from_loglikelihood()).T
-        if self.BSGL:
+        if self.singleFstats or self.BSGL:
             twoF = np.zeros_like(detstat)
-            self.search.BSGL = False
-            for idx, samp in enumerate(self.samples):
+            if self.BSGL:
+                self.search.BSGL = (
+                    False  # temporarily disable this to get the actual Fstat back
+                )
+            twoFX = np.zeros((len(self.samples), self.search.FstatResults.numDetectors))
+            for idx, samp in enumerate(
+                tqdm(
+                    self.samples,
+                    desc=f"Recomputing full detection statistics for {len(self.samples)} final samples",
+                )
+            ):
                 p = self._set_point_for_evaluation(samp)
                 if isinstance(p, dict):
                     twoF[idx] = self.search.get_det_stat(**p)
                 else:
                     twoF[idx] = self.search.get_det_stat(*p)
-            self.search.BSGL = self.BSGL
-            samples_out = np.concatenate((samples_out, twoF), axis=1)
-        # TODO: add single-IFO F-stats?
-        samples_out = np.concatenate((samples_out, detstat), axis=1)
-        Ncols = np.shape(samples_out)[1]
+                if self.singleFstats or self.BSGL:
+                    twoFX[idx, :] = self.search.twoFX[
+                        : self.search.FstatResults.numDetectors
+                    ]
+            if self.BSGL:
+                samples_out = np.concatenate((samples_out, twoF), axis=1)
+                self.search.BSGL = self.BSGL  # reset to original value
+            samples_out = np.concatenate((samples_out, twoFX), axis=1)
+        self.samples_with_detstats = np.concatenate((samples_out, detstat), axis=1)
+
+        # update dtype
+        new_dtype = np.dtype(
+            [(key, self.samples_with_detstats.dtype) for key in self.output_keys]
+        )
+        # In converting the array,
+        # we use .view() to change how the memory is interpreted without copying data,
+        # then .reshape(-1) to flatten the extra dimension that view() might preserve.
+        # Note this produces a structured array with shape (nsamples,),
+        # not (nsamples,nkeys)!
+        self.samples_with_detstats = self.samples_with_detstats.view(new_dtype).reshape(
+            -1
+        )
+
+        return self.samples_with_detstats
+
+    def export_samples_to_disk(self):
+        """
+        Export MCMC samples into a text file using `numpy.savetxt`.
+
+        This includes both the parameter-space point values
+        and the detection statistics calculated for them.
+        """
+        self._get_output_keys()
+        if self.samples.dtype.names is None or np.any(
+            [key not in self.samples.dtype.names for key in self.output_keys]
+        ):
+            self.add_samples_to_detstats()
+        self.samples_file = os.path.join(self.outdir, self.label + "_samples.dat")
+        logger.info("Exporting samples to {}".format(self.samples_file))
+        header = "\n".join(self.output_file_header)
+        header += "\n" + " ".join(self.output_keys)
+        outfmt = self._get_savetxt_fmt_list()
+        Ncols = len(self.samples_with_detstats.dtype.names)
         if len(outfmt) != Ncols:
             raise RuntimeError(
                 "Lengths of data rows ({:d})"
@@ -1927,7 +1993,7 @@ class MCMCSearch(BaseSearchClass):
             )
         np.savetxt(
             self.samples_file,
-            samples_out,
+            self.samples_with_detstats,
             delimiter=" ",
             header=header,
             fmt=outfmt,
@@ -2452,6 +2518,7 @@ class MCMCGlitchSearch(MCMCSearch):
         theta_initial=None,
         rhohatmax=1000,
         binary=False,
+        singleFstats=False,
         BSGL=False,
         SSBprec=None,
         RngMedWindow=None,
@@ -2528,6 +2595,7 @@ class MCMCGlitchSearch(MCMCSearch):
             maxCoverFreq=self.maxCoverFreq,
             search_ranges=search_ranges,
             detectors=self.detectors,
+            singleFstats=self.singleFstats,
             BSGL=self.BSGL,
             nglitch=self.nglitch,
             theta0_idx=self.theta0_idx,
@@ -2634,11 +2702,6 @@ class MCMCGlitchSearch(MCMCSearch):
             for i, idx in enumerate(self.theta_idxs):
                 if idx in self.theta_idxs[:i]:
                     self.theta_idxs[i] += 1
-
-        self.output_keys = self.theta_keys.copy()
-        self.output_keys.append("twoF")
-        if self.BSGL:
-            self.output_keys.append("log10BSGL")
 
     def _get_data_dictionary_to_save(self):
         d = dict(
@@ -2778,6 +2841,7 @@ class MCMCSemiCoherentSearch(MCMCSearch):
         theta_initial=None,
         rhohatmax=1000,
         binary=False,
+        singleFstats=False,
         BSGL=False,
         SSBprec=None,
         RngMedWindow=None,
@@ -2814,6 +2878,7 @@ class MCMCSemiCoherentSearch(MCMCSearch):
         self.theta_initial = theta_initial
         self.rhohatmax = rhohatmax
         self.binary = binary
+        self.singleFstats = singleFstats
         self.BSGL = BSGL
         self.SSBprec = SSBprec
         self.RngMedWindow = RngMedWindow
@@ -2885,6 +2950,7 @@ class MCMCSemiCoherentSearch(MCMCSearch):
             nsegs=self.nsegs,
             sftfilepattern=self.sftfilepattern,
             binary=self.binary,
+            singleFstats=self.singleFstats,
             BSGL=self.BSGL,
             minStartTime=self.minStartTime,
             maxStartTime=self.maxStartTime,
@@ -2940,6 +3006,7 @@ class MCMCFollowUpSearch(MCMCSemiCoherentSearch, core.DeprecatedClass):
         theta_initial=None,
         rhohatmax=1000,
         binary=False,
+        singleFstats=False,
         BSGL=False,
         SSBprec=None,
         RngMedWindow=None,
@@ -2968,6 +3035,7 @@ class MCMCFollowUpSearch(MCMCSemiCoherentSearch, core.DeprecatedClass):
         self.theta_initial = theta_initial
         self.rhohatmax = rhohatmax
         self.binary = binary
+        self.singleFstats = singleFstats
         self.BSGL = BSGL
         self.SSBprec = SSBprec
         self.RngMedWindow = RngMedWindow
@@ -3434,6 +3502,7 @@ class MCMCTransientSearch(MCMCSearch):
             transientWindowType=self.transientWindowType,
             minStartTime=self.minStartTime,
             maxStartTime=self.maxStartTime,
+            singleFstats=self.singleFstats,
             BSGL=self.BSGL,
             BtSG=self.BtSG,
             binary=self.binary,
@@ -3530,11 +3599,6 @@ class MCMCTransientSearch(MCMCSearch):
         self.theta_idxs = [self.theta_idxs[i] for i in idxs]
         self.theta_symbols = [self.theta_symbols[i] for i in idxs]
         self.theta_keys = [self.theta_keys[i] for i in idxs]
-
-        self.output_keys = self.theta_keys.copy()
-        self.output_keys.append("twoF")
-        if self.BSGL:
-            self.output_keys.append("log10BSGL")
 
     def _get_savetxt_fmt_dict(self):
         fmt_dict = utils.get_doppler_params_output_format(

--- a/pyfstat/mcmc_based_searches.py
+++ b/pyfstat/mcmc_based_searches.py
@@ -347,7 +347,7 @@ class MCMCSearch(BaseSearchClass):
             # We turn this off unless needed for BSGL,
             # because the main sampler run will not return any extra stats anyway,
             # and we will just recompute these in post-processing.
-            # (see add_samples_to_detstats()).
+            # (see add_detstats_to_samples()).
             # But we do this only after initiating the self.search object,
             # so that whatToCompute is set up correctly.
             self.search.singleFstats = False
@@ -1910,7 +1910,7 @@ class MCMCSearch(BaseSearchClass):
         fmt_list = [fmt_dict[key] for key in self.output_keys]
         return fmt_list
 
-    def add_samples_to_detstats(self):
+    def add_detstats_to_samples(self):
         """
         Add detection statistics to the sampled parameter-space points.
 
@@ -1985,7 +1985,7 @@ class MCMCSearch(BaseSearchClass):
         if self.samples.dtype.names is None or np.any(
             [key not in self.samples.dtype.names for key in self.output_keys]
         ):
-            self.add_samples_to_detstats()
+            self.add_detstats_to_samples()
         self.samples_file = os.path.join(self.outdir, self.label + "_samples.dat")
         logger.info("Exporting samples to {}".format(self.samples_file))
         header = "\n".join(self.output_file_header)
@@ -2619,7 +2619,7 @@ class MCMCGlitchSearch(MCMCSearch):
             # We turn this off unless needed for BSGL,
             # because the main sampler run will not return any extra stats anyway,
             # and we will just recompute these in post-processing.
-            # (see add_samples_to_detstats()).
+            # (see add_detstats_to_samples()).
             # But we do this only after initiating the self.search object,
             # so that whatToCompute is set up correctly.
             self.search.singleFstats = False
@@ -2987,7 +2987,7 @@ class MCMCSemiCoherentSearch(MCMCSearch):
             # We turn this off unless needed for BSGL,
             # because the main sampler run will not return any extra stats anyway,
             # and we will just recompute these in post-processing.
-            # (see add_samples_to_detstats()).
+            # (see add_detstats_to_samples()).
             # But we do this only after initiating the self.search object,
             # so that whatToCompute is set up correctly.
             self.search.singleFstats = False

--- a/tests/test_mcmc_based_searches.py
+++ b/tests/test_mcmc_based_searches.py
@@ -253,10 +253,37 @@ class TestMCMCSearchBSGL(TestMCMCSearch):
             ntemps=2,
             log10beta_min=-1,
             BSGL=False,
+            singleFstats=True,
         )
         self.search.run(plot_walkers=True)
         self.search.print_summary()
-        # The standard checks here are expected to fail,
+        # check for the right output keys
+        self.assertTrue(
+            "twoF" in self.search.output_keys,
+            f"'twoF' is not in output keys: {self.search.output_keys}",
+        )
+        self.assertTrue(
+            "twoF" in self.search.samples_with_detstats.dtype.names,
+            f"'twoF' is not in samples dtype names:  {self.search.samples_with_detstats.dtype.names}",
+        )
+        for IFO in self.detectors.split(","):
+            self.assertTrue(
+                f"twoF{IFO}" in self.search.output_keys,
+                f"'twoF{IFO}' is not in output keys: {self.search.output_keys}",
+            )
+            self.assertTrue(
+                f"twoF{IFO}" in self.search.samples_with_detstats.dtype.names,
+                f"'twoF{IFO}' is not in samples dtype names:  {self.search.samples_with_detstats.dtype.names}",
+            )
+        self.assertFalse(
+            "log10BSGL" in self.search.output_keys,
+            f"'log10BSGL' should not be in output keys: {self.search.output_keys}",
+        )
+        self.assertFalse(
+            "log10BSGL" in self.search.samples_with_detstats.dtype.names,
+            f"'log10BSGL' should not be in samples dtype names:  {self.search.samples_with_detstats.dtype.names}",
+        )
+        # The standard checks on detection statistics values here are expected to fail,
         # as the F-search will get confused by the line
         # and recover a much higher maxTwoF than predicted.
         self._check_twoF_predicted(assertTrue=False)
@@ -280,7 +307,33 @@ class TestMCMCSearchBSGL(TestMCMCSearch):
         )
         self.search.run(plot_walkers=True)
         self.search.print_summary()
-        # Still skipping the standard checks,
+        # check for the right output keys
+        self.assertTrue(
+            "twoF" in self.search.output_keys,
+            f"'twoF' is not in output keys: {self.search.output_keys}",
+        )
+        self.assertTrue(
+            "twoF" in self.search.samples_with_detstats.dtype.names,
+            f"'twoF' is not in samples dtype names:  {self.search.samples_with_detstats.dtype.names}",
+        )
+        for IFO in self.detectors.split(","):
+            self.assertTrue(
+                f"twoF{IFO}" in self.search.output_keys,
+                f"'twoF{IFO}' is not in output keys: {self.search.output_keys}",
+            )
+            self.assertTrue(
+                f"twoF{IFO}" in self.search.samples_with_detstats.dtype.names,
+                f"'twoF{IFO}' is not in samples dtype names:  {self.search.samples_with_detstats.dtype.names}",
+            )
+        self.assertTrue(
+            "log10BSGL" in self.search.output_keys,
+            f"'log10BSGL' is not in output keys: {self.search.output_keys}",
+        )
+        self.assertTrue(
+            "log10BSGL" in self.search.samples_with_detstats.dtype.names,
+            f"'log10BSGL' is not in samples dtype names:  {self.search.samples_with_detstats.dtype.names}",
+        )
+        # Still skipping the standard checks on detection statistics values,
         # as we're using too cheap a MCMC setup here for them to be robust.
         self._check_twoF_predicted(assertTrue=False)
         mode_F0_BSGLsearch = self.max_dict["F0"]


### PR DESCRIPTION
 - values are obtained in post-processing of final samples, because ptemcee integration does not (easily) allow for getting extra quantities out at each sampling step; added a tqdm progress bar for this
 - also split up export_samples_to_disk() method introducing a new add_samples_to_detstats() which takes care of this
 - new self.samples_with_detstats object stores the parameter space points + detection statistics as a structured numpy array with shape (nsamples,) and column names